### PR TITLE
Accept --location option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Added option to set the app with a `CPLN_APP` env var. [PR 88](https://github.com/shakacode/heroku-to-control-plane/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Show `org` and `app` on every command excluding `info`, `version`, `maintenance`, `env`, `ps`, and `latest_image`. [PR 94](https://github.com/shakacode/heroku-to-control-plane/pull/94) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 - Added option to only use `CPLN_ORG` and `CPLN_APP` env vars if `allow_org_override_by_env` and `allow_app_override_by_env` configs are set to `true` in `controlplane.yml`. [PR 109](https://github.com/shakacode/heroku-to-control-plane/pull/109) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Added `--location` option for `apply-template`, `ps`, `run`, `run:detached`. [PR 105](https://github.com/shakacode/heroku-to-control-plane/pull/105) by [Mostafa Ahangarha](https://github.com/ahangarha).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Added option to set the app with a `CPLN_APP` env var. [PR 88](https://github.com/shakacode/heroku-to-control-plane/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Show `org` and `app` on every command excluding `info`, `version`, `maintenance`, `env`, `ps`, and `latest_image`. [PR 94](https://github.com/shakacode/heroku-to-control-plane/pull/94) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 - Added option to only use `CPLN_ORG` and `CPLN_APP` env vars if `allow_org_override_by_env` and `allow_app_override_by_env` configs are set to `true` in `controlplane.yml`. [PR 109](https://github.com/shakacode/heroku-to-control-plane/pull/109) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-- Added `--location` option for `apply-template`, `ps`, `run`, `run:detached`. [PR 105](https://github.com/shakacode/heroku-to-control-plane/pull/105) by [Mostafa Ahangarha](https://github.com/ahangarha).
+- Added `CPLN_LOCATION` env variable and `--location` option for `apply-template`, `ps`, `run`, `run:detached`. [PR 105](https://github.com/shakacode/heroku-to-control-plane/pull/105) by [Mostafa Ahangarha](https://github.com/ahangarha).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ aliases:
     # Control Plane offers the ability to use multiple locations.
     # default_location is used for commands that require a location
     # including `ps`, `run`, `run:detached`, `apply-template`.
-    # This can be overridden with option --location=<location>
+    # This can be overridden with option --location=<location> and
+    # CPLN_LOCATION environment variable.
     default_location: aws-us-east-2
 
     # Allows running the command `cpl setup-app`

--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ aliases:
     # (provided that `allow_org_override_by_env` is set to `true`).
     cpln_org: my-org-staging
 
-    # Example apps use only one location. Control Plane offers the ability to use multiple locations.
+    # Control Plane offers the ability to use multiple locations.
+    # default_location is used for commands that require a location
+    # including `ps`, `run`, `run:detached`, `apply-template`.
+    # This can be overridden with option --location=<location>
     default_location: aws-us-east-2
 
     # Allows running the command `cpl setup-app`

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -18,7 +18,8 @@ aliases:
     # Control Plane offers the ability to use multiple locations.
     # default_location is used for commands that require a location
     # including `ps`, `run`, `run:detached`, `apply-template`.
-    # This can be overridden with option --location=<location>
+    # This can be overridden with option --location=<location> and
+    # CPLN_LOCATION environment variable.
     # TODO: Allow specification of multiple locations.
     default_location: aws-us-east-2
 

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -15,7 +15,11 @@ aliases:
     # (provided that `allow_org_override_by_env` is set to `true`).
     cpln_org: my-org-staging
 
-    # Example apps use only one location. Control Plane offers the ability to use multiple locations.
+    # Control Plane offers the ability to use multiple locations.
+    # default_location is used for commands that require a location
+    # including `ps`, `run`, `run:detached`, `apply-template`.
+    # This can be overridden with option --location=<location>
+    # TODO: Allow specification of multiple locations.
     default_location: aws-us-east-2
 
     # Allows running the command `cpl setup-app`

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -7,6 +7,7 @@ module Command
     REQUIRES_ARGS = true
     OPTIONS = [
       app_option(required: true),
+      location_option,
       skip_confirm_option
     ].freeze
     DESCRIPTION = "Applies application-specific configs from templates"
@@ -126,7 +127,7 @@ module Command
     def apply_template(filename)
       data = File.read(filename)
                  .gsub("APP_GVC", config.app)
-                 .gsub("APP_LOCATION", config[:default_location])
+                 .gsub("APP_LOCATION", config.options[:location] || config[:default_location])
                  .gsub("APP_ORG", config.org)
                  .gsub("APP_IMAGE", latest_image)
 

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -127,7 +127,7 @@ module Command
     def apply_template(filename)
       data = File.read(filename)
                  .gsub("APP_GVC", config.app)
-                 .gsub("APP_LOCATION", config.options[:location] || config[:default_location])
+                 .gsub("APP_LOCATION", config.location)
                  .gsub("APP_ORG", config.org)
                  .gsub("APP_IMAGE", latest_image)
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -117,7 +117,8 @@ module Command
           banner: "LOCATION_NAME",
           desc: "Location name",
           type: :string,
-          required: required
+          required: required,
+          default: ENV.fetch("CPLN_LOCATION", nil)
         }
       }
     end

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -109,6 +109,19 @@ module Command
       }
     end
 
