### PR TITLE
Add promote-app-from-upstream command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,6 +155,18 @@ cpl open -a $APP_NAME
 cpl open -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
+### `promote-app-from-upstream`
+
+- Copies the latest image from upstream, runs a release script (optional), and deploys the image
+- It performs the following steps:
+  - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
+  - Runs a release script if specified through `release_script` in the `.controlplane/controlplane.yml` file
+  - Runs `cpl deploy-image` to deploy the image
+
+```sh
+cpl promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN
+```
+
 ### `ps`
 
 - Shows running replicas in app

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -248,6 +248,10 @@ module Command
       @cp ||= Controlplane.new(config)
     end
 
+    def perform(cmd)
+      system(cmd) || exit(false)
+    end
+
     private
 
     # returns 0 if no prior image

--- a/lib/command/no_command.rb
+++ b/lib/command/no_command.rb
@@ -13,7 +13,7 @@ module Command
     def call
       return unless config.options[:version]
 
-      Version.new(config).call
+      perform("cpl version")
     end
   end
 end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Command
+  class PromoteAppFromUpstream < Base
+    NAME = "promote-app-from-upstream"
+    OPTIONS = [
+      app_option(required: true),
+      upstream_token_option(required: true)
+    ].freeze
+    DESCRIPTION = "Copies the latest image from upstream, runs a release script (optional), and deploys the image"
+    LONG_DESCRIPTION = <<~DESC
+      - Copies the latest image from upstream, runs a release script (optional), and deploys the image
+      - It performs the following steps:
+        - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
+        - Runs a release script if specified through `release_script` in the `.controlplane/controlplane.yml` file
+        - Runs `cpl deploy-image` to deploy the image
+    DESC
+
+    def call
+      check_release_script
+      copy_image_from_upstream
+      run_release_script
+      deploy_image
+    end
+
+    private
+
+    def check_release_script
+      release_script_name = config.current[:release_script]
+      unless release_script_name
+        progress.puts("Can't find option 'release_script' for app '#{config.app}' in 'controlplane.yml'. " \
+                      "Skipping release script.\n\n")
+        return
+      end
+
+      @release_script_path = Pathname.new("#{config.app_cpln_dir}/#{release_script_name}").expand_path
+
+      raise "Can't find release script in '#{@release_script_path}'." unless File.exist?(@release_script_path)
+    end
+
+    def copy_image_from_upstream
+      perform("cpl copy-image-from-upstream -a #{config.app} -t #{config.options[:upstream_token]}")
+      progress.puts
+    end
+
+    def run_release_script
+      return unless @release_script_path
+
+      progress.puts("Running release script...\n\n")
+      perform("bash #{@release_script_path}")
+      progress.puts
+    end
+
+    def deploy_image
+      perform("cpl deploy-image -a #{config.app}")
+    end
+  end
+end


### PR DESCRIPTION
Partial fix for #8

Example outputs:

- When no release script was specified:

![Code_AKKPxyhemt](https://user-images.githubusercontent.com/25509361/229118571-af28e7d1-049f-4523-8783-4f0c1c1248aa.png)

- When a release script was specified, but the file doesn't exist:

![Code_x3pAmYcwQl](https://user-images.githubusercontent.com/25509361/229118605-0d30b745-26fd-45e4-8d30-8662c5b19969.png)

- When a release script was specified, and the file exists:

![Code_v5VY9eDQnP](https://user-images.githubusercontent.com/25509361/229118644-d22aec93-1de0-43da-80da-77e91471d356.png)

In this case, the content of `release_script` was:

```sh
#!/bin/bash

echo "Test"
```