### PR TITLE
Add info command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,16 +91,16 @@ if [ cpl exists -a $APP_NAME ]; ...
 
 ### `info`
 
-- Displays a list of available workloads for all GVCs or a specific GVC in an org
+- Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)
 
 ```sh
-# Shows available workloads for all GVCs.
+# Shows available workloads for all apps.
 cpl info
 
-# Shows available workloads for a specific GVC.
+# Shows available workloads for a specific app.
 cpl info -a $APP_NAME
 
-# Shows available workloads for all GVCs in a different org.
+# Shows available workloads for all apps in a different org.
 cpl info -o $ORG_NAME
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,6 +89,21 @@ cpl env -a $APP_NAME
 if [ cpl exists -a $APP_NAME ]; ...
 ```
 
+### `info`
+
+- Displays a list of available workloads for all GVCs or a specific GVC in an org
+
+```sh
+# Shows available workloads for all GVCs.
+cpl info
+
+# Shows available workloads for a specific GVC.
+cpl info -a $APP_NAME
+
+# Shows available workloads for all GVCs in a different org.
+cpl info -o $ORG_NAME
+```
+
 ### `latest-image`
 
 - Displays the latest image name

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -38,6 +38,19 @@ module Command
       end
     end
 
+    def self.org_option(required: false)
+      {
+        name: :org,
+        params: {
+          aliases: ["-o"],
+          banner: "ORG_NAME",
+          desc: "Organization name",
+          type: :string,
+          required: required
+        }
+      }
+    end
+
     def self.app_option(required: false)
       {
         name: :app,

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -16,7 +16,7 @@ module Command
 
       config[:app_workloads].each do |workload|
         cp.fetch_workload!(workload).dig("spec", "containers").each do |container|
-          next unless container["image"].match?(%r{^/org/#{config[:cpln_org]}/image/#{config.app}:})
+          next unless container["image"].match?(%r{^/org/#{config.org}/image/#{config.app}:})
 
           cp.workload_set_image_ref(workload, container: container["name"], image: image)
           progress.puts "updated #{container['name']}"

--- a/lib/command/info.rb
+++ b/lib/command/info.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Command
+  class Info < Base
+    NAME = "info"
+    OPTIONS = [
+      org_option,
+      app_option
+    ].freeze
+    DESCRIPTION = "Displays a list of available workloads for all GVCs or a specific GVC in an org"
+    LONG_DESCRIPTION = <<~HEREDOC
+      - Displays a list of available workloads for all GVCs or a specific GVC in an org
+    HEREDOC
+    EXAMPLES = <<~HEREDOC
+      ```sh
+      # Shows available workloads for all GVCs.
+      cpl info
+
+      # Shows available workloads for a specific GVC.
+      cpl info -a $APP_NAME
+
+      # Shows available workloads for all GVCs in a different org.
+      cpl info -o $ORG_NAME
+      ```
+    HEREDOC
+
+    def call
+      ensure_org!
+
+      gvcs = config.app ? [config.app] : cp.fetch_gvcs["items"].map { |gvc| gvc["name"] }
+      gvcs.each do |gvc|
+        puts Shell.color(gvc, :blue)
+
+        workloads = cp.fetch_workloads(gvc)["items"].map { |workload| workload["name"] }
+        workloads.each do |workload|
+          puts "  #{workload}"
+        end
+      end
+    end
+
+    private
+
+    def ensure_org!
+      return if config.org
+
+      Shell.abort("Please specify an org, either through the '-o' flag " \
+                  "or the 'default_cpln_org' key in 'controlplane.yml'.")
+    end
+  end
+end

--- a/lib/command/info.rb
+++ b/lib/command/info.rb
@@ -7,19 +7,19 @@ module Command
       org_option,
       app_option
     ].freeze
-    DESCRIPTION = "Displays a list of available workloads for all GVCs or a specific GVC in an org"
+    DESCRIPTION = "Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)"
     LONG_DESCRIPTION = <<~HEREDOC
-      - Displays a list of available workloads for all GVCs or a specific GVC in an org
+      - Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)
     HEREDOC
     EXAMPLES = <<~HEREDOC
       ```sh
-      # Shows available workloads for all GVCs.
+      # Shows available workloads for all apps.
       cpl info
 
-      # Shows available workloads for a specific GVC.
+      # Shows available workloads for a specific app.
       cpl info -a $APP_NAME
 
-      # Shows available workloads for all GVCs in a different org.
+      # Shows available workloads for all apps in a different org.
       cpl info -o $ORG_NAME
       ```
     HEREDOC

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -80,7 +80,7 @@ module Command
 
       # Override image if specified
       image = config.options[:image]
-      image = "/org/#{config[:cpln_org]}/image/#{latest_image}" if image == "latest"
+      image = "/org/#{config.org}/image/#{latest_image}" if image == "latest"
       container["image"] = image if image
 
       # Set runner

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -77,7 +77,7 @@ module Command
 
       # Override image if specified
       image = config.options[:image]
-      image = "/org/#{config[:cpln_org]}/image/#{latest_image}" if image == "latest"
+      image = "/org/#{config.org}/image/#{latest_image}" if image == "latest"
       container["image"] = image if image
 
       # Set cron job props

--- a/lib/command/setup.rb
+++ b/lib/command/setup.rb
@@ -53,7 +53,7 @@ module Command
       data = File.read(filename)
                  .gsub("APP_GVC", config.app)
                  .gsub("APP_LOCATION", config[:default_location])
-                 .gsub("APP_ORG", config[:cpln_org])
+                 .gsub("APP_ORG", config.org)
                  .gsub("APP_IMAGE", latest_image)
 
       cp.apply(YAML.safe_load(data))

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -2,7 +2,7 @@
 
 class Config
   attr_reader :config, :current,
-              :app, :app_dir,
+              :org, :app, :app_dir,
               # command line options
               :args, :options
 
@@ -14,6 +14,9 @@ class Config
     @app = options[:app]
 
     load_app_config
+
+    @org = options[:org] || config[:default_cpln_org]
+
     pick_current_config if app
     warn_deprecated_options if current
   end
@@ -66,10 +69,11 @@ class Config
     ensure_config_apps!
     config[:apps].each do |c_app, c_data|
       ensure_config_app!(c_app, c_data)
-      if c_app.to_s == app || (c_data[:match_if_app_name_starts_with] && app.start_with?(c_app.to_s))
-        @current = c_data
-        break
-      end
+      next unless c_app.to_s == app || (c_data[:match_if_app_name_starts_with] && app.start_with?(c_app.to_s))
+
+      @current = c_data
+      @org = self[:cpln_org]
+      break
     end
     ensure_current_config_app!(app)
   end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -7,7 +7,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     @config = config
     @api = ControlplaneApi.new
     @gvc = config.app
-    @org = config[:cpln_org]
+    @org = config.org
   end
 
   # image
@@ -73,7 +73,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   def workload_set_image_ref(workload, container:, image:)
     cmd = "cpln workload update #{workload} #{gvc_org}"
-    cmd += " --set spec.containers.#{container}.image=/org/#{config[:cpln_org]}/image/#{image}"
+    cmd += " --set spec.containers.#{container}.image=/org/#{config.org}/image/#{image}"
     perform!(cmd)
   end
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -29,6 +29,10 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   # gvc
 
+  def fetch_gvcs
+    api.gvc_list(org: org)
+  end
+
   def gvc_query(app_name = config.app)
     # When `match_if_app_name_starts_with` is `true`, we query for any gvc containing the name,
     # otherwise we query for a gvc with the exact name.
@@ -54,6 +58,10 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   # workload
+
+  def fetch_workloads(a_gvc = gvc)
+    api.workload_list(gvc: a_gvc, org: org)
+  end
 
   def fetch_workload(workload)
     api.workload_get(workload: workload, gvc: gvc, org: org)

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ControlplaneApi
+  def gvc_list(org:)
+    api_json("/org/#{org}/gvc", method: :get)
+  end
+
   def gvc_get(org:, gvc:)
     api_json("/org/#{org}/gvc/#{gvc}", method: :get)
   end
@@ -27,6 +31,10 @@ class ControlplaneApi
     params = params.map { |k, v| %(#{k}=#{CGI.escape(v)}) }.join("&")
 
     api_json_direct("/logs/org/#{org}/loki/api/v1/query_range?#{params}", method: :get, host: :logs)
+  end
+
+  def workload_list(org:, gvc:)
+    api_json("/org/#{org}/gvc/#{gvc}/workload", method: :get)
   end
 
   def workload_get(org:, gvc:, workload:)


### PR DESCRIPTION
Partial fix for #8

Also adds an `org` option (and the ability to specify a default org through `default_cpln_org` in `controlplane.yml`), because we need to be able to run `cpl info` without providing an app.

Example output:

![Code_kg9NkJeVaV](https://user-images.githubusercontent.com/25509361/226956808-068654f1-e0ce-407c-bdfd-bf08ec08ca0b.png)