+    def self.location_option(required: false)
+      {
+        name: :location,
+        params: {
+          aliases: ["-l"],
+          banner: "LOCATION_NAME",
+          desc: "Location name",
+          type: :string,
+          required: required
+        }
+      }
+    end
+
     def self.upstream_token_option(required: false)
       {
         name: :upstream_token,

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -109,7 +109,7 @@ module Command
       }
     end
 
-    def self.location_option(required: false) # rubocop:disable Metrics/MethodLength
+    def self.location_option(required: false)
       {
         name: :location,
         params: {
@@ -117,8 +117,7 @@ module Command
           banner: "LOCATION_NAME",
           desc: "Location name",
           type: :string,
-          required: required,
-          default: ENV.fetch("CPLN_LOCATION", nil)
+          required: required
         }
       }
     end

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -109,7 +109,7 @@ module Command
       }
     end
 
-    def self.location_option(required: false)
+    def self.location_option(required: false) # rubocop:disable Metrics/MethodLength
       {
         name: :location,
         params: {

--- a/lib/command/ps.rb
+++ b/lib/command/ps.rb
@@ -5,6 +5,7 @@ module Command
     NAME = "ps"
     OPTIONS = [
       app_option(required: true),
+      location_option,
       workload_option
     ].freeze
     DESCRIPTION = "Shows running replicas in app"
@@ -25,12 +26,14 @@ module Command
     def call
       cp.fetch_gvc!
 
+      location = config.options["location"] || config[:default_location]
+
       workloads = [config.options[:workload]] if config.options[:workload]
       workloads ||= config[:app_workloads] + config[:additional_workloads]
       workloads.each do |workload|
         cp.fetch_workload!(workload)
 
-        result = cp.workload_get_replicas(workload, location: config[:default_location])
+        result = cp.workload_get_replicas(workload, location: location)
         result["items"].each { |replica| puts replica }
       end
     end

--- a/lib/command/ps.rb
+++ b/lib/command/ps.rb
@@ -26,7 +26,7 @@ module Command
     def call
       cp.fetch_gvc!
 
-      location = config.options["location"] || config[:default_location]
+      location = config.location
 
       workloads = [config.options[:workload]] if config.options[:workload]
       workloads ||= config[:app_workloads] + config[:additional_workloads]

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -57,7 +57,7 @@ module Command
     attr_reader :location, :workload, :one_off, :container
 
     def call # rubocop:disable Metrics/MethodLength
-      @location = config.options["location"] || config[:default_location]
+      @location = config.location
       @workload = config.options["workload"] || config[:one_off_workload]
       @one_off = "#{workload}-run-#{rand(1000..9999)}"
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -10,6 +10,7 @@ module Command
       app_option(required: true),
       image_option,
       workload_option,
+      location_option,
       use_local_token_option,
       terminal_size_option
     ].freeze
@@ -56,7 +57,7 @@ module Command
     attr_reader :location, :workload, :one_off, :container
 
     def call # rubocop:disable Metrics/MethodLength
-      @location = config[:default_location]
+      @location = config.options["location"] || config[:default_location]
       @workload = config.options["workload"] || config[:one_off_workload]
       @one_off = "#{workload}-run-#{rand(1000..9999)}"
 

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -9,6 +9,7 @@ module Command
       app_option(required: true),
       image_option,
       workload_option,
+      location_option,
       use_local_token_option
     ].freeze
     DESCRIPTION = "Runs one-off **_non-interactive_** replicas (close analog of `heroku run:detached`)"
@@ -47,7 +48,7 @@ module Command
     attr_reader :location, :workload, :one_off, :container
 
     def call # rubocop:disable Metrics/MethodLength
