### PR TITLE
Add Git hooks with overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,10 @@
+PreCommit:
+  RuboCop:
+    enabled: true
+    on_warn: fail
+    command: ["bundle", "exec", "rubocop"]
+
+PrePush:
+  RSpec:
+    enabled: true
+    command: ["bundle", "exec", "rspec"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,16 +11,22 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    childprocess (4.1.0)
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dotenv (2.8.1)
+    iniparse (1.5.0)
     io-console (0.6.0)
     irb (1.6.3)
       reline (>= 0.3.0)
     json (2.6.3)
+    overcommit (0.60.0)
+      childprocess (>= 0.6.3, < 5)
+      iniparse (~> 1.4)
+      rexml (~> 3.2)
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
@@ -81,6 +87,7 @@ PLATFORMS
 
 DEPENDENCIES
   cpl!
+  overcommit (~> 0.60.0)
   rake (~> 13.0)
   rspec (~> 3.12.0)
   rubocop (~> 1.45.0)

--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "psych",    "~> 5.1.0"
   spec.add_dependency "thor",     "~> 1.2.1"
 
+  spec.add_development_dependency "overcommit",    "~> 0.60.0"
   spec.add_development_dependency "rspec",         "~> 3.12.0"
   spec.add_development_dependency "rubocop",       "~> 1.45.0"
   spec.add_development_dependency "rubocop-rake",  "~> 0.6.0"


### PR DESCRIPTION
In order to prevent formatting issues from being committed, and pushes from being made when specs are failing, I think it would be beneficial to add some Git hooks.

I found the [overcommit](https://github.com/sds/overcommit) gem, which makes this process easier.

This adds:

- a `pre-commit` hook that runs `rubocop`
- a `pre-push` hook that runs `rspec`

One thing to note is that it's not automatically installed, so devs will have to run `overcommit --install` in order to enable it for their local clone, but I think it's nice to have the option. I mean, CI will still catch any issues, but it's nice to be able to validate it locally as well.