### PR TITLE
fix: use CPLN_ENDPOINT if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 - Fixed issue where `copy-image-from-upstream` command does not copy commit. [PR 70](https://github.com/shakacode/heroku-to-control-plane/pull/70) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Fixed issue where an error is not raised if the app is not defined. [PR 73](https://github.com/shakacode/heroku-to-control-plane/pull/73) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Fixed issue where `CPLN_ENDPOINT` is not used if available. [PR 75](https://github.com/shakacode/heroku-to-control-plane/pull/75) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Added
 

--- a/spec/command/cleanup_images_spec.rb
+++ b/spec/command/cleanup_images_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Command::CleanupImages do
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
 

--- a/spec/command/copy_image_from_upstream_spec.rb
+++ b/spec/command/copy_image_from_upstream_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe Command::CopyImageFromUpstream do
   # rubocop:disable RSpec/AnyInstance
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml")
     allow_any_instance_of(described_class).to receive(:ensure_docker_running!)

--- a/spec/command/maintenance_off_spec.rb
+++ b/spec/command/maintenance_off_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe Command::MaintenanceOff do
   # rubocop:disable RSpec/AnyInstance
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml")
     allow_any_instance_of(described_class).to receive(:sleep).and_return(true)

--- a/spec/command/maintenance_on_spec.rb
+++ b/spec/command/maintenance_on_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 describe Command::MaintenanceOn do
   # rubocop:disable RSpec/AnyInstance
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml")
     allow_any_instance_of(described_class).to receive(:sleep).and_return(true)

--- a/spec/command/maintenance_set_page_spec.rb
+++ b/spec/command/maintenance_set_page_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Command::MaintenanceSetPage do
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
   end

--- a/spec/command/maintenance_spec.rb
+++ b/spec/command/maintenance_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Command::Maintenance do
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
   end

--- a/spec/command/run_cleanup_spec.rb
+++ b/spec/command/run_cleanup_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe Command::RunCleanup do
   before do
+    allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow_any_instance_of(Config).to receive(:find_app_config_file).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
 

--- a/spec/core/controlplane_api_direct_spec.rb
+++ b/spec/core/controlplane_api_direct_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe ControlplaneApiDirect do
+  let(:described_instance) { described_class.new }
+
+  describe "#api_host" do
+    it "returns correct host for 'api' when CPLN_ENDPOINT is not set" do
+      allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
+
+      host = described_instance.api_host(:api)
+
+      expect(host).to eq("https://api.cpln.io")
+    end
+
+    it "returns correct host for 'api' when CPLN_ENDPOINT is set" do
+      allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("http://api.cpln.io")
+
+      host = described_instance.api_host(:api)
+
+      expect(host).to eq("http://api.cpln.io")
+    end
+
+    it "returns correct host for 'logs'" do
+      host = described_instance.api_host(:logs)
+
+      expect(host).to eq("https://logs.cpln.io")
+    end
+  end
+
+  describe "#api_token" do
+    before do
+      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
+    end
+
+    it "returns token from CPLN_TOKEN" do
+      allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token_1")
+
+      token = described_instance.api_token
+
+      expect(token).to eq("token_1")
+    end
+
+    it "returns token from 'cpln profile token'" do
+      allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return(nil)
+      allow(described_instance).to receive(:`).with("cpln profile token").and_return("token_2")
+
+      token = described_instance.api_token
+
+      expect(token).to eq("token_2")
+    end
+
+    it "raises error if token is not found" do
+      allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return(nil)
+      allow(described_instance).to receive(:`).with("cpln profile token").and_return("")
+
+      message = "Unknown API token format. " \
+                "Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable."
+      expect do
+        described_instance.api_token
+      end.to raise_error(RuntimeError, message)
+    end
+  end
+end


### PR DESCRIPTION
When running a command from a CPLN workload container, it must use `CPLN_ENDPOINT`, otherwise the request will not work.