### PR TITLE
Revert default org

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,17 +91,18 @@ if [ cpl exists -a $APP_NAME ]; ...
 
 ### `info`
 
-- Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)
+- Displays a list of available workloads for all apps or a specific app in all orgs or a specific org (apps equal GVCs)
+- Only displays apps/workloads that match what's defined in the `.controlplane/controlplane.yml` file
 
 ```sh
-# Shows available workloads for all apps.
+# Shows available workloads for all apps in all orgs.
 cpl info
+
+# Shows available workloads for all apps in a specific org.
+cpl info -o $ORG_NAME
 
 # Shows available workloads for a specific app.
 cpl info -a $APP_NAME
-
-# Shows available workloads for all apps in a different org.
-cpl info -o $ORG_NAME
 ```
 
 ### `latest-image`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,17 +91,20 @@ if [ cpl exists -a $APP_NAME ]; ...
 
 ### `info`
 
-- Displays a list of available workloads for all apps or a specific app in all orgs or a specific org (apps equal GVCs)
-- Only displays apps/workloads that match what's defined in the `.controlplane/controlplane.yml` file
+- Displays the diff between defined/available apps/workloads (apps equal GVCs)
+- Apps that are defined but not available are displayed in red
+- Apps that are available but not defined are displayed in green
+- Apps that are both defined and available are displayed in white
+- The diff is based on what's defined in the `.controlplane/controlplane.yml` file
 
 ```sh
-# Shows available workloads for all apps in all orgs.
+# Shows diff for all apps in all orgs.
 cpl info
 
-# Shows available workloads for all apps in a specific org.
+# Shows diff for all apps in a specific org.
 cpl info -o $ORG_NAME
 
-# Shows available workloads for a specific app.
+# Shows diff for a specific app.
 cpl info -a $APP_NAME
 ```
 

--- a/lib/command/info.rb
+++ b/lib/command/info.rb
@@ -1,32 +1,37 @@
 # frozen_string_literal: true
 
 module Command
-  class Info < Base
+  class Info < Base # rubocop:disable Metrics/ClassLength
     NAME = "info"
     OPTIONS = [
       org_option,
       app_option
     ].freeze
-    DESCRIPTION = "Displays a list of available workloads for all apps or a specific app " \
-                  "in all orgs or a specific org (apps equal GVCs)"
+    DESCRIPTION = "Displays the diff between defined/available apps/workloads (apps equal GVCs)"
     LONG_DESCRIPTION = <<~DESC
-      - Displays a list of available workloads for all apps or a specific app in all orgs or a specific org (apps equal GVCs)
-      - Only displays apps/workloads that match what's defined in the `.controlplane/controlplane.yml` file
+      - Displays the diff between defined/available apps/workloads (apps equal GVCs)
+      - Apps that are defined but not available are displayed in red
+      - Apps that are available but not defined are displayed in green
+      - Apps that are both defined and available are displayed in white
+      - The diff is based on what's defined in the `.controlplane/controlplane.yml` file
     DESC
     EXAMPLES = <<~EX
       ```sh
-      # Shows available workloads for all apps in all orgs.
+      # Shows diff for all apps in all orgs.
       cpl info
 
-      # Shows available workloads for all apps in a specific org.
+      # Shows diff for all apps in a specific org.
       cpl info -o $ORG_NAME
 
-      # Shows available workloads for a specific app.
+      # Shows diff for a specific app.
       cpl info -a $APP_NAME
       ```
     EX
 
     def call
+      @missing_apps_workloads = {}
+      @missing_apps_starting_with = {}
+
       if config.app && !config.current[:match_if_app_name_starts_with]
         single_app_info
       else
@@ -36,41 +41,26 @@ module Command
 
     private
 
-    def check_if_app_matches(app, app_name, app_options)
+    def app_matches?(app, app_name, app_options)
       app == app_name.to_s || (app_options[:match_if_app_name_starts_with] && app.start_with?(app_name.to_s))
     end
 
     def find_app_options(app)
       @app_options ||= {}
       @app_options[app] ||= config.apps.find do |app_name, app_options|
-                              check_if_app_matches(app, app_name, app_options)
+                              app_matches?(app, app_name, app_options)
                             end&.last
     end
 
-    def filter_workloads(app, workloads)
+    def find_workloads(app)
       app_options = find_app_options(app)
       return [] if app_options.nil?
 
-      workloads.filter do |workload|
-        app_options[:app_workloads].include?(workload) ||
-          app_options[:additional_workloads].include?(workload) ||
-          app_options[:one_off_workload] == workload
-      end.sort
+      (app_options[:app_workloads] + app_options[:additional_workloads] + [app_options[:one_off_workload]]).uniq
     end
 
