### PR TITLE
Fix cleanup-stale-apps command for when app does not have image

### DIFF
--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -210,7 +210,7 @@ module Command
 
       # Or special string to indicate no image available
       if matching_items.empty?
-        "#{app_name}:#{NO_IMAGE_AVAILABLE}"
+        name_only ? "#{app_name}:#{NO_IMAGE_AVAILABLE}" : nil
       else
         latest_item = matching_items.max_by { |item| extract_image_number(item["name"]) }
         name_only ? latest_item["name"] : latest_item

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -51,6 +51,7 @@ module Command
 
             images = cp.image_query(app_name)["items"].filter { |item| item["name"].start_with?("#{app_name}:") }
             image = latest_image_from(images, app_name: app_name, name_only: false)
+            next unless image
 
             created_date = DateTime.parse(image["created"])
             diff_in_days = (now - created_date).to_i


### PR DESCRIPTION
When an app doesn't have an image, the `cleanup-stale-apps` command fails because it tries to access `image["created"]`, which doesn't exist.