### PR TITLE
Fix promote-image deprecated command

### DIFF
--- a/lib/deprecated_commands.json
+++ b/lib/deprecated_commands.json
@@ -1,6 +1,6 @@
 {
   "build": "build-image",
   "promote": "deploy-image",
-  "promote-image": "deploy-image",
+  "promote_image": "deploy-image",
   "runner": "run:detached"
 }


### PR DESCRIPTION
There's a small typo in the `promote-image` deprecated command that raises an error when running `cpl promote-image` instead of automatically running `deploy-image` and displaying a deprecation warning.