-    def orgs
-      result = []
-
-      if config.options[:org]
-        result.push(config.options[:org])
-      else
-        config.apps.each do |_app, app_options|
-          org = app_options[:cpln_org] || app_options[:org]
-          result.push(org) unless result.include?(org)
-        end
-      end
-
-      result
+    def fetch_workloads(app)
+      cp.fetch_workloads(app)["items"].map { |workload| workload["name"] }
     end
 
     def fetch_app_workloads(org) # rubocop:disable Metrics/MethodLength
@@ -85,45 +75,159 @@ module Command
       end
 
       if config.app
-        result.select! { |app, _| check_if_app_matches(app, config.app, config.current) }
+        result.select { |app, _| app_matches?(app, config.app, config.current) }
       else
-        result.reject! { |app, _| find_app_options(app).nil? }
+        result.reject { |app, _| find_app_options(app).nil? }
+      end
+    end
+
+    def orgs # rubocop:disable Metrics/MethodLength
+      result = []
+
+      if config.options[:org]
+        result.push(config.options[:org])
+      else
+        config.apps.each do |app_name, app_options|
+          next if config.app && !app_matches?(config.app, app_name, app_options)
+
+          org = app_options[:cpln_org] || app_options[:org]
+          result.push(org) unless result.include?(org)
+        end
       end
 
-      result.sort.to_h
+      result.sort
+    end
+
+    def apps(org)
+      result = []
+
+      config.apps.each do |app_name, app_options|
+        next if config.app && !app_matches?(config.app, app_name, app_options)
+
+        app_org = app_options[:cpln_org] || app_options[:org]
+        result.push(app_name.to_s) if app_org == org
+      end
+
+      result += @app_workloads.keys.map(&:to_s)
+      result.uniq.sort
+    end
+
+    def should_app_start_with?(app)
+      config.apps[app.to_sym]&.dig(:match_if_app_name_starts_with)
+    end
+
+    def any_app_starts_with?(app)
+      @app_workloads.keys.find { |app_name| app_matches?(app_name, app, config.apps[app.to_sym]) }
+    end
+
+    def check_any_app_starts_with(app)
+      if any_app_starts_with?(app)
+        false
+      else
+        @missing_apps_starting_with[app] ||= ["gvc"]
+
+        puts "  - #{Shell.color("Any app starting with '#{app}'", :red)}"
+        true
+      end
+    end
+
+    def add_to_missing_workloads(app, workload)
+      if should_app_start_with?(app)
+        @missing_apps_starting_with[app] ||= []
+        @missing_apps_starting_with[app].push(workload)
+      else
+        @missing_apps_workloads[app] ||= []
+        @missing_apps_workloads[app].push(workload)
+      end
+    end
+
+    def print_app(app, org)
+      if should_app_start_with?(app)
+        check_any_app_starts_with(app)
+      elsif cp.fetch_gvc(app, org).nil?
+        @missing_apps_workloads[app] = ["gvc"]
+
+        puts "  - #{Shell.color(app, :red)}"
+        true
+      else
+        puts "  - #{app}"
+        true
+      end
+    end
+
+    def print_workload(app, workload)
+      if @defined_workloads.include?(workload) && !@available_workloads.include?(workload)
+        add_to_missing_workloads(app, workload)
+
+        puts "    - #{Shell.color(workload, :red)}"
+      elsif !@defined_workloads.include?(workload) && @available_workloads.include?(workload)
+        puts "    - #{Shell.color(workload, :green)}"
+      else
+        puts "    - #{workload}"
+      end
+    end
+
+    def print_missing_apps_workloads
+      return if @missing_apps_workloads.empty?
+
+      puts "\nSome apps/workloads are missing. Please create them with:"
+
+      @missing_apps_workloads.each do |app, workloads|
+        puts "  - `cpl setup #{workloads.join(' ')} -a #{app}`"
+      end
+    end
+
+    def print_missing_apps_starting_with
+      return if @missing_apps_starting_with.empty?
+
+      puts "\nThere are no apps starting with some names. If you wish to create any, do so with " \
+           "(replace 'whatever' with whatever suffix you want):"
+
+      @missing_apps_starting_with.each do |app, workloads|
+        app_with_suffix = "#{app}#{app.end_with?('-') ? '' : '-'}whatever"
+        puts "  - `cpl setup #{workloads.join(' ')} -a #{app_with_suffix}`"
+      end
     end
 
     def single_app_info
       puts "#{Shell.color(config.org, :blue)}:"
-      puts "  #{config.app}:"
 
