### PR TITLE
Remove default gems from gemspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          rubygems: latest
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install
       - name: Analyze code
@@ -46,8 +46,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          rubygems: latest
-          bundler-cache: false
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,22 +2,15 @@ PATH
   remote: .
   specs:
     cpl (0.1.0)
-      cgi (~> 0.3.6)
       debug (~> 1.7.1)
       dotenv (~> 2.8.1)
-      json (~> 2.6.3)
-      net-http (~> 0.3.2)
-      pathname (~> 0.2.1)
       psych (~> 5.1.0)
-      tempfile (~> 0.1.3)
       thor (~> 1.2.1)
-      yaml (~> 0.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    cgi (0.3.6)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
@@ -28,12 +21,9 @@ GEM
     irb (1.6.2)
       reline (>= 0.3.0)
     json (2.6.3)
-    net-http (0.3.2)
-      uri
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    pathname (0.2.1)
     psych (5.1.0)
       stringio
     rainbow (3.1.1)
@@ -82,11 +72,8 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     stringio (3.0.5)
-    tempfile (0.1.3)
     thor (1.2.1)
     unicode-display_width (2.4.2)
-    uri (0.12.0)
-    yaml (0.2.1)
 
 PLATFORMS
   x86_64-linux

--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -15,16 +15,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_dependency "cgi",      "~> 0.3.6"
   spec.add_dependency "debug",    "~> 1.7.1"
   spec.add_dependency "dotenv",   "~> 2.8.1"
-  spec.add_dependency "json",     "~> 2.6.3"
-  spec.add_dependency "net-http", "~> 0.3.2"
-  spec.add_dependency "pathname", "~> 0.2.1"
   spec.add_dependency "psych",    "~> 5.1.0"
-  spec.add_dependency "tempfile", "~> 0.1.3"
   spec.add_dependency "thor",     "~> 1.2.1"
-  spec.add_dependency "yaml",     "~> 0.2.1"
 
   spec.add_development_dependency "rspec",         "~> 3.12.0"
   spec.add_development_dependency "rubocop",       "~> 1.45.0"


### PR DESCRIPTION
Default gems are already included in Ruby, so unless we need a specific version, there's no need to add them to the gemspec. It was leading to issues like:

> You have already activated pathname 0.2.0, but your Gemfile requires pathname 0.2.1. Since pathname is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports pathname as a default gem.

The only default gem that I left is `psych`, because without specifying version `5.1.0`, it will use an older version that doesn't have `safe_load_file`, which we're using (see https://github.com/shakacode/heroku-to-control-plane/actions/runs/4378957563/jobs/7664349486 for an example job that fails without specifying `psych`).

Seems like it doesn't break anything, since the tests are running ok, and I also tested locally with Ruby 2.7.0 and 3.1.2.