### PR TITLE
Fix terminal size

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -244,6 +244,7 @@ cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME
 - Runs one-off **_interactive_** replicas (analog of `heroku run`)
 - Uses `Standard` workload type and `cpln exec` as the execution method, with CLI streaming
 - May not work correctly with tasks that last over 5 minutes (there's a Control Plane scaling bug at the moment)
+- If `fix_terminal_size` is `true` in the `.controlplane/controlplane.yml` file, the remote terminal size will be fixed to match the local terminal size (may also be overriden through `--terminal-size`)
 
 > **IMPORTANT:** Useful for development where it's needed for interaction, and where network connection drops and
 > task crashing are tolerable. For production tasks, it's better to use `cpl run:detached`.

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -153,6 +153,18 @@ module Command
       }
     end
 
+    def self.terminal_size_option(required: false)
+      {
+        name: :terminal_size,
+        params: {
+          banner: "ROWS,COLS",
+          desc: "Override remote terminal size (e.g. `--terminal-size 10,20`)",
+          type: :string,
+          required: required
+        }
+      }
+    end
+
     def self.all_options
       methods.grep(/_option$/).map { |method| send(method.to_s) }
     end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -104,7 +104,7 @@ module Command
       cp.apply("kind" => "workload", "name" => one_off, "spec" => spec)
     end
 
-    def runner_script
+    def runner_script # rubocop:disable Metrics/MethodLength
       script = Scripts.helpers_cleanup
 
       if config.options["use_local_token"]
@@ -113,6 +113,10 @@ module Command
           unset CONTROLPLANE_TOKEN
         SHELL
       end
+
+      # NOTE: fixes terminal size to match local terminal
+      rows, cols = `stty -a`.match(/(\d+)\s*rows;\s*(\d+)\s*columns/).captures
+      script += "stty rows #{rows}\nstty cols #{cols}\n" if rows && cols
 
       script += args_join(config.args)
       script

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -10,13 +10,15 @@ module Command
       app_option(required: true),
       image_option,
       workload_option,
-      use_local_token_option
+      use_local_token_option,
+      terminal_size_option
     ].freeze
     DESCRIPTION = "Runs one-off **_interactive_** replicas (analog of `heroku run`)"
     LONG_DESCRIPTION = <<~DESC
       - Runs one-off **_interactive_** replicas (analog of `heroku run`)
       - Uses `Standard` workload type and `cpln exec` as the execution method, with CLI streaming
       - May not work correctly with tasks that last over 5 minutes (there's a Control Plane scaling bug at the moment)
+      - If `fix_terminal_size` is `true` in the `.controlplane/controlplane.yml` file, the remote terminal size will be fixed to match the local terminal size (may also be overriden through `--terminal-size`)
 
       > **IMPORTANT:** Useful for development where it's needed for interaction, and where network connection drops and
       > task crashing are tolerable. For production tasks, it's better to use `cpl run:detached`.
@@ -115,8 +117,14 @@ module Command
       end
 
       # NOTE: fixes terminal size to match local terminal
-      rows, cols = `stty -a`.match(/(\d+)\s*rows;\s*(\d+)\s*columns/).captures
-      script += "stty rows #{rows}\nstty cols #{cols}\n" if rows && cols
+      if config.current[:fix_terminal_size] || config.options[:terminal_size]
+        if config.options[:terminal_size]
+          rows, cols = config.options[:terminal_size].split(",")
+        else
+          rows, cols = `stty -a`.match(/(\d+)\s*rows;\s*(\d+)\s*columns/).captures
+        end
+        script += "stty rows #{rows}\nstty cols #{cols}\n" if rows && cols
+      end
 
       script += args_join(config.args)
       script


### PR DESCRIPTION
This PR fixes terminal size *if local terminal size is stable (!= resized later)*

Actually, by default, it is `rows: 0, cols: 0` on remote.

Maybe this is worth an option in config yaml `fix-terminal-size: true` or a possibility to override from cli e.g. `--terminal-size 10,20`. I mean, resizing behavior may not be desirable in every case, and it might be reverted if `0,0` provided.