### PR TITLE
Set commit as runtime env var when building image

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -39,7 +39,8 @@ cpl apply-template gvc postgres redis rails -a $APP_NAME
 
 - Builds and pushes the image to Control Plane
 - Automatically assigns image numbers, e.g., `app:1`, `app:2`, etc.
-- Uses `.controlplane/Dockerfile`
+- Uses `.controlplane/Dockerfile` or a different Dockerfile specified through `dockerfile` in the `.controlplane/controlplane.yml` file
+- If a commit is provided through `--commit` or `-c`, it will be set as the runtime env var `GIT_COMMIT`
 
 ```sh
 cpl build-image -a $APP_NAME

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -32,7 +32,7 @@ module Command
       build_args = []
       build_args.push("GIT_COMMIT=#{commit}") if commit
 
-      cp.image_build_with_docker(image_url, dockerfile: dockerfile, build_args: build_args)
+      cp.image_build(image_url, dockerfile: dockerfile, build_args: build_args)
 
       progress.puts("\nPushed image to '/org/#{config.org}/image/#{image_name}'.")
     end

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -21,6 +21,8 @@ module Command
       dockerfile = config.current[:dockerfile] || "Dockerfile"
       dockerfile = "#{config.app_cpln_dir}/#{dockerfile}"
 
+      raise "Can't find Dockerfile at '#{dockerfile}'." unless File.exist?(dockerfile)
+
       progress.puts("Building image from Dockerfile '#{dockerfile}'...\n\n")
 
       image_name = latest_image_next

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -11,10 +11,11 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Builds and pushes the image to Control Plane
       - Automatically assigns image numbers, e.g., `app:1`, `app:2`, etc.
-      - Uses `.controlplane/Dockerfile`
+      - Uses `.controlplane/Dockerfile` or a different Dockerfile specified through `dockerfile` in the `.controlplane/controlplane.yml` file
+      - If a commit is provided through `--commit` or `-c`, it will be set as the runtime env var `GIT_COMMIT`
     DESC
 
-    def call
+    def call # rubocop:disable Metrics/MethodLength
       ensure_docker_running!
 
       dockerfile = config.current[:dockerfile] || "Dockerfile"
@@ -22,7 +23,16 @@ module Command
 
       progress.puts("Building image from Dockerfile '#{dockerfile}'...\n\n")
 
-      cp.image_build(latest_image_next, dockerfile: dockerfile)
+      image_name = latest_image_next
+      image_url = "#{config.org}.registry.cpln.io/#{image_name}"
+
+      commit = config.options[:commit]
+      build_args = []
+      build_args.push("GIT_COMMIT=#{commit}") if commit
+
+      cp.image_build_with_docker(image_url, dockerfile: dockerfile, build_args: build_args)
+
+      progress.puts("\nPushed image to '/org/#{config.org}/image/#{image_name}'.")
     end
 
     private

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -41,6 +41,15 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     perform!(cmd)
   end
 
+  def image_build_with_docker(image, dockerfile:, build_args: [], push: true)
+    cmd = "docker build -t #{image} -f #{dockerfile}"
+    build_args.each { |build_arg| cmd += " --build-arg #{build_arg}" }
+    cmd += " #{config.app_dir}"
+    perform!(cmd)
+
+    image_push(image) if push
+  end
+
   def image_query(app_name = config.app, org_name = config.org)
     cmd = "cpln image query --org #{org_name} -o yaml --max -1 --prop repository=#{app_name}"
     perform_yaml(cmd)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -35,13 +35,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   # image
 
-  def image_build(image, dockerfile:, push: true)
-    cmd = "cpln image build --org #{org} --name #{image} --dir #{config.app_dir} --dockerfile #{dockerfile}"
-    cmd += " --push" if push
-    perform!(cmd)
-  end
-
-  def image_build_with_docker(image, dockerfile:, build_args: [], push: true)
+  def image_build(image, dockerfile:, build_args: [], push: true)
     cmd = "docker build -t #{image} -f #{dockerfile}"
     build_args.each { |build_arg| cmd += " --build-arg #{build_arg}" }
     cmd += " #{config.app_dir}"


### PR DESCRIPTION
- Sets commit as runtime env var `GIT_COMMIT` when building image, by providing it to `docker build` through `--build-arg`
- Raises error if Dockerfile can't be found when building image