-      workloads = cp.fetch_workloads["items"].map { |workload| workload["name"] }
-      workloads = filter_workloads(config.app, workloads)
-      return puts "    No available workloads." if workloads.empty?
+      print_app(config.app, config.org)
 
+      @defined_workloads = find_workloads(config.app)
+      @available_workloads = fetch_workloads(config.app)
+
+      workloads = (@defined_workloads + @available_workloads).uniq.sort
       workloads.each do |workload|
-        puts "    - #{workload}"
+        print_workload(config.app, workload)
       end
+
+      print_missing_apps_workloads
     end
 
     def multiple_apps_info # rubocop:disable Metrics/MethodLength
       orgs.each do |org|
         puts "#{Shell.color(org, :blue)}:"
 
-        app_workloads = fetch_app_workloads(org)
-        next puts "  No available apps." if app_workloads.empty?
+        @app_workloads = fetch_app_workloads(org)
 
-        app_workloads.each do |app, workloads|
-          puts "  #{app}:"
+        apps(org).each do |app|
+          next unless print_app(app, org)
 
-          workloads = filter_workloads(app, workloads)
-          next puts "    No available workloads." if workloads.empty?
+          @defined_workloads = find_workloads(app)
+          @available_workloads = @app_workloads[app] || []
 
+          workloads = (@defined_workloads + @available_workloads).uniq.sort
           workloads.each do |workload|
-            puts "    - #{workload}"
+            print_workload(app, workload)
           end
         end
+
+        puts
       end
+
+      print_missing_apps_workloads
+      print_missing_apps_starting_with
     end
   end
 end

--- a/lib/command/info.rb
+++ b/lib/command/info.rb
@@ -7,44 +7,123 @@ module Command
       org_option,
       app_option
     ].freeze
-    DESCRIPTION = "Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)"
+    DESCRIPTION = "Displays a list of available workloads for all apps or a specific app " \
+                  "in all orgs or a specific org (apps equal GVCs)"
     LONG_DESCRIPTION = <<~DESC
-      - Displays a list of available workloads for all apps or a specific app in an org (apps equal GVCs)
+      - Displays a list of available workloads for all apps or a specific app in all orgs or a specific org (apps equal GVCs)
+      - Only displays apps/workloads that match what's defined in the `.controlplane/controlplane.yml` file
     DESC
     EXAMPLES = <<~EX
       ```sh
-      # Shows available workloads for all apps.
+      # Shows available workloads for all apps in all orgs.
       cpl info
+
+      # Shows available workloads for all apps in a specific org.
+      cpl info -o $ORG_NAME
 
       # Shows available workloads for a specific app.
       cpl info -a $APP_NAME
-
-      # Shows available workloads for all apps in a different org.
-      cpl info -o $ORG_NAME
       ```
     EX
 
     def call
-      ensure_org!
-
-      gvcs = config.app ? [config.app] : cp.fetch_gvcs["items"].map { |gvc| gvc["name"] }
-      gvcs.each do |gvc|
-        puts Shell.color(gvc, :blue)
-
-        workloads = cp.fetch_workloads(gvc)["items"].map { |workload| workload["name"] }
-        workloads.each do |workload|
-          puts "  #{workload}"
-        end
+      if config.app && !config.current[:match_if_app_name_starts_with]
+        single_app_info
+      else
+        multiple_apps_info
       end
     end
 
     private
 
-    def ensure_org!
-      return if config.org
+    def check_if_app_matches(app, app_name, app_options)
+      app == app_name.to_s || (app_options[:match_if_app_name_starts_with] && app.start_with?(app_name.to_s))
+    end
 
