### PR TITLE
Capitalize `n` in confirmation to indicate it as the default behavior

### DIFF
--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -36,7 +36,7 @@ class Shell
   end
 
   def self.confirm(message)
-    shell.yes?("#{message} (y/n)")
+    shell.yes?("#{message} (y/N)")
   end
 
   def self.warn(message)


### PR DESCRIPTION
By convention, CLI apps use capital letters for the default value on confirmations.

Current confirmation:
`Are you sure you want to delete 'react-webpack-rails-tutorial'? (y/n)`

New confirmation:
`Are you sure you want to delete 'react-webpack-rails-tutorial'? (y/N)`