### PR TITLE
fix: raise error if app is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed issue where an error is not raised if the app is not defined. [PR 73](https://github.com/shakacode/heroku-to-control-plane/pull/73) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Changed
 
 - Updated docs for `run` commands regarding passing arguments at the end. [PR 71](https://github.com/shakacode/heroku-to-control-plane/pull/71) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -86,6 +86,8 @@ class Config
 
       [app_name, app_options_with_new_keys]
     end
+
+    ensure_current_config_app!(app) if app
   end
 
   def load_app_config

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -34,8 +34,8 @@ class Config
     "#{app_dir}/.controlplane"
   end
 
-  def should_app_start_with?(app)
-    apps[app.to_sym]&.dig(:match_if_app_name_starts_with) || false
+  def should_app_start_with?(app_name)
+    apps[app_name.to_sym]&.dig(:match_if_app_name_starts_with) || false
   end
 
   private


### PR DESCRIPTION
An error was not being raised if the app is not defined in `.controlplane.yml`.