### PR TITLE
Fix run commands when specifying image

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -364,12 +364,6 @@ cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 # COMMAND may also be passed at the end (in this case, no need to quote).
 cpl run:detached -a $APP_NAME -- rails db:migrate
 
-# Uses some other image.
-cpl run:detached rails db:migrate -a $APP_NAME --image /some/full/image/path
-
-# Uses latest app image (which may not be promoted yet).
-cpl run:detached rails db:migrate -a $APP_NAME --image latest
-
 # Uses a different image (which may not be promoted yet).
 cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
 cpl run:detached rails db:migrate -a $APP_NAME --image latest       # Latest sequential image

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -99,8 +99,8 @@ module Command
 
       # Override image if specified
       image = config.options[:image]
-      image = "/org/#{config.org}/image/#{latest_image}" if image == "latest"
-      container_spec["image"] = image if image
+      image = latest_image if image == "latest"
+      container_spec["image"] = "/org/#{config.org}/image/#{image}"
 
       # Set runner
       container_spec["env"] ||= []

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -28,12 +28,6 @@ module Command
       # COMMAND may also be passed at the end (in this case, no need to quote).
       cpl run:detached -a $APP_NAME -- rails db:migrate
 
-      # Uses some other image.
-      cpl run:detached rails db:migrate -a $APP_NAME --image /some/full/image/path
-
-      # Uses latest app image (which may not be promoted yet).
-      cpl run:detached rails db:migrate -a $APP_NAME --image latest
-
       # Uses a different image (which may not be promoted yet).
       cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
       cpl run:detached rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
@@ -91,8 +85,8 @@ module Command
 
       # Override image if specified
       image = config.options[:image]
-      image = "/org/#{config.org}/image/#{latest_image}" if image == "latest"
-      container_spec["image"] = image if image
+      image = latest_image if image == "latest"
+      container_spec["image"] = "/org/#{config.org}/image/#{image}"
 
       # Set cron job props
       spec["type"] = "cron"


### PR DESCRIPTION
When specifying an image, the `run` and `run:detached` commands create a workload with an invalid image, since the correct image format is `/org/{ORG}/image/{IMAGE}` and we're providing only `{IMAGE}`. This PR fixes that.