### PR TITLE
Followup to PR for improving error messages

### DIFF
--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -148,7 +148,7 @@ module Command
 
     def ensure_workload_deleted(workload)
       progress.puts "- Ensure workload is deleted"
-      cp.workload_delete(workload, no_raise: true)
+      cp.workload_delete(workload)
     end
 
     def latest_image_from(items, app_name: config.app, name_only: true)

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -137,7 +137,7 @@ module Command
     end
 
     def wait_for_workload(workload)
-      wait_for("workload to start") { cp.workload_get(workload) }
+      wait_for("workload to start") { cp.fetch_workload(workload) }
     end
 
     def wait_for_replica(workload, location)

--- a/lib/command/delete.rb
+++ b/lib/command/delete.rb
@@ -35,7 +35,7 @@ module Command
     def delete_gvc
       progress.puts "- Deleting gvc:"
 
-      return progress.puts "none" unless cp.gvc_get
+      return progress.puts "none" unless cp.fetch_gvc
 
       cp.gvc_delete
       progress.puts config.app

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -15,7 +15,7 @@ module Command
       image = latest_image
 
       config[:app_workloads].each do |workload|
-        cp.workload_get_and_ensure(workload).dig("spec", "containers").each do |container|
+        cp.fetch_workload!(workload).dig("spec", "containers").each do |container|
           next unless container["image"].match?(%r{^/org/#{config[:cpln_org]}/image/#{config.app}:})
 
           cp.workload_set_image_ref(workload, container: container["name"], image: image)

--- a/lib/command/env.rb
+++ b/lib/command/env.rb
@@ -12,7 +12,7 @@ module Command
     HEREDOC
 
     def call
-      cp.gvc_get_and_ensure.dig("spec", "env").map do |prop|
+      cp.fetch_gvc!.dig("spec", "env").map do |prop|
         # NOTE: atm no special chars handling, consider adding if needed
         puts "#{prop['name']}=#{prop['value']}"
       end

--- a/lib/command/exists.rb
+++ b/lib/command/exists.rb
@@ -17,7 +17,7 @@ module Command
     HEREDOC
 
     def call
-      exit(!cp.gvc_get.nil?)
+      exit(!cp.fetch_gvc.nil?)
     end
   end
 end

--- a/lib/command/open.rb
+++ b/lib/command/open.rb
@@ -23,7 +23,7 @@ module Command
 
     def call
       workload = config.options[:workload] || config[:one_off_workload]
-      data = cp.workload_get_and_ensure(workload)
+      data = cp.fetch_workload!(workload)
       url = data["status"]["endpoint"]
       opener = `which xdg-open open`.split("\n").grep_v("not found").first
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -59,7 +59,7 @@ module Command
       progress.puts "- Cloning workload '#{workload}' on '#{config.options[:app]}' to '#{one_off}'"
 
       # Create a base copy of workload props
-      spec = cp.workload_get_and_ensure(workload).fetch("spec")
+      spec = cp.fetch_workload!(workload).fetch("spec")
       container = spec["containers"].detect { _1["name"] == workload } || spec["containers"].first
 
       # remove other containers if any

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -57,7 +57,7 @@ module Command
       progress.puts "- Cloning workload '#{workload}' on '#{config.options[:app]}' to '#{one_off}'"
 
       # Get base specs of workload
-      spec = cp.workload_get_and_ensure(workload).fetch("spec")
+      spec = cp.fetch_workload!(workload).fetch("spec")
       container = spec["containers"].detect { _1["name"] == workload } || spec["containers"].first
 
       # remove other containers if any
@@ -113,7 +113,7 @@ module Command
     def show_logs_waiting # rubocop:disable Metrics/MethodLength
       progress.puts "- Scheduled, fetching logs (it is cron job, so it may take up to a minute to start)"
       begin
-        while cp.workload_get(one_off)
+        while cp.fetch_workload(one_off)
           sleep(WORKLOAD_SLEEP_CHECK)
           print_uniq_logs
         end

--- a/lib/command/setup.rb
+++ b/lib/command/setup.rb
@@ -37,7 +37,7 @@ module Command
     def call
       config.args.each do |template|
         filename = "#{config.app_cpln_dir}/templates/#{template}.yml"
-        ensure_template(template, filename)
+        ensure_template!(template, filename)
         apply_template(filename)
         progress.puts(template)
       end
@@ -45,7 +45,7 @@ module Command
 
     private
 
-    def ensure_template(template, filename)
+    def ensure_template!(template, filename)
       Shell.abort("Can't find template '#{template}' at '#{filename}', please create it.") unless File.exist?(filename)
     end
 

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -19,7 +19,7 @@ class Config
   end
 
   def [](key)
-    ensure_current_config
+    ensure_current_config!
 
     old_key = old_option_keys[key]
     if current.key?(key)
@@ -41,37 +41,37 @@ class Config
 
   private
 
-  def ensure_current_config
+  def ensure_current_config!
     Shell.abort("Can't find current config, please specify an app.") unless current
   end
 
-  def ensure_current_config_app(app)
+  def ensure_current_config_app!(app)
     Shell.abort("Can't find app '#{app}' in 'controlplane.yml'.") unless current
   end
 
-  def ensure_config
+  def ensure_config!
     Shell.abort("'controlplane.yml' is empty.") unless config
   end
 
-  def ensure_config_apps
+  def ensure_config_apps!
     Shell.abort("Can't find key 'apps' in 'controlplane.yml'.") unless config[:apps]
   end
 
-  def ensure_config_app(app, options)
+  def ensure_config_app!(app, options)
     Shell.abort("App '#{app}' is empty in 'controlplane.yml'.") unless options
   end
 
   def pick_current_config
-    ensure_config
-    ensure_config_apps
+    ensure_config!
+    ensure_config_apps!
     config[:apps].each do |c_app, c_data|
-      ensure_config_app(c_app, c_data)
+      ensure_config_app!(c_app, c_data)
       if c_app.to_s == app || (c_data[:match_if_app_name_starts_with] && app.start_with?(c_app.to_s))
         @current = c_data
         break
       end
     end
-    ensure_current_config_app(app)
+    ensure_current_config_app!(app)
   end
 
   def load_app_config

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -15,7 +15,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   def image_build(image, dockerfile:, push: true)
     cmd = "cpln image build --org #{org} --name #{image} --dir #{config.app_dir} --dockerfile #{dockerfile}"
     cmd += " --push" if push
-    perform(cmd)
+    perform!(cmd)
   end
 
   def image_query(app_name = config.app)
@@ -74,7 +74,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   def workload_set_image_ref(workload, container:, image:)
     cmd = "cpln workload update #{workload} #{gvc_org}"
     cmd += " --set spec.containers.#{container}.image=/org/#{config[:cpln_org]}/image/#{image}"
-    perform(cmd)
+    perform!(cmd)
   end
 
   def workload_set_suspend(workload, value)
@@ -85,34 +85,39 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   def workload_force_redeployment(workload)
     cmd = "cpln workload force-redeployment #{workload} #{gvc_org}"
+    perform!(cmd)
+  end
+
+  def workload_delete(workload)
+    cmd = "cpln workload delete #{workload} #{gvc_org}"
+    cmd += " 2> /dev/null"
     perform(cmd)
   end
 
-  def workload_delete(workload, no_raise: false)
+  def workload_delete!(workload)
     cmd = "cpln workload delete #{workload} #{gvc_org}"
-    cmd += " 2> /dev/null" if no_raise
-    no_raise ? perform_no_raise(cmd) : perform(cmd)
+    perform!(cmd)
   end
 
   def workload_connect(workload, location:, container: nil, shell: nil)
     cmd = "cpln workload connect #{workload} #{gvc_org} --location #{location}"
     cmd += " --container #{container}" if container
     cmd += " --shell #{shell}" if shell
-    perform(cmd)
+    perform!(cmd)
   end
 
   def workload_exec(workload, location:, container: nil, command: nil)
     cmd = "cpln workload exec #{workload} #{gvc_org} --location #{location}"
     cmd += " --container #{container}" if container
     cmd += " -- #{command}"
-    perform(cmd)
+    perform!(cmd)
   end
 
   # logs
 
   def logs(workload:)
     cmd = "cpln logs '{workload=\"#{workload}\"}' --org #{org} -t -o raw --limit 200"
-    perform(cmd)
+    perform!(cmd)
   end
 
   def log_get(workload:, from:, to:)
@@ -126,18 +131,18 @@ class Controlplane # rubocop:disable Metrics/ClassLength
       f.write(data.to_yaml)
       f.rewind
       cmd = "cpln apply #{gvc_org} --file #{f.path} > /dev/null"
-      perform(cmd)
+      perform!(cmd)
     end
   end
 
   private
 
   def perform(cmd)
-    system(cmd) || exit(false)
+    system(cmd)
   end
 
-  def perform_no_raise(cmd)
-    system(cmd)
+  def perform!(cmd)
+    system(cmd) || exit(false)
   end
 
   def perform_yaml(cmd)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -38,12 +38,12 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     perform_yaml(cmd)
   end
 
-  def gvc_get(a_gvc = gvc)
+  def fetch_gvc(a_gvc = gvc)
     api.gvc_get(gvc: a_gvc, org: org)
   end
 
-  def gvc_get_and_ensure(a_gvc = gvc)
-    gvc_data = gvc_get(a_gvc)
+  def fetch_gvc!(a_gvc = gvc)
+    gvc_data = fetch_gvc(a_gvc)
     return gvc_data if gvc_data
 
     Shell.abort("Can't find GVC '#{gvc}', please create it with 'cpl setup gvc -a #{config.app}'.")

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -55,12 +55,12 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   # workload
 
-  def workload_get(workload)
+  def fetch_workload(workload)
     api.workload_get(workload: workload, gvc: gvc, org: org)
   end
 
-  def workload_get_and_ensure(workload)
-    workload_data = workload_get(workload)
+  def fetch_workload!(workload)
+    workload_data = fetch_workload(workload)
     return workload_data if workload_data
 
     Shell.abort("Can't find workload '#{workload}', please create it with 'cpl setup #{workload} -a #{config.app}'.")
@@ -78,7 +78,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def workload_set_suspend(workload, value)
-    data = workload_get_and_ensure(workload)
+    data = fetch_workload!(workload)
     data["spec"]["defaultOptions"]["suspend"] = value
     apply(data)
   end


### PR DESCRIPTION
Followup to #17

- Renames `workload_get` and `workload_get_and_ensure` to `fetch_workload` and `fetch_workload!`, respectively
- Renames `gvc_get` and `gvc_get_and_ensure` to `fetch_gvc` and `fetch_gvc!`, respectively
- Uses exclamation mark to indicate versions of methods that raise errors