### PR TITLE
Fix --help option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,15 @@
 # Contributing
 
 ## Installation
-Rather than installing `cpl` as a Ruby gem, install this repo locally and alias `cpl` command globally for easier access, e.g.:
+
+Rather than installing `cpl` as a Ruby gem, install this repo locally and alias the `cpl` command globally for easier
+access, e.g.:
 
 ```sh
 git clone https://github.com/shakacode/heroku-to-control-plane
 
 # Create an alias in some local shell startup script, e.g., `.profile`, `.bashrc`, etc.
-alias cpl="~/projects/heroku-to-control-plane/cpl"
+alias cpl="~/projects/heroku-to-control-plane/bin/cpl"
 ```
 
 Or set the path of the Ruby gem in your Gemfile.
@@ -16,13 +18,30 @@ Or set the path of the Ruby gem in your Gemfile.
 gem 'cpl', path: '~/projects/heroku-to-control-plane'
 ```
 
-## Linting
-Be sure to run `rubocop -a` before committing code.
+## Linting/Testing
+
+Before committing or pushing code, be sure to:
+
+- Run `bundle exec rake update_command_docs` to sync any doc changes made in the source code to the docs
+- Run `bundle exec rubocop -a` to fix any linting errors
+- Run `bundle exec rspec` to run the test suite
+
+You can also install [overcommit](https://github.com/sds/overcommit) and let it automatically check for you:
+
+```sh
+gem install overcommit
+
+overcommit --install
+```
 
 ## Debugging
 
-1. Install gem: `gem install debug`
-2. Require: Add a `require "debug"` statement to the file you want to debug.
-3. Add breakpoint: Add a `debugger` statement to the line you want to debug.
-4. Modify the `lib/command/test.rb` file to triggger the code that you want to run.
-5. Run the test in your test app with a `.controlplane` directory. `cpl test -a my-app-name`
+1. Add a breakpoint (`debugger`) to any line of code you want to debug.
+2. Modify the `lib/command/test.rb` file to trigger the code you want to test. To simulate a command, you can use
+   `Cpl::Cli.start` (e.g., `Cpl::Cli.start(["deploy-image", "-a", "my-app-name"])` would be the same as running
+   `cpl deploy-image -a my-app-name`).
+3. Run the `test` command in your test app with a `.controlplane` directory.
+
+```sh
+cpl test
+```

--- a/bin/cpl
+++ b/bin/cpl
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "cpl"
+require_relative "../lib/cpl"
 
 Cpl::Cli.start

--- a/cpl
+++ b/cpl
@@ -1,15 +1,6 @@
-#!/bin/sh
+#!/usr/bin/env ruby
+# frozen_string_literal: true
 
-SCRIPT_DIR=$(dirname $(realpath $0))
+require_relative "lib/cpl"
 
-# exports .env to vars
-#
-# Example .env:
-# CPLN_TOKEN=xxx
-#
-if [ -f "$SCRIPT_DIR/.env" ]; then
-  export $(grep -v '^#' $SCRIPT_DIR/.env | xargs -0)
-fi
-
-# exec $SCRIPT_DIR/old_commands/main.sh "$@"
-exec ruby $SCRIPT_DIR/lib/main.rb "$@"
+Cpl::Cli.start

--- a/examples/circleci.yml
+++ b/examples/circleci.yml
@@ -59,8 +59,7 @@ build-review-app:
           cpln profile create default --token ${CPLN_TOKEN} --org ${CPLN_ORG} --gvc ${APP_NAME}
           cpln image docker-login
 
-          git clone https://github.com/shakacode/heroku-to-control-plane ~/heroku-to-control-plane
-          sudo ln -s ~/heroku-to-control-plane/cpl /usr/local/bin/cpl
+          gem install cpl
     - run:
         name: Provision review app if needed
         command: |

--- a/lib/command/test.rb
+++ b/lib/command/test.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Be sure to have run: gem install debug
 require "debug"
 
 module Command
@@ -14,13 +13,10 @@ module Command
     HIDE = true
 
     def call
-      # Change code here to test.
+      # Modify this method to trigger the code you want to test.
       # You can use `debugger` to debug.
-      # debugger
-      # Or print values
-      # rubocop:disable Lint/Debugger
-      pp latest_image_next
-      # rubocop:enable Lint/Debugger
+      # You can use `Cpl::Cli.start` to simulate a command
+      # (e.g., `Cpl::Cli.start(["deploy-image", "-a", "my-app-name"])`).
     end
   end
 end

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -13,7 +13,7 @@ require "yaml"
 require_relative "command/base"
 
 modules = Dir["#{__dir__}/**/*.rb"].reject do |file|
-  file == __FILE__ || file.end_with?("main.rb") || file.end_with?("base.rb")
+  file == __FILE__ || file.end_with?("base.rb")
 end
 modules.sort.each { require(_1) }
 

--- a/lib/main.rb
+++ b/lib/main.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "cpl"
-
-Cpl::Cli.start


### PR DESCRIPTION
Fixes #59 

When using the `--help` option, it can display `main.rb` instead of `cpl`. This PR fixes that.

| | Screenshot |
| --- | --- |
| Before | ![help_option_before](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/91e2da33-11a5-479f-9a68-014f7a4b9b39) |
| After | ![help_option_after](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/2e85733b-79b2-4a9c-8cb7-cfe8e9d9a3a7) |