### PR TITLE
fix: reset api token when switching profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed issue where API token is not reset when switching profile. [PR 77](https://github.com/shakacode/heroku-to-control-plane/pull/77) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.1.0] - 2023-09-20
 
 ### Fixed

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -14,6 +14,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   def profile_switch(profile)
     ENV["CPLN_PROFILE"] = profile
+    ControlplaneApiDirect.reset_api_token
   end
 
   def profile_exists?(profile)

--- a/lib/core/controlplane_api_direct.rb
+++ b/lib/core/controlplane_api_direct.rb
@@ -58,5 +58,9 @@ class ControlplaneApiDirect
     raise "Unknown API token format. " \
           "Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable."
   end
+
+  def self.reset_api_token
+    remove_class_variable(:@@api_token) if defined?(@@api_token)
+  end
   # rubocop:enable Style/ClassVars
 end


### PR DESCRIPTION
When switching profile, the original API token was still being used, because of a class variable that wasn't reset, leading to authentication errors when making API requests.