-      @location = config[:default_location]
+      @location = config.options["location"] || config[:default_location]
       @workload = config.options["workload"] || config[:one_off_workload]
       @one_off = "#{workload}-runner-#{rand(1000..9999)}"
 

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -48,7 +48,7 @@ module Command
     attr_reader :location, :workload, :one_off, :container
 
     def call # rubocop:disable Metrics/MethodLength
-      @location = config.options["location"] || config[:default_location]
+      @location = config.location
       @workload = config.options["workload"] || config[:one_off_workload]
       @one_off = "#{workload}-runner-#{rand(1000..9999)}"
 

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -18,7 +18,7 @@ class Config # rubocop:disable Metrics/ClassLength
 
     ensure_required_options!
 
-    @location = options[:location] || config.dig(:apps, app&.to_sym, :default_location)
+    @location = options[:location] || current&.dig(:default_location)
 
     Shell.verbose_mode(options[:verbose])
   end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -3,7 +3,7 @@
 require_relative "helpers"
 
 class Config # rubocop:disable Metrics/ClassLength
-  attr_reader :org_comes_from_env, :app_comes_from_env,
+  attr_reader :org_comes_from_env, :app_comes_from_env, :location,
               # command line options
               :args, :options, :required_options
 
@@ -17,6 +17,8 @@ class Config # rubocop:disable Metrics/ClassLength
     @required_options = required_options
 
     ensure_required_options!
+
+    @location = options[:location] || config.dig(:apps, app.to_sym, :default_location)
 
     Shell.verbose_mode(options[:verbose])
   end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -18,7 +18,7 @@ class Config # rubocop:disable Metrics/ClassLength
 
     ensure_required_options!
 
-    @location = options[:location] || config.dig(:apps, app.to_sym, :default_location)
+    @location = options[:location] || config.dig(:apps, app&.to_sym, :default_location)
 
     Shell.verbose_mode(options[:verbose])
   end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -30,7 +30,7 @@ class Config # rubocop:disable Metrics/ClassLength
   end
 
   def location
-    @location ||= load_location_from_options || load_location_from_env
+    @location ||= load_location_from_options || load_location_from_env || load_location_from_file
   end
 
   def [](key)
@@ -245,7 +245,7 @@ class Config # rubocop:disable Metrics/ClassLength
   def load_location_from_file
     return unless current&.key?(:default_location)
 
-    strip_str_and_validate(options[:default_location])
+    strip_str_and_validate(current.fetch(:default_location))
   end
 
   def warn_deprecated_options(app_options)

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -3,7 +3,7 @@
 require_relative "helpers"
 
 class Config # rubocop:disable Metrics/ClassLength
-  attr_reader :org_comes_from_env, :app_comes_from_env, :location,
+  attr_reader :org_comes_from_env, :app_comes_from_env,
               # command line options
               :args, :options, :required_options
 
@@ -18,8 +18,6 @@ class Config # rubocop:disable Metrics/ClassLength
 
     ensure_required_options!
 
-    @location = options[:location] || current&.dig(:default_location)
-
     Shell.verbose_mode(options[:verbose])
   end
 
@@ -29,6 +27,10 @@ class Config # rubocop:disable Metrics/ClassLength
 
   def app
     @app ||= load_app_from_options || load_app_from_env
+  end
+
+  def location
+    @location ||= load_location_from_options || load_location_from_env
   end
 
   def [](key)
@@ -230,6 +232,20 @@ class Config # rubocop:disable Metrics/ClassLength
     return unless current&.key?(:cpln_org)
 
     strip_str_and_validate(current[:cpln_org])
+  end
+
+  def load_location_from_options
+    strip_str_and_validate(options[:location])
+  end
+
+  def load_location_from_env
+    strip_str_and_validate(ENV.fetch("CPLN_LOCATION", nil))
+  end
+
+  def load_location_from_file
+    return unless current&.key?(:default_location)
+
+    strip_str_and_validate(options[:default_location])
   end
 
   def warn_deprecated_options(app_options)


### PR DESCRIPTION
This PR add a `-l, --location` option to the project, which can be used in the following commands:
- `apply-template`
- `ps`
- `run`
- `run:detached`

~Question: Should we have `CPLN_LOCATION` as well?~ --> Added in ad26c1e
Question: Should we add an option to prevent override by env variable? (like org and app)

---
Closes #100 