### PR TITLE
Include deployed endpoints in output for deploy-image command

### DIFF
--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -11,17 +11,27 @@ module Command
       - Deploys the latest image to app workloads
     DESC
 
-    def call
+    def call # rubocop:disable Metrics/MethodLength
+      deployed_endpoints = {}
+
       image = latest_image
 
       config[:app_workloads].each do |workload|
-        cp.fetch_workload!(workload).dig("spec", "containers").each do |container|
+        workload_data = cp.fetch_workload!(workload)
+        workload_data.dig("spec", "containers").each do |container|
           next unless container["image"].match?(%r{^/org/#{config.org}/image/#{config.app}:})
 
-          step("Deploying image '#{image}' for workload '#{container['name']}'") do
-            cp.workload_set_image_ref(workload, container: container["name"], image: image)
+          container_name = container["name"]
+          step("Deploying image '#{image}' for workload '#{container_name}'") do
+            cp.workload_set_image_ref(workload, container: container_name, image: image)
+            deployed_endpoints[container_name] = workload_data.dig("status", "endpoint")
           end
         end
+      end
+
+      progress.puts("\nDeployed endpoints:")
+      deployed_endpoints.each do |workload, endpoint|
+        progress.puts("  - #{workload}: #{endpoint}")
       end
     end
   end


### PR DESCRIPTION
After #25, we stopped displaying the endpoints when running `deploy-image`, but they're super helpful when deploying to temporary apps like review apps, so this PR adds them back as a nice list at the end of the output.

| Before | After |
| --- | --- |
| ![Code_FgRNlsY3s7](https://user-images.githubusercontent.com/25509361/230520042-e71d4f12-1678-400e-9e86-ea575630c17b.png) | ![Code_CnqsiiycO0](https://user-images.githubusercontent.com/25509361/230520086-22caf8bd-d7ae-4c1a-b70e-6c9151e498df.png) |

