### PR TITLE
Show error message when running build-image if Docker is not running

### DIFF
--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -15,11 +15,22 @@ module Command
     HEREDOC
 
     def call
+      ensure_docker_running!
+
       dockerfile = config.current[:dockerfile] || "Dockerfile"
       dockerfile = "#{config.app_cpln_dir}/#{dockerfile}"
       progress.puts "- Building dockerfile: #{dockerfile}"
 
       cp.image_build(latest_image_next, dockerfile: dockerfile)
+    end
+
+    private
+
+    def ensure_docker_running!
+      `docker version > /dev/null 2>&1`
+      return if $?.success? # rubocop:disable Style/SpecialGlobalVars
+
+      Shell.abort("Can't run Docker. Please make sure that it's installed and started, then try again.")
     end
   end
 end


### PR DESCRIPTION
Runs `docker version` and checks if the result was a success to make sure that Docker is running, and shows an error message if not.