### PR TITLE
Fix macos build and support multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+## [1.1.2] - 2023-10-17
+### Fixed
+
+- Fixed failed build on MacOS by adding platform flag and fixed multiple files in yaml document for template. [PR 81](https://github.com/shakacode/heroku-to-control-plane/pull/81) by [justin808](https://github.com/justin808).
+
+## [1.1.1] - 2023-09-23
+
 ### Fixed
 
 - Fixed issue where API token is not reset when switching profile. [PR 77](https://github.com/shakacode/heroku-to-control-plane/pull/77) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes since the last non-beta release.
 _Please add entries here for your pull requests that are not yet released._
 
 ## [1.1.2] - 2023-10-17
+
 ### Fixed
 
 - Fixed failed build on MacOS by adding platform flag and fixed multiple files in yaml document for template. [PR 81](https://github.com/shakacode/heroku-to-control-plane/pull/81) by [justin808](https://github.com/justin808).
@@ -84,7 +85,9 @@ _Please add entries here for your pull requests that are not yet released._
 
 - Initial release
 
-[Unreleased]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.1.1...v1.1.2
+[1.1.1]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/shakacode/heroku-to-control-plane/compare/v1.0.2...v1.0.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cpl (1.1.1)
+    cpl (1.1.2.rc.0)
       debug (~> 1.7.1)
       dotenv (~> 2.8.1)
       psych (~> 5.1.0)
@@ -25,7 +25,7 @@ GEM
     hashdiff (1.0.1)
     iniparse (1.5.0)
     io-console (0.6.0)
-    irb (1.8.1)
+    irb (1.8.3)
       rdoc
       reline (>= 0.3.8)
     json (2.6.3)
@@ -36,7 +36,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.0.0)
       ast (~> 2.4.1)
-    psych (5.1.0)
+    psych (5.1.1.1)
       stringio
     public_suffix (5.0.1)
     rainbow (3.1.1)
@@ -44,7 +44,7 @@ GEM
     rdoc (6.5.0)
       psych (>= 4.0.0)
     regexp_parser (2.6.2)
-    reline (0.3.8)
+    reline (0.3.9)
       io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/README.md
+++ b/README.md
@@ -29,17 +29,18 @@ a **helper CLI** based on templates to save lots of day-to-day typing (and human
 2. [Concept Mapping](#concept-mapping)
 3. [Installation](#installation)
 4. [Steps to Migrate](#steps-to-migrate)
-5. [Config](#config)
-6. [Environment](#environment)
-7. [Database](#database)
-8. [In-memory Databases](#in-memory-databases)
-9. [Scheduled Jobs](#scheduled-jobs)
-10. [CLI Commands Reference](#cli-commands-reference)
-11. [Mapping of Heroku Commands to `cpl` and `cpln`](#mapping-of-heroku-commands-to-cpl-and-cpln)
-12. [Examples](#examples)
-13. [Migrating Postgres Database from Heroku Infrastructure](/docs/postgres.md)
-14. [Migrating Redis Database from Heroku Infrastructure](/docs/redis.md)
-15. [Tips](/docs/tips.md)
+5. [Configuration Files](#configuration-files)
+6. [Workflow](#workflow)
+7. [Environment](#environment)
+8. [Database](#database)
+9. [In-memory Databases](#in-memory-databases)
+10. [Scheduled Jobs](#scheduled-jobs)
+11. [CLI Commands Reference](#cli-commands-reference)
+12. [Mapping of Heroku Commands to `cpl` and `cpln`](#mapping-of-heroku-commands-to-cpl-and-cpln)
+13. [Examples](#examples)
+14. [Migrating Postgres Database from Heroku Infrastructure](/docs/postgres.md)
+15. [Migrating Redis Database from Heroku Infrastructure](/docs/redis.md)
+16. [Tips](/docs/tips.md)
 
 ## Key Features
 
@@ -89,23 +90,31 @@ For the typical Rails app, this means:
 
 ## Installation
 
-1. Ensure your [Control Plane](https://controlplane.com) account is set up. Set up an `organization` <your-org> for testing in that account and modify value for `aliases.common.cpln_org` in `.controlplane/controlplane.yml`. If you need an organization, please [contact Shakcode](mailto:controlplane@shkacode.com).
-1. Install [Node.js](https://nodejs.org/en) (required for Control Plane CLI).
+1. Ensure your [Control Plane](https://controlplane.com) account is set up. Set up an `organization` <your-org> for testing in that account and modify the value for `aliases.common.cpln_org` in `.controlplane/controlplane.yml`. If you need an organization, please [contact Shakacode](mailto:controlplane@shakacode.com).
 
-1. Install [Ruby](https://www.ruby-lang.org/en/) (required for these helpers).
+2. Install [Node.js](https://nodejs.org/en) (required for Control Plane CLI).
 
-1. Install Control Plane CLI (and configure access) [docs here](https://docs.controlplane.com/quickstart/quick-start-3-cli#getting-started-with-the-cli), `npm install -g @controlplane/cli`. You can update the `cpln` command line with `npm update -g @controlplane/cli`. Then run `cpln login` to ensure access.
+3. Install [Ruby](https://www.ruby-lang.org/en/) (required for these helpers).
+
+4. Install Control Plane CLI, and configure access ([docs here](https://docs.controlplane.com/quickstart/quick-start-3-cli#getting-started-with-the-cli)).
+
 ```sh
+# Install CLI
 npm install -g @controlplane/cli
+
+# Configure access
 cpln login
+
+# Update CLI
+npm update -g @controlplane/cli
 ```
 
-1. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
+5. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
 
-1. Install Heroku to Control Plane `cpl` CLI, either as a [Ruby gem](https://rubygems.org/gems/cpl) or a local clone.
+6. Install Heroku to Control Plane `cpl` CLI, either as a [Ruby gem](https://rubygems.org/gems/cpl) or a local clone.
    For information on the latter, see [CONTRIBUTING.md](CONTRIBUTING.md). You may also install `cpl` in your project's Gemfile.
 
-1. This project has a `Dockerfile` for Control Plane in this directory. You can use it as an example for your project. Ensure that you have Docker running.
+7. You can use [this Dockerfile](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/Dockerfile) as an example for your project. Ensure that you have Docker running.
 
 **Note:** Do not confuse the `cpl` CLI with the `cpln` CLI. The `cpl` CLI is the Heroku to Control Plane playbook CLI.
 The `cpln` CLI is the Control Plane CLI.
@@ -116,7 +125,7 @@ Click [here](/docs/migrating.md) to see the steps to migrate.
 
 ## Configuration Files
 
-The `cpl` gem is based on several configuration files within a `/.controlplane` top-level directory in your Rails project.
+The `cpl` gem is based on several configuration files within a `/.controlplane` top-level directory in your project.
 
 ```
 .controlplane/
@@ -132,14 +141,15 @@ The `cpl` gem is based on several configuration files within a `/.controlplane` 
 1. `controlplane.yml` describes the overall application. Be sure to have <your-org> as the value for `aliases.common.cpln_org`.
 2. `Dockerfile` builds the production application. `entrypoint.sh` is an _example_ entrypoint script for the production application, referenced in your Dockerfile.
 3. `templates` directory contains the templates for the various workloads, such as `rails.yml` and `postgres.yml`.
-4. `templates/gvc.yml` defines your project's GVC (like a Heroku app). Most importantly, it contains ENV values for app.
-5. `templates/rails.yml` defines your Rails workload. It may inherit ENV values from the parent GVC, which is populated from the `templates/gvc.yml`. This file also configures scaling, sizing, firewalls, and other workload specific values.
-6. For other workloads (like lines in a Heroku Procfile), you create additional template files. For example, you can base a `templates/sidekiq.yml` on the `templates/rails.yml` file.
-7. You can have other files in the `templates` directory, such as `redis.yml` and `postgres.yml` which could setup Redis and Postgres for a testing application.
+4. `templates/gvc.yml` defines your project's GVC (like a Heroku app). More importantly, it contains ENV values for the app.
+5. `templates/rails.yml` defines your Rails workload. It may inherit ENV values from the parent GVC, which is populated from the `templates/gvc.yml`. This file also configures scaling, sizing, firewalls, and other workload-specific values.
+6. For other workloads (like lines in a Heroku `Procfile`), you create additional template files. For example, you can base a `templates/sidekiq.yml` on the `templates/rails.yml` file.
+7. You can have other files in the `templates` directory, such as `redis.yml` and `postgres.yml`, which could setup Redis and Postgres for a testing application.
 
 Here's a complete example of all supported config keys explained for the `controlplane.yml` file:
-                                                       
+
 ### `controlplane.yml`
+
 ```yaml
 # Keys beginning with "cpln_" correspond to your settings in Control Plane.
 
@@ -234,58 +244,64 @@ apps:
 
 ## Workflow
 
-For a live example, see the [react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/readme.md).
+For a live example, see the [react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/readme.md) repository.
+
 This example should closely match the below example.
 
 Suppose your app is called `tutorial-app`. You can run the following commands.
 
 ### Setup Commands
+
 ```sh
 # Provision all infrastructure on Control Plane.
-# app tutorial-app will be created per definition in .controlplane/controlplane.yml
+# `tutorial-app` will be created per definition in .controlplane/controlplane.yml.
 cpl apply-template gvc postgres redis rails -a tutorial-app
 
-# Build and push docker image to Control Plane repository
-# Note, may take many minutes. Be patient. Check for error messages, such as forgetting to run `cpln image docker-login --org <your-org>`
+# Build and push the Docker image to the Control Plane repository.
+# Note, it may take many minutes. Be patient.
+# Check for error messages, such as forgetting to run `cpln image docker-login --org <your-org>`.
 cpl build-image -a tutorial-app
 
-# Promote image to app after running `cpl build-image command`
-# Note, the UX of images may not show the image for up to 5 minutes. However, it's ready.
+# Promote the image to the app after running the `cpl build-image` command.
+# Note, the UX of the images may not show the image for up to 5 minutes. However, it's ready.
 cpl deploy-image -a tutorial-app
 
-# See how app is starting up
+# See how the app is starting up.
 cpl logs -a tutorial-app
 
-# Open app in browser (once it has started up)
+# Open the app in browser (once it has started up).
 cpl open -a tutorial-app
 ```
 
-### Promoting code updates
+### Promoting Code Updates
 
 After committing code, you will update your deployment of `tutorial-app` with the following commands:
 
 ```sh
-# Build and push new image with sequential image tagging, e.g. 'tutorial-app:1', then 'tutorial-app:2', etc.
+# Build and push a new image with sequential image tagging, e.g. 'tutorial-app:1', then 'tutorial-app:2', etc.
 cpl build-image -a tutorial-app
 
-# Run database migrations (or other release tasks) with latest image,
-# while app is still running on previous image.
+# Run database migrations (or other release tasks) with the latest image,
+# while the app is still running on the previous image.
 # This is analogous to the release phase.
-cpl runner rails db:migrate -a tutorial-app --image latest
+cpl run:detached rails db:migrate -a tutorial-app --image latest
 
-# Pomote latest image to app
+# Pomote the latest image to the app.
 cpl deploy-image -a tutorial-app
 ```
 
 If you needed to push a new image with a specific commit SHA, you can run the following command:
 
 ```sh
-# Build and push with sequential image tagging and commit SHA, e.g. 'tutorial-app:123_ABCD'
+# Build and push with sequential image tagging and commit SHA, e.g. 'tutorial-app:123_ABCD', etc.
 cpl build-image -a tutorial-app --commit ABCD
 ```
 
 ### Real World
-Most companies will configure their CI system to handle the above steps. Please [contact Shakcode](mailto:controlplane@shkacode.com) for examples of how to do this, jump on [**React+Rails Slack channel**] (https://reactrails.slack.com/join/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE).
+
+Most companies will configure their CI system to handle the above steps. Please [contact Shakacode](mailto:controlplane@shakacode.com) for examples of how to do this.
+
+You can also join our [**Slack channel**](https://reactrails.slack.com/join/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE) for ShakaCode open source projects.
 
 ## Environment
 
@@ -307,25 +323,27 @@ It is also possible to set up a Secret store (of type `Dictionary`), which we ca
 Policy to access the secret.
 
 In `templates/gvc.yml`:
+
 ```yaml
 spec:
   env:
     - name: MY_GLOBAL_VAR
-      value: 'value'
+      value: "value"
     - name: MY_SECRET_GLOBAL_VAR
-      value: 'cpln://secret/MY_SECRET_STORE_NAME/MY_SECRET_GLOBAL_VAR'
+      value: "cpln://secret/MY_SECRET_STORE_NAME/MY_SECRET_GLOBAL_VAR"
 ```
 
 In `templates/rails.yml`:
+
 ```yaml
 spec:
   containers:
     - name: rails
       env:
         - name: MY_LOCAL_VAR
-          value: 'value'
+          value: "value"
         - name: MY_SECRET_LOCAL_VAR
-          value: 'cpln://secret/MY_SECRET_STORE_NAME/MY_SECRET_LOCAL_VAR'
+          value: "cpln://secret/MY_SECRET_STORE_NAME/MY_SECRET_LOCAL_VAR"
       inheritEnv: true # To enable global env inheritance.
 ```
 

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -35,13 +35,12 @@ module Command
       ```
     EX
 
-    def call # rubocop:disable Metrics/MethodLength
+    def call # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
       ensure_templates!
 
-      @app_status = :existing
-      @created_workloads = []
-      @failed_workloads = []
-      @skipped_workloads = []
+      @created_items = []
+      @failed_templates = []
+      @skipped_templates = []
 
       @asked_for_confirmation = false
 
@@ -57,9 +56,11 @@ module Command
 
       pending_templates.each do |template, filename|
         step("Applying template '#{template}'", abort_on_error: false) do
-          apply_template(filename)
-          if $CHILD_STATUS.success?
-            report_success(template)
+          items = apply_template(filename)
+          if items
+            items.each do |item|
+              report_success(item)
+            end
           else
             report_failure(template)
           end
@@ -68,10 +69,9 @@ module Command
         end
       end
 
-      print_app_status
-      print_created_workloads
-      print_failed_workloads
-      print_skipped_workloads
+      print_created_items
+      print_failed_templates
+      print_skipped_templates
     end
 
     private
@@ -134,62 +134,37 @@ module Command
       cp.apply_template(data)
     end
 
-    def report_success(template)
-      if template == "gvc"
-        @app_status = :success
-      else
-        @created_workloads.push(template)
-      end
+    def report_success(item)
+      @created_items.push(item)
     end
 
     def report_failure(template)
-      if template == "gvc"
-        @app_status = :failure
-      else
-        @failed_workloads.push(template)
-      end
+      @failed_templates.push(template)
     end
 
     def report_skipped(template)
-      if template == "gvc"
-        @app_status = :skipped
-      else
-        @skipped_workloads.push(template)
-      end
+      @skipped_templates.push(template)
     end
 
-    def print_app_status
-      return if @app_status == :existing
+    def print_created_items
+      return unless @created_items.any?
 
-      case @app_status
-      when :success
-        progress.puts("\n#{Shell.color("Created app '#{config.app}'.", :green)}")
-      when :failure
-        progress.puts("\n#{Shell.color("Failed to create app '#{config.app}'.", :red)}")
-      when :skipped
-        progress.puts("\n#{Shell.color("Skipped app '#{config.app}' (already exists).", :blue)}")
-      end
+      created = @created_items.map { |item| "  - [#{item[:kind]}] #{item[:name]}" }.join("\n")
+      progress.puts("\n#{Shell.color('Created items:', :green)}\n#{created}")
     end
 
-    def print_created_workloads
-      return unless @created_workloads.any?
+    def print_failed_templates
+      return unless @failed_templates.any?
 
-      workloads = @created_workloads.map { |template| "  - #{template}" }.join("\n")
-      progress.puts("\n#{Shell.color('Created workloads:', :green)}\n#{workloads}")
+      failed = @failed_templates.map { |template| "  - #{template}" }.join("\n")
+      progress.puts("\n#{Shell.color('Failed to apply templates:', :red)}\n#{failed}")
     end
 
-    def print_failed_workloads
-      return unless @failed_workloads.any?
+    def print_skipped_templates
+      return unless @skipped_templates.any?
 
-      workloads = @failed_workloads.map { |template| "  - #{template}" }.join("\n")
-      progress.puts("\n#{Shell.color('Failed to create workloads:', :red)}\n#{workloads}")
-    end
-
-    def print_skipped_workloads
-      return unless @skipped_workloads.any?
-
-      workloads = @skipped_workloads.map { |template| "  - #{template}" }.join("\n")
-      progress.puts("\n#{Shell.color('Skipped workloads (already exist):', :blue)}\n#{workloads}")
+      skipped = @skipped_templates.map { |template| "  - #{template}" }.join("\n")
+      progress.puts("\n#{Shell.color('Skipped templates (already exist):', :blue)}\n#{skipped}")
     end
   end
 end

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -130,7 +130,8 @@ module Command
                  .gsub("APP_ORG", config.org)
                  .gsub("APP_IMAGE", latest_image)
 
-      cp.apply(YAML.safe_load(data))
+      # Don't read in YAML.safe_load as that doesn't handle multiple documents
+      cp.apply_template(data)
     end
 
     def report_success(template)

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -111,7 +111,7 @@ module Command
       end
 
       # Create workload clone
-      cp.apply("kind" => "workload", "name" => one_off, "spec" => spec)
+      cp.apply_hash("kind" => "workload", "name" => one_off, "spec" => spec)
     end
 
     def runner_script # rubocop:disable Metrics/MethodLength

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -104,7 +104,7 @@ module Command
       container_spec["env"] << { "name" => "CONTROLPLANE_RUNNER", "value" => runner_script }
 
       # Create workload clone
-      cp.apply("kind" => "workload", "name" => one_off, "spec" => spec)
+      cp.apply_hash("kind" => "workload", "name" => one_off, "spec" => spec)
     end
 
     def runner_script # rubocop:disable Metrics/MethodLength

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -291,17 +291,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def apply_hash(data) # rubocop:disable Metrics/MethodLength
-    Tempfile.create do |f|
-      f.write(data.to_yaml)
-      f.rewind
-      cmd = "cpln apply #{gvc_org} --file #{f.path} > /dev/null"
-      if Shell.tmp_stderr
-        cmd += " 2> #{Shell.tmp_stderr.path}"
-        perform(cmd)
-      else
-        perform!(cmd)
-      end
-    end
+    apply_template(data.to_yaml)
   end
 
   private

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -290,7 +290,6 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
-
   def apply_hash(data) # rubocop:disable Metrics/MethodLength
     Tempfile.create do |f|
       f.write(data.to_yaml)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -290,7 +290,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def apply_hash(data) # rubocop:disable Metrics/MethodLength
+  def apply_hash(data)
     apply_template(data.to_yaml)
   end
 

--- a/lib/cpl/version.rb
+++ b/lib/cpl/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Cpl
-  VERSION = "1.1.1"
+  VERSION = "1.1.2.rc.0"
   MIN_CPLN_VERSION = "0.0.71"
 end


### PR DESCRIPTION
Conversion of template yaml to hash and back resulted in the loss of multiple documents in one yaml file.

MacOS builds require specification of the platform.