### PR TITLE
Add ps:wait command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -285,6 +285,18 @@ cpl ps:stop -a $APP_NAME
 cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
+### `ps:wait`
+
+- Waits for workloads in app to be ready after re-deployment
+
+```sh
+# Waits for all workloads in app.
+cpl ps:wait -a $APP_NAME
+
+# Waits for a specific workload in app.
+cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
+```
+
 ### `run`
 
 - Runs one-off **_interactive_** replicas (analog of `heroku run`)

--- a/lib/command/ps_start.rb
+++ b/lib/command/ps_start.rb
@@ -42,9 +42,7 @@ module Command
 
       @workloads.reverse_each do |workload|
         step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
-          cp.fetch_workload_deployments(workload)&.dig("items")&.any? do |item|
-            item.dig("status", "ready")
-          end
+          cp.wait_for_workload_deployments(workload, ready: true)
         end
       end
     end

--- a/lib/command/ps_start.rb
+++ b/lib/command/ps_start.rb
@@ -42,7 +42,7 @@ module Command
 
       @workloads.reverse_each do |workload|
         step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
-          cp.wait_for_workload_deployments(workload, ready: true)
+          cp.workload_deployments_ready?(workload, expected_status: true)
         end
       end
     end

--- a/lib/command/ps_stop.rb
+++ b/lib/command/ps_stop.rb
@@ -42,7 +42,7 @@ module Command
 
       @workloads.each do |workload|
         step("Waiting for workload '#{workload}' to be not ready", retry_on_failure: true) do
-          cp.wait_for_workload_deployments(workload, ready: false)
+          cp.workload_deployments_ready?(workload, expected_status: false)
         end
       end
     end

--- a/lib/command/ps_stop.rb
+++ b/lib/command/ps_stop.rb
@@ -42,9 +42,7 @@ module Command
 
       @workloads.each do |workload|
         step("Waiting for workload '#{workload}' to be not ready", retry_on_failure: true) do
-          cp.fetch_workload_deployments(workload)&.dig("items")&.all? do |item|
-            !item.dig("status", "ready")
-          end
+          cp.wait_for_workload_deployments(workload, ready: false)
         end
       end
     end

--- a/lib/command/ps_stop.rb
+++ b/lib/command/ps_stop.rb
@@ -6,7 +6,7 @@ module Command
     OPTIONS = [
       app_option(required: true),
       workload_option,
-      wait_option("workload to be not ready")
+      wait_option("workload to not be ready")
     ].freeze
     DESCRIPTION = "Stops workloads in app"
     LONG_DESCRIPTION = <<~DESC
@@ -41,7 +41,7 @@ module Command
       progress.puts
 
       @workloads.each do |workload|
-        step("Waiting for workload '#{workload}' to be not ready", retry_on_failure: true) do
+        step("Waiting for workload '#{workload}' to not be ready", retry_on_failure: true) do
           cp.workload_deployments_ready?(workload, expected_status: false)
         end
       end

--- a/lib/command/ps_wait.rb
+++ b/lib/command/ps_wait.rb
@@ -27,7 +27,7 @@ module Command
 
       @workloads.reverse_each do |workload|
         step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
-          cp.wait_for_workload_deployments(workload, ready: true)
+          cp.workload_deployments_ready?(workload, expected_status: true)
         end
       end
     end

--- a/lib/command/ps_wait.rb
+++ b/lib/command/ps_wait.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Command
+  class PsWait < Base
+    NAME = "ps:wait"
+    OPTIONS = [
+      app_option(required: true),
+      workload_option
+    ].freeze
+    DESCRIPTION = "Waits for workloads in app to be ready after re-deployment"
+    LONG_DESCRIPTION = <<~DESC
+      - Waits for workloads in app to be ready after re-deployment
+    DESC
+    EXAMPLES = <<~EX
+      ```sh
+      # Waits for all workloads in app.
+      cpl ps:wait -a $APP_NAME
+
+      # Waits for a specific workload in app.
+      cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
+      ```
+    EX
+
+    def call
+      @workloads = [config.options[:workload]] if config.options[:workload]
+      @workloads ||= config[:app_workloads] + config[:additional_workloads]
+
+      @workloads.reverse_each do |workload|
+        step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
+          cp.wait_for_workload_deployments(workload, ready: true)
+        end
+      end
+    end
+  end
+end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -149,22 +149,22 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.workload_deployments(workload: workload, gvc: gvc, org: org)
   end
 
-  def deployment_version_ready?(version, next_version, ready:)
+  def workload_deployment_version_ready?(version, next_version, expected_status:)
     return false unless version["workload"] == next_version
 
     version["containers"]&.all? do |_, container|
-      ready_status = container.dig("resources", "replicas") == container.dig("resources", "replicasReady")
-      ready ? ready_status : !ready_status
+      ready = container.dig("resources", "replicas") == container.dig("resources", "replicasReady")
+      expected_status == true ? ready : !ready
     end
   end
 
-  def wait_for_workload_deployments(workload, ready:)
+  def workload_deployments_ready?(workload, expected_status:)
     deployments = fetch_workload_deployments(workload)["items"]
     deployments.all? do |deployment|
       next_version = deployment.dig("status", "expectedDeploymentVersion")
 
       deployment.dig("status", "versions")&.all? do |version|
-        deployment_version_ready?(version, next_version, ready: ready)
+        workload_deployment_version_ready?(version, next_version, expected_status: expected_status)
       end
     end
   end

--- a/spec/command/maintenance_off_spec.rb
+++ b/spec/command/maintenance_off_spec.rb
@@ -61,7 +61,7 @@ describe Command::MaintenanceOff do
 
       Stopping workload 'maintenance'... #{Shell.color('done!', :green)}
 
-      Waiting for workload 'maintenance' to be not ready... #{Shell.color('done!', :green)}
+      Waiting for workload 'maintenance' to not be ready... #{Shell.color('done!', :green)}
 
       Maintenance mode disabled for app 'my-app-staging'.
     OUTPUT

--- a/spec/command/maintenance_on_spec.rb
+++ b/spec/command/maintenance_on_spec.rb
@@ -59,9 +59,9 @@ describe Command::MaintenanceOn do
       Stopping workload 'redis'... #{Shell.color('done!', :green)}
       Stopping workload 'postgres'... #{Shell.color('done!', :green)}
 
-      Waiting for workload 'rails' to be not ready... #{Shell.color('done!', :green)}
-      Waiting for workload 'redis' to be not ready... #{Shell.color('done!', :green)}
-      Waiting for workload 'postgres' to be not ready... #{Shell.color('done!', :green)}
+      Waiting for workload 'rails' to not be ready... #{Shell.color('done!', :green)}
+      Waiting for workload 'redis' to not be ready... #{Shell.color('done!', :green)}
+      Waiting for workload 'postgres' to not be ready... #{Shell.color('done!', :green)}
 
       Maintenance mode enabled for app 'my-app-staging'.
     OUTPUT


### PR DESCRIPTION
Fixes #54

This command waits until all replicas in all deployments in all workloads (or a specific workload) are ready with the next deployed version.