### PR TITLE
Rename 'setup' to 'setup_app_templates' in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Changed
 
 - `--org` option now takes precedence over `CPLN_ORG` env var, which takes precedence over `cpln_org` from `controlplane.yml`. [PR 88](https://github.com/shakacode/heroku-to-control-plane/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Deprecated `setup` entry in the ControlePlane config file and introduced `setup_app_templates` in its place. [PR 112](https://github.com/shakacode/heroku-to-control-plane/pull/112) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 
 ## [1.1.2] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Changed
 
 - `--org` option now takes precedence over `CPLN_ORG` env var, which takes precedence over `cpln_org` from `controlplane.yml`. [PR 88](https://github.com/shakacode/heroku-to-control-plane/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-- Deprecated `setup` entry in the Control Plane config file and introduced `setup_app_templates` in its place. [PR 112](https://github.com/shakacode/heroku-to-control-plane/pull/112) by [Mostafa Ahangarhga](https://github.com/ahangarha).
+- Renamed `setup` config into `setup_app_templates`. [PR 112](https://github.com/shakacode/heroku-to-control-plane/pull/112) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 
 ## [1.1.2] - 2023-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Changed
 
 - `--org` option now takes precedence over `CPLN_ORG` env var, which takes precedence over `cpln_org` from `controlplane.yml`. [PR 88](https://github.com/shakacode/heroku-to-control-plane/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-- Deprecated `setup` entry in the ControlePlane config file and introduced `setup_app_templates` in its place. [PR 112](https://github.com/shakacode/heroku-to-control-plane/pull/112) by [Mostafa Ahangarhga](https://github.com/ahangarha).
+- Deprecated `setup` entry in the Control Plane config file and introduced `setup_app_templates` in its place. [PR 112](https://github.com/shakacode/heroku-to-control-plane/pull/112) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 
 ## [1.1.2] - 2023-10-17
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ aliases:
 
     # Allows running the command `cpl setup-app`
     # instead of `cpl apply-template gvc redis postgres memcached rails sidekiq`.
-    setup:
+    setup_app_templates:
       - gvc
       - redis
       - postgres

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -390,8 +390,8 @@ cpl run:detached rails db:migrate:status -a $APP_NAME --use-local-token
 ### `setup-app`
 
 - Creates an app and all its workloads
-- Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
-- This should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+- Specify the templates for the app and workloads through `setup` in the `.controlplane/controlplane.yml` file
+- This should should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
 
 ```sh
 cpl setup-app -a $APP_NAME

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -390,8 +390,8 @@ cpl run:detached rails db:migrate:status -a $APP_NAME --use-local-token
 ### `setup-app`
 
 - Creates an app and all its workloads
-- Specify the templates for the app and workloads through `setup` in the `.controlplane/controlplane.yml` file
-- This should should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+- Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
+- This should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
 
 ```sh
 cpl setup-app -a $APP_NAME

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -29,13 +29,13 @@ Edit the `.controlplane/controlplane.yml` file as needed. Note that the `my-app-
 is defined in this file. See
 [this example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/controlplane.yml).
 
-Before the initial setup, add the templates for the app to the `.controlplane/controlplane.yml` file, using the `setup`
+Before the initial setup, add the templates for the app to the `.controlplane/controlplane.yml` file, using the `setup_app_templates`
 key, e.g.:
 
 ```yaml
 my-app-staging:
   <<: *common
-  setup:
+  setup_app_templates:
     - gvc
     - redis
     - memcached
@@ -191,7 +191,7 @@ configure an entry for, e.g., `my-app-review`, and then create review apps start
   my-app-review:
     <<: *common
     match_if_app_name_starts_with: true
-    setup:
+    setup_app_templates:
       - gvc
       - redis
       - memcached

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -14,7 +14,7 @@ module Command
     DESC
 
     def call
-      templates = config[:setup]
+      templates = config[:setup_app_templates]
 
       app = cp.fetch_gvc
       if app

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -9,8 +9,8 @@ module Command
     DESCRIPTION = "Creates an app and all its workloads"
     LONG_DESCRIPTION = <<~DESC
       - Creates an app and all its workloads
-      - Specify the templates for the app and workloads through `setup` in the `.controlplane/controlplane.yml` file
-      - This should should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+      - Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
+      - This should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
     DESC
 
     def call

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -133,6 +133,7 @@ class Config # rubocop:disable Metrics/ClassLength
       org: :cpln_org,
       location: :default_location,
       prefix: :match_if_app_name_starts_with,
+      setup: :setup_app_templates,
       old_image_retention_days: :image_retention_days
     }
   end


### PR DESCRIPTION
Note https://github.com/shakacode/heroku-to-control-plane/issues/96#issuecomment-1819318986


> I have two proposals here:
> 
> 1. Drop the `setup-app` command entirely and replace it with `--all` in `apply-template`.
>    I think the value of this command is to ease the initial setup of an app with all of its templates. If the user has any specific use case, then the normal usage of `apply-template t1 t2 t3` is there.
> 2. We assume `setup_app_template` includes all templates unless specified in the config file. This means if the user has not made an entry in the config file, still `setup-app` can be used, and it applies all the templates. In this case, the user can white-list templates in the config file under `setup_app_template`.
> 
> I think the first approach is better because it is much simpler.

---
Closes #96 