### PR TITLE
Updates to run commands

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,15 +8,18 @@ on:
 
 jobs:
   rspec:
-    runs-on: ubuntu-latest
-    name: RSpec
-    env:
-      RAILS_ENV: test
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         ruby:
           - "2.7"
           - "3.0"
+    runs-on: ${{ matrix.os }}
+    name: RSpec
+    env:
+      RAILS_ENV: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,13 +8,16 @@ on:
 
 jobs:
   rubocop:
-    runs-on: ubuntu-latest
-    name: Rubocop
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
         ruby:
           - "2.7"
           - "3.0"
+    runs-on: ${{ matrix.os }}
+    name: Rubocop
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -187,28 +187,22 @@ module Command
       end
     end
 
-    def wait_for(title)
-      progress.print "- Waiting for #{title}"
-      until yield
-        progress.print(".")
-        sleep(1)
-      end
-      progress.puts
-    end
-
     def wait_for_workload(workload)
-      wait_for("workload to start") { cp.fetch_workload(workload) }
+      step("Waiting for workload", retry_on_failure: true) do
+        cp.fetch_workload(workload)
+      end
     end
 
     def wait_for_replica(workload, location)
-      wait_for("replica") do
+      step("Waiting for replica", retry_on_failure: true) do
         cp.workload_get_replicas_safely(workload, location: location)&.dig("items", 0)
       end
     end
 
     def ensure_workload_deleted(workload)
-      progress.puts "- Ensure workload is deleted"
-      cp.delete_workload(workload)
+      step("Deleting workload") do
+        cp.delete_workload(workload)
+      end
     end
 
     def latest_image_from(items, app_name: config.app, name_only: true)

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -127,7 +127,7 @@ module Command
         if config.options[:terminal_size]
           rows, cols = config.options[:terminal_size].split(",")
         else
-          rows, cols = `stty -a`.match(/(\d+)\s*rows;\s*(\d+)\s*columns/).captures
+          rows, cols = `stty size`.split(/\s+/)
         end
         script += "stty rows #{rows}\nstty cols #{cols}\n" if rows && cols
       end

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -59,8 +59,10 @@ module Command
       wait_for_workload(one_off)
       show_logs_waiting
     ensure
-      progress.puts
-      ensure_workload_deleted(one_off)
+      if cp.fetch_workload(one_off)
+        progress.puts
+        ensure_workload_deleted(one_off)
+      end
       exit(1) if @crashed
     end
 

--- a/lib/core/scripts.rb
+++ b/lib/core/scripts.rb
@@ -10,7 +10,7 @@ module Scripts
         -H "Authorization: ${CONTROLPLANE_TOKEN}" -s | grep -o '"replicas":[0-9]*' | grep -o '[0-9]*')
 
       if [ "$REPLICAS_QTY" -gt 0 ]; then
-        echo "-- MULTIPLE REPLICAS ATTEMPT !!!! replicas: $REPLICAS_QTY"
+        echo "-- MULTIPLE REPLICAS ATTEMPT: $REPLICAS_QTY --"
         exit -1
       fi
     SHELL

--- a/lib/core/scripts.rb
+++ b/lib/core/scripts.rb
@@ -24,7 +24,7 @@ module Scripts
 
   # NOTE: please escape all '/' as '//' (as it is ruby interpolation here as well)
   def http_dummy_server_ruby
-    'require "socket";s=TCPServer.new(ENV["PORT"]);' \
+    'require "socket";s=TCPServer.new(ENV["PORT"] || 80);' \
       'loop do c=s.accept;c.puts("HTTP/1.1 200 OK\\nContent-Length: 2\\n\\nOk");c.close end'
   end
 


### PR DESCRIPTION
- Ensures that we get the terminal size from a common output on Linux and Mac
- Improves the output
- Defaults to port 80 when not set
- Checks if the workload still exists before deleting it
- Adds macOS to CI

Example outputs:

| Command | Before | After |
| --- | --- | --- |
| `run` | ![Code_LnPcwzVNVo](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/aaeb2c18-2ada-4d7d-bce3-029cc7a6cde9) | ![Code_HHPIN4bP4Z](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/16c0c745-be4b-4ca2-a2fb-61560eb04ef4) |
| `run:detached` | ![Code_tyfaJGEtKl](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/b3fdc3e2-d04c-4266-b355-caef0773efec) | ![Code_fphx2KqrFq](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/e08173c6-01f0-4bd0-abbe-dd70114e7360) |