### PR TITLE
fix: copy commit from upstream when copying image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Fixed
 
+- Fixed issue where `copy-image-from-upstream` command does not copy commit. [PR 70](https://github.com/shakacode/heroku-to-control-plane/pull/70) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Fixed issue where an error is not raised if the app is not defined. [PR 73](https://github.com/shakacode/heroku-to-control-plane/pull/73) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Changed

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -226,15 +226,19 @@ module Command
         end
     end
 
-    def latest_image_next(app = config.app, org = config.org)
+    def latest_image_next(app = config.app, org = config.org, commit: config.options[:commit])
       @latest_image_next ||= {}
       @latest_image_next[app] ||= begin
         latest_image_name = latest_image(app, org)
         image = latest_image_name.split(":").first
         image += ":#{extract_image_number(latest_image_name) + 1}"
-        image += "_#{config.options[:commit]}" if config.options[:commit]
+        image += "_#{commit}" if commit
         image
       end
+    end
+
+    def extract_image_commit(image_name)
+      image_name.match(/_(\h+)$/)&.captures&.first
     end
 
     # NOTE: use simplified variant atm, as shelljoin do different escaping

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -226,7 +226,9 @@ module Command
         end
     end
 
-    def latest_image_next(app = config.app, org = config.org, commit: config.options[:commit])
+    def latest_image_next(app = config.app, org = config.org, commit: nil)
+      commit ||= config.options[:commit]
+
       @latest_image_next ||= {}
       @latest_image_next[app] ||= begin
         latest_image_name = latest_image(app, org)

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -70,6 +70,7 @@ module Command
         cp.profile_switch(@upstream_profile)
         upstream_image = config.options[:image]
         upstream_image = latest_image(@upstream, @upstream_org) if !upstream_image || upstream_image == "latest"
+        @commit = extract_image_commit(upstream_image)
         @upstream_image_url = "#{@upstream_org}.registry.cpln.io/#{upstream_image}"
       end
     end
@@ -77,7 +78,7 @@ module Command
     def fetch_app_image_url
       step("Fetching app image URL") do
         cp.profile_switch("default")
-        app_image = latest_image_next(config.app, config.org)
+        app_image = latest_image_next(config.app, config.org, commit: @commit)
         @app_image_url = "#{config.org}.registry.cpln.io/#{app_image}"
       end
     end

--- a/spec/command/copy_image_from_upstream_spec.rb
+++ b/spec/command/copy_image_from_upstream_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Command::CopyImageFromUpstream do
+  # rubocop:disable RSpec/AnyInstance
+  before do
+    allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
+    allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml")
+    allow_any_instance_of(described_class).to receive(:ensure_docker_running!)
+    allow_any_instance_of(Controlplane).to receive(:profile_exists?).and_return(false)
+    allow_any_instance_of(Controlplane).to receive(:profile_create).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:profile_switch).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:profile_delete).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:image_login).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:image_pull).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:image_tag).and_return(true)
+    allow_any_instance_of(Controlplane).to receive(:image_push).and_return(true)
+  end
+
+  it "copies commit from upstream if exists", vcr: true do
+    allow_any_instance_of(Command::Base).to receive(:latest_image)
+      .with("my-app-staging", "my-org-staging").and_return("my-app-staging:0_123abc")
+    allow_any_instance_of(Command::Base).to receive(:latest_image)
+      .with("my-app-production", "my-org-production").and_return("my-app-production:8_456def")
+
+    expected_output = <<~OUTPUT
+      Creating upstream profile... #{Shell.color('done!', :green)}
+      Fetching upstream image URL... #{Shell.color('done!', :green)}
+      Fetching app image URL... #{Shell.color('done!', :green)}
+      Pulling image from 'my-org-staging.registry.cpln.io/my-app-staging:0_123abc'... #{Shell.color('done!', :green)}
+      Pushing image to 'my-org-production.registry.cpln.io/my-app-production:9_123abc'... #{Shell.color('done!', :green)}
+      Deleting upstream profile... #{Shell.color('done!', :green)}
+    OUTPUT
+
+    output = command_output do
+      args = ["-a", "my-app-production", "--upstream-token", "upstream_token"]
+      Cpl::Cli.start([described_class::NAME, *args])
+    end
+
+    expect(output).to eq(expected_output)
+  end
+
+  it "does not copy commit from upstream if not exists", vcr: true do
+    allow_any_instance_of(Command::Base).to receive(:latest_image)
+      .with("my-app-staging", "my-org-staging").and_return("my-app-staging:0")
+    allow_any_instance_of(Command::Base).to receive(:latest_image)
+      .with("my-app-production", "my-org-production").and_return("my-app-production:8_456def")
+
+    expected_output = <<~OUTPUT
+      Creating upstream profile... #{Shell.color('done!', :green)}
+      Fetching upstream image URL... #{Shell.color('done!', :green)}
+      Fetching app image URL... #{Shell.color('done!', :green)}
+      Pulling image from 'my-org-staging.registry.cpln.io/my-app-staging:0'... #{Shell.color('done!', :green)}
+      Pushing image to 'my-org-production.registry.cpln.io/my-app-production:9'... #{Shell.color('done!', :green)}
+      Deleting upstream profile... #{Shell.color('done!', :green)}
+    OUTPUT
+
+    output = command_output do
+      args = ["-a", "my-app-production", "--upstream-token", "upstream_token"]
+      Cpl::Cli.start([described_class::NAME, *args])
+    end
+
+    expect(output).to eq(expected_output)
+  end
+  # rubocop:enable RSpec/AnyInstance
+end


### PR DESCRIPTION
When using the `copy-image-from-upstream` command, if the upstream image has a commit hash in its name (e.g., "my-app-staging:100_abc123"), it should be copied to the name of the downstream image (e.g., "my-app-production:200_abc123").