### PR TITLE
Fix deprecated commands

### DIFF
--- a/lib/main.rb
+++ b/lib/main.rb
@@ -35,4 +35,4 @@ trap "INT" do
   exit(1)
 end
 
-commands[config.cmd].new(config).call
+commands[command].new(config).call


### PR DESCRIPTION
Deprecated commands are not working:

![Code_jHs10Wf07A](https://user-images.githubusercontent.com/25509361/217314960-0e53a2d8-9011-4dc5-910b-a73ce4c8b89b.png)
