### PR TITLE
Add feature to hide sensitive data in logs

### DIFF
--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -23,10 +23,10 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def profile_create(profile, token)
-    @sensitive_data_pattern = /(?<=--token )(\S+)/
+    sensitive_data_pattern = /(?<=--token )(\S+)/
     cmd = "cpln profile create #{profile} --token #{token}"
     cmd += " > /dev/null" if Shell.should_hide_output?
-    perform!(cmd)
+    perform!(cmd, sensitive_data_pattern: sensitive_data_pattern)
   end
 
   def profile_delete(profile)
@@ -342,19 +342,19 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   private
 
   def perform(cmd)
-    Shell.debug("CMD", hide_sensitive_data(cmd))
+    Shell.debug("CMD", cmd)
 
     system(cmd)
   end
 
-  def perform!(cmd)
-    Shell.debug("CMD", hide_sensitive_data(cmd))
+  def perform!(cmd, sensitive_data_pattern: nil)
+    Shell.debug("CMD", cmd, sensitive_data_pattern: sensitive_data_pattern)
 
     system(cmd) || exit(false)
   end
 
   def perform_yaml(cmd)
-    Shell.debug("CMD", hide_sensitive_data(cmd))
+    Shell.debug("CMD", cmd)
 
     result = `#{cmd}`
     $CHILD_STATUS.success? ? YAML.safe_load(result) : exit(false)
@@ -362,12 +362,5 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   def gvc_org
     "--gvc #{gvc} --org #{org}"
-  end
-
-  def hide_sensitive_data(message)
-    pattern = @sensitive_data_pattern
-    return message unless pattern.is_a?(Regexp)
-
-    message.gsub(pattern, "XXXXXXX")
   end
 end

--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -55,11 +55,32 @@ class Shell
     @verbose = verbose
   end
 
-  def self.debug(prefix, message)
-    stderr.puts("\n[#{color(prefix, :red)}] #{message}") if verbose
+  def self.debug(prefix, message, sensitive_data_pattern: nil)
+    filtered_message = hide_sensitive_data(message, sensitive_data_pattern)
+
+    stderr.puts("\n[#{color(prefix, :red)}] #{filtered_message}") if verbose
   end
 
   def self.should_hide_output?
     tmp_stderr && !verbose
+  end
+
+  #
+  # Hide sensitive data based on the passed pattern
+  #
+  # @param [String] message
+  #   The message to get processed.
+  # @param [Regexp, nil] pattern
+  #   The regular expression to be used. If not provided, no filter gets applied.
+  #
+  # @return [String]
+  #   Filtered message.
+  #
+  # @example
+  #   hide_sensitive_data("--token abcd", /(?<=--token )(\S+)/)
+  def self.hide_sensitive_data(message, pattern = nil)
+    return message unless pattern.is_a?(Regexp)
+
+    message.gsub(pattern, "XXXXXXX")
   end
 end

--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -56,9 +56,10 @@ class Shell
   end
 
   def self.debug(prefix, message, sensitive_data_pattern: nil)
-    filtered_message = hide_sensitive_data(message, sensitive_data_pattern)
+    return unless verbose
 
-    stderr.puts("\n[#{color(prefix, :red)}] #{filtered_message}") if verbose
+    filtered_message = hide_sensitive_data(message, sensitive_data_pattern)
+    stderr.puts("\n[#{color(prefix, :red)}] #{filtered_message}")
   end
 
   def self.should_hide_output?


### PR DESCRIPTION
With this implementation, we can set the sensitive data pattern in the closest place to the sensitive data. This can (hopefully) prevent accidental typos in pattern matching.

I couldn't implement test for this feature.

---
Closes #97 