### PR TITLE
Add `--clean` option to `run:detached` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Added
+
+- Added `--clean` option to `run:detached` command to delete workload when disconnecting. [PR 129](https://github.com/shakacode/heroku-to-control-plane/pull/129) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Changed
 
 - `build-image` command now accepts extra options and passes them to `docker build`. [PR 126](https://github.com/shakacode/heroku-to-control-plane/pull/126) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -375,6 +375,7 @@ cpl run:cleanup -a $APP_NAME
 - Implemented with only async execution methods, more suitable for production tasks
 - Has alternative log fetch implementation with only JSON-polling and no WebSockets
 - Less responsive but more stable, useful for CI tasks
+- Deletes the workload when disconnecting by default (can be disabled with `--no-clean` - the workload will still self-delete when finishing)
 
 ```sh
 cpl run:detached rails db:prepare -a $APP_NAME

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -221,6 +221,18 @@ module Command
       }
     end
 
+    def self.clean_option(required: false)
+      {
+        name: :clean,
+        params: {
+          desc: "Deletes workload when disconnecting",
+          type: :boolean,
+          required: required,
+          default: true
+        }
+      }
+    end
+
     def self.all_options
       methods.grep(/_option$/).map { |method| send(method.to_s) }
     end

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -10,7 +10,8 @@ module Command
       image_option,
       workload_option,
       location_option,
-      use_local_token_option
+      use_local_token_option,
+      clean_option
     ].freeze
     DESCRIPTION = "Runs one-off **_non-interactive_** replicas (close analog of `heroku run:detached`)"
     LONG_DESCRIPTION = <<~DESC
@@ -19,6 +20,7 @@ module Command
       - Implemented with only async execution methods, more suitable for production tasks
       - Has alternative log fetch implementation with only JSON-polling and no WebSockets
       - Less responsive but more stable, useful for CI tasks
+      - Deletes the workload when disconnecting by default (can be disabled with `--no-clean` - the workload will still self-delete when finishing)
     DESC
     EXAMPLES = <<~EX
       ```sh
@@ -59,7 +61,7 @@ module Command
       wait_for_workload(one_off)
       show_logs_waiting
     ensure
-      if cp.fetch_workload(one_off)
+      if config.options[:clean] && cp.fetch_workload(one_off)
         progress.puts
         ensure_workload_deleted(one_off)
       end

--- a/spec/cpl_spec.rb
+++ b/spec/cpl_spec.rb
@@ -37,7 +37,9 @@ describe Cpl do
         args = [option_key_name, option_value]
       end
 
-      allow(Config).to receive(:new).with([], { option[:name].to_sym => option_value }, []).and_call_original
+      allow(Config).to receive(:new)
+        .with([], a_hash_including(option[:name].to_sym => option_value), [])
+        .and_call_original
 
       allow_any_instance_of(Config).to receive(:config_file_path).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
       expect_any_instance_of(Command::Test).to receive(:call) # rubocop:disable RSpec/AnyInstance


### PR DESCRIPTION
Fixes #127

Adds a `--clean` option to the `run:detached` command that defaults to `true`:

- when `true`, the workload will be deleted when disconnecting
- when `false`, the workload will not be deleted when disconnecting (for example, when pressing `Ctrl + C`), but it will still self-delete when finishing