### PR TITLE
Updates to setup command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,6 +11,30 @@ This `-a` option is used in most of the commands and will pick all other app con
 
 ### Commands
 
+### `apply-template`
+
+- Applies application-specific configs from templates (e.g., for every review-app)
+- Publishes (creates or updates) those at Control Plane infrastructure
+- Picks templates from the `.controlplane/templates` directory
+- Templates are ordinary Control Plane templates but with variable preprocessing
+
+**Preprocessed template variables:**
+
+```
+APP_GVC      - basically GVC or app name
+APP_LOCATION - default location
+APP_ORG      - organization
+APP_IMAGE    - will use latest app image
+```
+
+```sh
+# Applies single template.
+cpl apply-template redis -a $APP_NAME
+
+# Applies several templates (practically creating full app).
+cpl apply-template gvc postgres redis rails -a $APP_NAME
+```
+
 ### `build-image`
 
 - Builds and pushes the image to Control Plane
@@ -238,6 +262,13 @@ cpl run rails c -a $APP_NAME
 # Uses a different image (which may not be promoted yet).
 cpl run rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
 cpl run rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+
+# Uses a different workload
+cpl run bash -a $APP_NAME -w other-workload
+
+# Overrides remote CPLN_TOKEN env variable with local token.
+# Useful when need superuser rights in remote container
+cpl run bash -a $APP_NAME --use-local-token
 ```
 
 ### `run:detached`
@@ -263,30 +294,19 @@ cpl run:detached rails db:migrate -a $APP_NAME --image latest
 # Uses a different image (which may not be promoted yet).
 cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
 cpl run:detached rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+
+# Uses a different workload
+cpl run:detached rails db:migrate:status -a $APP_NAME -w other-workload
 ```
 
-### `setup`
+### `setup-app`
 
-- Applies application-specific configs from templates (e.g., for every review-app)
-- Publishes (creates or updates) those at Control Plane infrastructure
-- Picks templates from the `.controlplane/templates` directory
-- Templates are ordinary Control Plane templates but with variable preprocessing
-
-**Preprocessed template variables:**
-
-```
-APP_GVC      - basically GVC or app name
-APP_LOCATION - default location
-APP_ORG      - organization
-APP_IMAGE    - will use latest app image
-```
+- Creates an app and all its workloads
+- Specify the templates for the app and workloads through `setup` in the `.controlplane/controlplane.yml` file
+- This should should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
 
 ```sh
-# Applies single template.
-cpl setup redis -a $APP_NAME
-
-# Applies several templates (practically creating full app).
-cpl setup gvc postgres redis rails -a $APP_NAME
+cpl setup-app -a $APP_NAME
 ```
 
 ### `version`

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Command
-  class Setup < Base # rubocop:disable Metrics/ClassLength
-    NAME = "setup"
-    USAGE = "setup TEMPLATE [TEMPLATE] ... [TEMPLATE]"
+  class ApplyTemplate < Base # rubocop:disable Metrics/ClassLength
+    NAME = "apply-template"
+    USAGE = "apply-template TEMPLATE [TEMPLATE] ... [TEMPLATE]"
     REQUIRES_ARGS = true
     OPTIONS = [
       app_option(required: true)
@@ -27,10 +27,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Applies single template.
-      cpl setup redis -a $APP_NAME
+      cpl apply-template redis -a $APP_NAME
 
       # Applies several templates (practically creating full app).
-      cpl setup gvc postgres redis rails -a $APP_NAME
+      cpl apply-template gvc postgres redis rails -a $APP_NAME
       ```
     EX
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -159,7 +159,7 @@ module Command
 
     def self.all_options_by_key_name
       all_options.each_with_object({}) do |option, result|
-        option[:params][:aliases].each { |current_alias| result[current_alias.to_s] = option }
+        option[:params][:aliases]&.each { |current_alias| result[current_alias.to_s] = option }
         result["--#{option[:name]}"] = option
       end
     end

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Command
+  class SetupApp < Base
+    NAME = "setup-app"
+    OPTIONS = [
+      app_option(required: true)
+    ].freeze
+    DESCRIPTION = "Creates an app and all its workloads"
+    LONG_DESCRIPTION = <<~DESC
+      - Creates an app and all its workloads
+      - Specify the templates for the app and workloads through `setup` in the `.controlplane/controlplane.yml` file
+      - This should should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+    DESC
+
+    def call
+      templates = config[:setup].join(" ")
+
+      app = cp.fetch_gvc
+      if app
+        raise "App '#{config.app}' already exists. If you want to update this app, " \
+              "either run 'cpl delete -a #{config.app}' and then re-run this command, " \
+              "or run 'cpl apply-template #{templates} -a #{config.app}'."
+      end
+
+      perform("cpl apply-template #{templates} -a #{config.app}")
+    end
+  end
+end

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -9,7 +9,12 @@ require "tempfile"
 require "thor"
 require "yaml"
 
-modules = Dir["#{__dir__}/**/*.rb"].reject { |file| file == __FILE__ || file.end_with?("main.rb") }
+# We need to require base before all commands, since the commands inherit from it
+require_relative "command/base"
+
+modules = Dir["#{__dir__}/**/*.rb"].reject do |file|
+  file == __FILE__ || file.end_with?("main.rb") || file.end_with?("base.rb")
+end
 modules.sort.each { require(_1) }
 
 # Fix for https://github.com/erikhuda/thor/issues/398

--- a/lib/deprecated_commands.json
+++ b/lib/deprecated_commands.json
@@ -2,5 +2,6 @@
   "build": "build-image",
   "promote": "deploy-image",
   "promote_image": "deploy-image",
-  "runner": "run:detached"
+  "runner": "run:detached",
+  "setup": "apply-template"
 }


### PR DESCRIPTION
Fixes #28

- Ensures that all templates exist before applying
- Renames `setup` command to `apply-template`
- Checks if app/workloads exist before applying
- Adds `setup-app` command

Example outputs for `apply-template`:

- When any template is missing:

![Code_ER9cSnro0J](https://user-images.githubusercontent.com/25509361/229213668-c8e780e0-bada-4579-8fba-641ffa9ded8c.png)

- When app/workloads already exist:

![Code_3wgJ1S5Cbo](https://user-images.githubusercontent.com/25509361/234972181-d767fa0b-485f-46a4-99ee-0145b5775e4b.png)

Example outputs for `setup-app`:

- When app already exists:

![Code_KyCmBtzPKw](https://user-images.githubusercontent.com/25509361/234972664-9c6d1c23-7109-4710-822f-8b582947ee7a.png)