### PR TITLE
docs: update docs for run commands regarding passing arguments at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Changed
+
+- Updated docs for `run` commands regarding passing arguments at the end. [PR 71](https://github.com/shakacode/heroku-to-control-plane/pull/71) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.0.4] - 2023-07-21
 
 ### Fixed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -314,8 +314,8 @@ cpl run -a $APP_NAME
 # Need to quote COMMAND if setting ENV value or passing args.
 cpl run 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 
-# COMMAND may also be passed at the end (in this case, no need to quote).
-cpl run -a $APP_NAME -- rails db:migrate
+# COMMAND may also be passed at the end.
+cpl run -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
 # Runs command, displays output, and exits shell.
 cpl run ls / -a $APP_NAME
@@ -362,8 +362,8 @@ cpl run:detached rails db:prepare -a $APP_NAME
 # Need to quote COMMAND if setting ENV value or passing args.
 cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 
-# COMMAND may also be passed at the end (in this case, no need to quote).
-cpl run:detached -a $APP_NAME -- rails db:migrate
+# COMMAND may also be passed at the end.
+cpl run:detached -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
 # Uses a different image (which may not be promoted yet).
 cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -31,8 +31,8 @@ module Command
       # Need to quote COMMAND if setting ENV value or passing args.
       cpl run 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 
-      # COMMAND may also be passed at the end (in this case, no need to quote).
-      cpl run -a $APP_NAME -- rails db:migrate
+      # COMMAND may also be passed at the end.
+      cpl run -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
       # Runs command, displays output, and exits shell.
       cpl run ls / -a $APP_NAME

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -26,8 +26,8 @@ module Command
       # Need to quote COMMAND if setting ENV value or passing args.
       cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
 
-      # COMMAND may also be passed at the end (in this case, no need to quote).
-      cpl run:detached -a $APP_NAME -- rails db:migrate
+      # COMMAND may also be passed at the end.
+      cpl run:detached -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
       # Uses a different image (which may not be promoted yet).
       cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name


### PR DESCRIPTION
Arguments at the end still have to be quoted if setting ENV value or passing quoted args.