### PR TITLE
Add generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Show `org` and `app` on every command excluding `info`, `version`, `maintenance`, `env`, `ps`, and `latest_image`. [PR 94](https://github.com/shakacode/heroku-to-control-plane/pull/94) by [Mostafa Ahangarha](https://github.com/ahangarha).
 - Added option to only use `CPLN_ORG` and `CPLN_APP` env vars if `allow_org_override_by_env` and `allow_app_override_by_env` configs are set to `true` in `controlplane.yml`. [PR 109](https://github.com/shakacode/heroku-to-control-plane/pull/109) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Added `CPLN_LOCATION` env variable and `--location` option for `apply-template`, `ps`, `run`, `run:detached`. [PR 105](https://github.com/shakacode/heroku-to-control-plane/pull/105) by [Mostafa Ahangarha](https://github.com/ahangarha).
+- Added `generate` command for creating basic Control Plane configuration directory. [PR 116](https://github.com/shakacode/heroku-to-control-plane/pull/116) by [Mostafa Ahangarhga](https://github.com/ahangarha).
 
 ### Changed
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,6 +131,15 @@ cpl env -a $APP_NAME
 if [ cpl exists -a $APP_NAME ]; ...
 ```
 
+### `generate`
+
+Creates base Control Plane config and template files
+
+```sh
+# Creates .controlplane directory with Control Plane config and other templates
+cpl generate
+```
+
 ### `info`
 
 - Displays the diff between defined/available apps/workloads (apps equal GVCs)

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Command
+  class Generator < Thor::Group
+    include Thor::Actions
+
+    def copy_files
+      directory("generator_templates", ".controlplane")
+    end
+
+    def self.source_root
+      File.expand_path("../", __dir__)
+    end
+  end
+
+  class Generate < Base
+    NAME = "generate"
+    DESCRIPTION = "Creates base Control Plane config and template files"
+    LONG_DESCRIPTION = <<~DESC
+      Creates base Control Plane config and template files
+    DESC
+    EXAMPLES = <<~EX
+      ```sh
+      # Creates .controlplane directory with Control Plane config and other templates
+      cpl generate
+      ```
+    EX
+    WITH_INFO_HEADER = false
+    WITH_MINIMAL_CONFIG = true
+
+    def call
+      Generator.start
+    end
+  end
+end

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -29,8 +29,8 @@ module Command
 
     def call
       if controlplane_directory_exists?
-        Shell.abort("The directory '.controlplane' already exists!")
-        exit
+        Shell.warn("The directory '.controlplane' already exists!")
+        return
       end
 
       Generator.start

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -28,7 +28,18 @@ module Command
     WITH_INFO_HEADER = false
 
     def call
+      if controlplane_directory_exists?
+        Shell.abort("The directory '.controlplane' already exists!")
+        exit
+      end
+
       Generator.start
+    end
+
+    private
+
+    def controlplane_directory_exists?
+      Dir.exist? ".controlplane"
     end
   end
 end

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -26,7 +26,6 @@ module Command
       ```
     EX
     WITH_INFO_HEADER = false
-    WITH_MINIMAL_CONFIG = true
 
     def call
       Generator.start

--- a/lib/generator_templates/Dockerfile
+++ b/lib/generator_templates/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:3.1.2
+
+RUN apt-get update
+
+WORKDIR /app
+
+# install ruby gems
+COPY Gemfile* ./
+
+RUN bundle config set without 'development test' && \
+    bundle config set with 'staging production' && \
+    bundle install --jobs=3 --retry=3
+
+COPY . ./
+
+ENV RAILS_ENV=production
+
+# compiling assets requires any value for ENV of SECRET_KEY_BASE
+ENV SECRET_KEY_BASE=NOT_USED_NON_BLANK
+
+RUN rails assets:precompile
+
+# add entrypoint
+COPY .controlplane/entrypoint.sh ./
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+CMD ["rails", "s"]

--- a/lib/generator_templates/controlplane.yml
+++ b/lib/generator_templates/controlplane.yml
@@ -1,0 +1,46 @@
+# Keys beginning with "cpln_" correspond to your settings in Control Plane.
+
+aliases:
+  common: &common
+    # Organization name for staging (customize to your needs).
+    # Production apps will use a different organization, specified below, for security.
+    cpln_org: my-org-staging
+
+    # Example apps use only one location. Control Plane offers the ability to use multiple locations.
+    # TODO: Allow specification of multiple locations.
+    default_location: aws-us-east-2
+
+    # Configure the workload name used as a template for one-off scripts, like a Heroku one-off dyno.
+    one_off_workload: rails
+
+    # Workloads that are for the application itself and are using application Docker images.
+    app_workloads:
+      - rails
+
+    # Additional "service type" workloads, using non-application Docker images.
+    additional_workloads:
+      - postgres
+
+    # Configure the workload name used when maintenance mode is on (defaults to "maintenance")
+    maintenance_workload: maintenance
+
+apps:
+  my-app-staging:
+    # Use the values from the common section above.
+    <<: *common
+  my-app-review:
+    <<: *common
+    # If `match_if_app_name_starts_with` is `true`, then use this config for app names starting with this name,
+    # e.g., "my-app-review-pr123", "my-app-review-anything-goes", etc.
+    match_if_app_name_starts_with: true
+  my-app-production:
+    <<: *common
+    # Use a different organization for production.
+    cpln_org: my-org-production
+    # Allows running the command `cpl promote-app-from-upstream -a my-app-production`
+    # to promote the staging app to production.
+    upstream: my-app-staging
+  my-app-other:
+    <<: *common
+    # You can specify a different `Dockerfile` relative to the `.controlplane/` directory (defaults to "Dockerfile").
+    dockerfile: ../some_other/Dockerfile

--- a/lib/generator_templates/controlplane.yml
+++ b/lib/generator_templates/controlplane.yml
@@ -1,5 +1,10 @@
 # Keys beginning with "cpln_" correspond to your settings in Control Plane.
 
+# You can opt out of allowing the use of CPLN_ORG and CPLN_APP env vars
+# to avoid any accidents with the wrong org / app.
+allow_org_override_by_env: true
+allow_app_override_by_env: true
+
 aliases:
   common: &common
     # Organization name for staging (customize to your needs).
@@ -35,6 +40,12 @@ apps:
     match_if_app_name_starts_with: true
   my-app-production:
     <<: *common
+
+    # You can also opt out of allowing the use of CPLN_ORG and CPLN_APP env vars per app.
+    # It's recommended to leave this off for production, to avoid any accidents.
+    allow_org_override_by_env: false
+    allow_app_override_by_env: false
+
     # Use a different organization for production.
     cpln_org: my-org-production
     # Allows running the command `cpl promote-app-from-upstream -a my-app-production`

--- a/lib/generator_templates/entrypoint.sh
+++ b/lib/generator_templates/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Runs before the main command
+
+echo " -- Preparing database"
+rails db:prepare
+
+echo " -- Finishing entrypoint.sh, executing '$@'"
+exec "$@"

--- a/lib/generator_templates/templates/gvc.yml
+++ b/lib/generator_templates/templates/gvc.yml
@@ -1,0 +1,21 @@
+# Template setup of the GVC, roughly corresponding to a Heroku app
+kind: gvc
+name: APP_GVC
+spec:
+  # For using templates for test apps, put ENV values here, stored in git repo.
+  # Production apps will have values configured manually after app creation.
+  env:
+    - name: DATABASE_URL
+      # Password does not matter because host postgres.APP_GVC.cpln.local can only be accessed
+      # locally within CPLN GVC, and postgres running on a CPLN workload is something only for a
+      # test app that lacks persistence.
+      value: 'postgres://the_user:the_password@postgres.APP_GVC.cpln.local:5432/APP_GVC'
+    - name: RAILS_ENV
+      value: production
+    - name: RAILS_SERVE_STATIC_FILES
+      value: 'true'
+
+  # Part of standard configuration
+  staticPlacement:
+    locationLinks:
+      - /org/APP_ORG/location/APP_LOCATION

--- a/lib/generator_templates/templates/postgres.yml
+++ b/lib/generator_templates/templates/postgres.yml
@@ -1,0 +1,176 @@
+# Comes from example at
+# https://github.com/controlplane-com/examples/blob/main/examples/postgres/manifest.yaml
+
+kind: volumeset
+name: postgres-poc-vs
+description: postgres-poc-vs
+spec:
+  autoscaling:
+    maxCapacity: 1000
+    minFreePercentage: 1
+    scalingFactor: 1.1
+  fileSystemType: ext4
+  initialCapacity: 10
+  performanceClass: general-purpose-ssd
+  snapshots:
+    createFinalSnapshot: true
+    retentionDuration: 7d
+
+---
+kind: secret
+name: postgres-poc-credentials
+description: ''
+type: dictionary
+data:
+  password: the_password #Replace this with a real password
+  username: the_user     #Replace this with a real username
+
+---
+kind: secret
+name: postgres-poc-entrypoint-script
+type: opaque
+data:
+  encoding: base64
+  payload: >-
+    IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc291cmNlIC91c3IvbG9jYWwvYmluL2RvY2tlci1lbnRyeXBvaW50LnNoCgppbnN0YWxsX2RlcHMoKSB7CiAgYXB0LWdldCB1cGRhdGUgLXkgPiAvZGV2L251bGwKICBhcHQtZ2V0IGluc3RhbGwgY3VybCAteSA+IC9kZXYvbnVsbAogIGFwdC1nZXQgaW5zdGFsbCB1bnppcCAteSA+IC9kZXYvbnVsbAogIGN1cmwgImh0dHBzOi8vYXdzY2xpLmFtYXpvbmF3cy5jb20vYXdzY2xpLWV4ZS1saW51eC14ODZfNjQuemlwIiAtbyAiYXdzY2xpdjIuemlwIiA+IC9kZXYvbnVsbAogIHVuemlwIGF3c2NsaXYyLnppcCA+IC9kZXYvbnVsbAogIC4vYXdzL2luc3RhbGwgPiAvZGV2L251bGwKfQoKZGJfaGFzX2JlZW5fcmVzdG9yZWQoKSB7CiAgaWYgWyAhIC1mICIkUEdEQVRBL0NQTE5fUkVTVE9SRUQiIF07IHRoZW4KICAgIHJldHVybiAxCiAgZmkKCiAgaWYgISBncmVwIC1xICJcLT4gJDEkIiAiJFBHREFUQS9DUExOX1JFU1RPUkVEIjsgdGhlbgogICAgcmV0dXJuIDEKICBlbHNlCiAgICByZXR1cm4gMAogIGZpCn0KCnJlc3RvcmVfZGIoKSB7Cgl3aGlsZSBbICEgLVMgL3Zhci9ydW4vcG9zdGdyZXNxbC8ucy5QR1NRTC41NDMyIF0KCWRvCiAgICBlY2hvICJXYWl0aW5nIDVzIGZvciBkYiBzb2NrZXQgdG8gYmUgYXZhaWxhYmxlIgogICAgc2xlZXAgNXMKICBkb25lCgoKCWlmICEgZGJfaGFzX2JlZW5fcmVzdG9yZWQgIiQxIjsgdGhlbgoJICBlY2hvICJJdCBhcHBlYXJzIGRiICckMScgaGFzIG5vdCB5ZXQgYmVlbiByZXN0b3JlZCBmcm9tIFMzLiBBdHRlbXB0aW5nIHRvIHJlc3RvcmUgJDEgZnJvbSAkMiIKCSAgaW5zdGFsbF9kZXBzCgkgIGRvY2tlcl9zZXR1cF9kYiAjRW5zdXJlcyAkUE9TVEdSRVNfREIgZXhpc3RzIChkZWZpbmVkIGluIHRoZSBlbnRyeXBvaW50IHNjcmlwdCBmcm9tIHRoZSBwb3N0Z3JlcyBkb2NrZXIgaW1hZ2UpCgkgIGF3cyBzMyBjcCAiJDIiIC0gfCBwZ19yZXN0b3JlIC0tY2xlYW4gLS1uby1hY2wgLS1uby1vd25lciAtZCAiJDEiIC1VICIkUE9TVEdSRVNfVVNFUiIKCSAgZWNobyAiJChkYXRlKTogJDIgLT4gJDEiIHwgY2F0ID4+ICIkUEdEQVRBL0NQTE5fUkVTVE9SRUQiCgllbHNlCgkgIGVjaG8gIkRiICckMScgYWxyZWFkeSBleGlzdHMuIFJlYWR5ISIKICBmaQp9CgpfbWFpbiAiJEAiICYKYmFja2dyb3VuZFByb2Nlc3M9JCEKCmlmIFsgLW4gIiRQT1NUR1JFU19BUkNISVZFX1VSSSIgXTsgdGhlbgogIHJlc3RvcmVfZGIgIiRQT1NUR1JFU19EQiIgIiRQT1NUR1JFU19BUkNISVZFX1VSSSIKZWxzZQogIGVjaG8gIkRlY2xpbmluZyB0byByZXN0b3JlIHRoZSBkYiBiZWNhdXNlIG5vIGFyY2hpdmUgdXJpIHdhcyBwcm92aWRlZCIKZmkKCndhaXQgJGJhY2tncm91bmRQcm9jZXNzCgoK
+
+#Here is the ASCII-encoded version of the script in the secret above
+#!/usr/bin/env bash
+#
+#source /usr/local/bin/docker-entrypoint.sh
+#
+#install_deps() {
+#  apt-get update -y > /dev/null
+#  apt-get install curl -y > /dev/null
+#  apt-get install unzip -y > /dev/null
+#  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" > /dev/null
+#  unzip awscliv2.zip > /dev/null
+#  ./aws/install > /dev/null
+#}
+#
+#db_has_been_restored() {
+#  if [ ! -f "$PGDATA/CPLN_RESTORED" ]; then
+#    return 1
+#  fi
+#
+#  if ! grep -q "\-> $1$" "$PGDATA/CPLN_RESTORED"; then
+#    return 1
+#  else
+#    return 0
+#  fi
+#}
+#
+#restore_db() {
+#  while [ ! -S /var/run/postgresql/.s.PGSQL.5432 ]
+#  do
+#    echo "Waiting 5s for db socket to be available"
+#    sleep 5s
+#  done
+#
+#
+#  if ! db_has_been_restored "$1"; then
+#    echo "It appears db '$1' has not yet been restored from S3. Attempting to restore $1 from $2"
+#    install_deps
+#    docker_setup_db #Ensures $POSTGRES_DB exists (defined in the entrypoint script from the postgres docker image)
+#    aws s3 cp "$2" - | pg_restore --clean --no-acl --no-owner -d "$1" -U "$POSTGRES_USER"
+#    echo "$(date): $2 -> $1" | cat >> "$PGDATA/CPLN_RESTORED"
+#  else
+#    echo "Db '$1' already exists. Ready!"
+#  fi
+#}
+#
+#_main "$@" &
+#backgroundProcess=$!
+#
+#if [ -n "$POSTGRES_ARCHIVE_URI" ]; then
+#  restore_db "$POSTGRES_DB" "$POSTGRES_ARCHIVE_URI"
+#else
+#  echo "Declining to restore the db because no archive uri was provided"
+#fi
+#
+#wait $backgroundProcess
+
+---
+kind: identity
+name: postgres-poc-identity
+description: postgres-poc-identity
+
+---
+kind: policy
+name: postgres-poc-access
+description: postgres-poc-access
+bindings:
+  - permissions:
+      - reveal
+# Uncomment these two
+#      - use
+#      - view
+    principalLinks:
+      - //gvc/APP_GVC/identity/postgres-poc-identity
+targetKind: secret
+targetLinks:
+  - //secret/postgres-poc-credentials
+  - //secret/postgres-poc-entrypoint-script
+
+---
+kind: workload
+name: postgres
+description: postgres
+spec:
+  type: stateful
+  containers:
+    - cpu: 1000m
+      memory: 512Mi
+      env:
+        # Uncomment next two envs will cause the db to be restored from the archive uri
+        #        - name: POSTGRES_ARCHIVE_URI  #Use this var to control the automatic restore behavior. If you leave it out, the db will start empty.
+        #          value: s3://YOUR_BUCKET/PATH_TO_ARCHIVE_FILE
+        # - name: POSTGRES_DB #The name of the initial db in case of doing a restore
+        #  value: test
+        - name: PGDATA #The location postgres stores the db. This can be anything other than /var/lib/postgresql/data, but it must be inside the mount point for the volume set
+          value: "/var/lib/postgresql/data/pg_data"
+        - name: POSTGRES_PASSWORD #The password for the default user
+          value: cpln://secret/postgres-poc-credentials.password
+        - name: POSTGRES_USER #The name of the default user
+          value: cpln://secret/postgres-poc-credentials.username
+      name: stateful
+      image: postgres:15
+      command: /bin/bash
+      args:
+        - "-c"
+        - "cat /usr/local/bin/cpln-entrypoint.sh >> ./cpln-entrypoint.sh && chmod u+x ./cpln-entrypoint.sh && ./cpln-entrypoint.sh postgres"
+      #command:  "cpln-entrypoint.sh"
+      #args:
+      #  - "postgres"
+      ports:
+        - number: 5432
+          protocol: tcp
+      volumes:
+        - uri: cpln://volumeset/postgres-poc-vs
+          path: "/var/lib/postgresql/data"
+        # Make the ENV value for the entry script a file
+        - uri: cpln://secret/postgres-poc-entrypoint-script
+          path: "/usr/local/bin/cpln-entrypoint.sh"
+      inheritEnv: false
+      livenessProbe:
+        tcpSocket:
+          port: 5432
+        failureThreshold: 1
+      readinessProbe:
+        tcpSocket:
+          port: 5432
+        failureThreshold: 1
+  identityLink: //identity/postgres-poc-identity
+  defaultOptions:
+    capacityAI: false
+    autoscaling:
+      metric: cpu
+      target: 95
+      maxScale: 1
+  firewallConfig:
+    external:
+      inboundAllowCIDR: []
+      outboundAllowCIDR:
+        - 0.0.0.0/0
+    internal:
+      inboundAllowType: same-gvc

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -1,0 +1,36 @@
+# Template setup of Rails server workload, roughly corresponding to Heroku dyno
+# type within Procfile.
+kind: workload
+name: rails
+spec:
+  type: standard
+  containers:
+    - name: rails
+      # 300m is a good starting place for a test app. You can experiment with CPU configuration
+      # once your app is running.
+      cpu: 300m
+      env:
+        - name: LOG_LEVEL
+          value: debug
+      # Inherit other ENV values from GVC
+      inheritEnv: true
+      image: '/org/APP_ORG/image/APP_IMAGE'
+      # 512 corresponds to a standard 1x dyno type
+      memory: 512Mi
+      ports:
+        - number: 3000
+          protocol: http
+  defaultOptions:
+    # Start out like this for "test apps"
+    autoscaling:
+      # Max of 1 effectively disables autoscaling, so a like a Heroku dyno count of 1
+      maxScale: 1
+    capacityAI: false
+  firewallConfig:
+    external:
+      # Default to allow public access to Rails server
+      inboundAllowCIDR:
+        - 0.0.0.0/0
+      # Could configure outbound for more security
+      outboundAllowCIDR:
+        - 0.0.0.0/0

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -44,7 +44,7 @@ describe Command::Generate do
 
         expect do
           Cpl::Cli.start([described_class::NAME])
-        end.to output(/already exist/).to_stdout
+        end.to output(/already exist/).to_stderr
 
         controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
         expect(controlplane_config_file_path).not_to exist

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "pathname"
-require "rake"
 
 GEM_ROOT_PATH = Pathname.new(Dir.pwd)
 GEM_TEMP_PATH = GEM_ROOT_PATH.join("tmp")
@@ -10,8 +9,12 @@ GENERATOR_PLAYGROUND_PATH = GEM_TEMP_PATH.join("sample-project")
 CONTROLPLANE_CONFIG_DIR_PATH = GENERATOR_PLAYGROUND_PATH.join(".controlplane")
 CPL_EXECUTABLE_PATH = GEM_ROOT_PATH.join("bin", "cpl")
 
-def sh_in_dir(dir, *shell_commands)
-  shell_commands.flatten.each { |shell_command| RakeFileUtils.sh %(cd '#{dir}' && #{shell_command.strip}) }
+def inside_dir(path)
+  original_working_dir = Dir.pwd
+  Dir.chdir path
+  yield if block_given?
+ensure
+  Dir.chdir original_working_dir
 end
 
 describe Command::Generate do
@@ -26,11 +29,11 @@ describe Command::Generate do
 
   context "when no configuration exist in the project" do
     it "generates base config files" do
-      command = "#{CPL_EXECUTABLE_PATH} generate"
-      sh_in_dir(GENERATOR_PLAYGROUND_PATH, command)
-
-      controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
-      expect(controlplane_config_file_path).to exist
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Cpl::Cli.start([described_class::NAME])
+        controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
+        expect(controlplane_config_file_path).to exist
+      end
     end
   end
 end

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -36,4 +36,19 @@ describe Command::Generate do
       end
     end
   end
+
+  context "when .controlplane directory already exist" do
+    it "doesn't generates base config files" do
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Dir.mkdir(CONTROLPLANE_CONFIG_DIR_PATH)
+
+        expect do
+          Cpl::Cli.start([described_class::NAME])
+        end.to output(/already exist/).to_stdout
+
+        controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
+        expect(controlplane_config_file_path).not_to exist
+      end
+    end
+  end
 end

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "pathname"
+require "rake"
+
+GEM_ROOT_PATH = Pathname.new(Dir.pwd)
+GEM_TEMP_PATH = GEM_ROOT_PATH.join("tmp")
+GENERATOR_PLAYGROUND_PATH = GEM_TEMP_PATH.join("sample-project")
+CONTROLPLANE_CONFIG_DIR_PATH = GENERATOR_PLAYGROUND_PATH.join(".controlplane")
+CPL_EXECUTABLE_PATH = GEM_ROOT_PATH.join("bin", "cpl")
+
+def sh_in_dir(dir, *shell_commands)
+  shell_commands.flatten.each { |shell_command| RakeFileUtils.sh %(cd '#{dir}' && #{shell_command.strip}) }
+end
+
+describe Command::Generate do
+  before do
+    FileUtils.rm_r(GENERATOR_PLAYGROUND_PATH) if Dir.exist?(GENERATOR_PLAYGROUND_PATH)
+    FileUtils.mkdir_p GENERATOR_PLAYGROUND_PATH
+  end
+
+  after do
+    FileUtils.rm_r GENERATOR_PLAYGROUND_PATH
+  end
+
+  context "when no configuration exist in the project" do
+    it "generates base config files" do
+      command = "#{CPL_EXECUTABLE_PATH} generate"
+      sh_in_dir(GENERATOR_PLAYGROUND_PATH, command)
+
+      controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
+      expect(controlplane_config_file_path).to exist
+    end
+  end
+end


### PR DESCRIPTION
⚠️ Note: This PR is on top of PR #110, because it doesn't need to read configuration files. The base branch is deliberately not set to `main` so that PR review becomes easier.

## Tasks:

- [x] Add generator
  - [x] `controlplane.yml`
  - [x] `Dockerfile`
  - [x] `templates/gvc.yml`
  - [x] `templates/rails.yml`
  - [x] `templates/postgres.yml`
- [x] Add options
  - [x] ~`--destination` for custom destination path (defaults to `./.controlplane`)~ - In future if we want to add feature for custom config path. 
  - [x] ~`--force` to force file change~ - Canceled in favor of the following task
  - [x] Prevent override on existing configurations
- [x] Add tests
- [x] Update Docs
- [x] Update Changelog

---
Closes #89 