-      Shell.abort("Please specify an org, either through the '-o' flag " \
-                  "or the 'default_cpln_org' key in 'controlplane.yml'.")
+    def find_app_options(app)
+      @app_options ||= {}
+      @app_options[app] ||= config.apps.find do |app_name, app_options|
+                              check_if_app_matches(app, app_name, app_options)
+                            end&.last
+    end
+
+    def filter_workloads(app, workloads)
+      app_options = find_app_options(app)
+      return [] if app_options.nil?
+
+      workloads.filter do |workload|
+        app_options[:app_workloads].include?(workload) ||
+          app_options[:additional_workloads].include?(workload) ||
+          app_options[:one_off_workload] == workload
+      end.sort
+    end
+
+    def orgs
+      result = []
+
+      if config.options[:org]
+        result.push(config.options[:org])
+      else
+        config.apps.each do |_app, app_options|
+          org = app_options[:cpln_org] || app_options[:org]
+          result.push(org) unless result.include?(org)
+        end
+      end
+
+      result
+    end
+
+    def fetch_app_workloads(org) # rubocop:disable Metrics/MethodLength
+      result = {}
+
+      workloads = cp.fetch_workloads_by_org(org)["items"]
+      workloads.each do |workload|
+        app = workload["links"].find { |link| link["rel"] == "gvc" }["href"].split("/").last
+
+        result[app] ||= []
+        result[app].push(workload["name"])
+      end
+
+      if config.app
+        result.select! { |app, _| check_if_app_matches(app, config.app, config.current) }
+      else
+        result.reject! { |app, _| find_app_options(app).nil? }
+      end
+
+      result.sort.to_h
+    end
+
+    def single_app_info
+      puts "#{Shell.color(config.org, :blue)}:"
+      puts "  #{config.app}:"
+
+      workloads = cp.fetch_workloads["items"].map { |workload| workload["name"] }
+      workloads = filter_workloads(config.app, workloads)
+      return puts "    No available workloads." if workloads.empty?
+
+      workloads.each do |workload|
+        puts "    - #{workload}"
+      end
+    end
+
+    def multiple_apps_info # rubocop:disable Metrics/MethodLength
+      orgs.each do |org|
+        puts "#{Shell.color(org, :blue)}:"
+
+        app_workloads = fetch_app_workloads(org)
+        next puts "  No available apps." if app_workloads.empty?
+
+        app_workloads.each do |app, workloads|
+          puts "  #{app}:"
+
+          workloads = filter_workloads(app, workloads)
+          next puts "    No available workloads." if workloads.empty?
+
+          workloads.each do |workload|
+            puts "    - #{workload}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -20,7 +20,7 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       cpl run:detached rails db:prepare -a $APP_NAME
-      
+
       # Need to quote COMMAND if setting ENV value or passing args to command to run
       cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -2,7 +2,7 @@
 
 class Config
   attr_reader :config, :current,
-              :org, :app, :app_dir,
+              :org, :app, :apps, :app_dir,
               # command line options
               :args, :options
 
@@ -11,11 +11,12 @@ class Config
   def initialize(args, options)
     @args = args
     @options = options
+    @org = options[:org]
     @app = options[:app]
 
     load_app_config
 
-    @org = options[:org] || config[:default_cpln_org]
+    @apps = config[:apps]
 
     pick_current_config if app
     warn_deprecated_options if current
@@ -65,8 +66,6 @@ class Config
   end
 
   def pick_current_config
-    ensure_config!
-    ensure_config_apps!
     config[:apps].each do |c_app, c_data|
       ensure_config_app!(c_app, c_data)
       next unless c_app.to_s == app || (c_data[:match_if_app_name_starts_with] && app.start_with?(c_app.to_s))
@@ -82,6 +81,8 @@ class Config
     config_file = find_app_config_file
     @config = YAML.safe_load_file(config_file, symbolize_names: true, aliases: true)
     @app_dir = Pathname.new(config_file).parent.parent.to_s
+    ensure_config!
+    ensure_config_apps!
   end
 
   def find_app_config_file

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -63,6 +63,10 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.workload_list(gvc: a_gvc, org: org)
   end
 
+  def fetch_workloads_by_org(a_org = org)
+    api.workload_list_by_org(org: a_org)
+  end
+
   def fetch_workload(workload)
     api.workload_get(workload: workload, gvc: gvc, org: org)
   end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -42,8 +42,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     perform_yaml(cmd)
   end
 
-  def fetch_gvc(a_gvc = gvc)
-    api.gvc_get(gvc: a_gvc, org: org)
+  def fetch_gvc(a_gvc = gvc, a_org = org)
+    api.gvc_get(gvc: a_gvc, org: a_org)
   end
 
   def fetch_gvc!(a_gvc = gvc)

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -37,6 +37,10 @@ class ControlplaneApi
     api_json("/org/#{org}/gvc/#{gvc}/workload", method: :get)
   end
 
+  def workload_list_by_org(org:)
+    api_json("/org/#{org}/workload", method: :get)
+  end
+
   def workload_get(org:, gvc:, workload:)
     api_json("/org/#{org}/gvc/#{gvc}/workload/#{workload}", method: :get)
   end


### PR DESCRIPTION
Reverts the logic for a default org added by #23 

So the info command now:

- retrieves workloads for a single app when used with `-a` (or multiple apps if `match_if_app_name_starts_with` is `true`)
- retrieves workloads for all apps in an org when used with `-o`
- retrieves workloads for all apps in all orgs (that are defined in `.controlplane/controlplane.yml`) when used without any params

![Code_94gg0sZbba](https://user-images.githubusercontent.com/25509361/228004108-0a4e54bd-969b-4202-b61a-9910d11d7ab3.png)