### PR TITLE
Add `--domain` option to `maintenance` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _Please add entries here for your pull requests that are not yet released._
 ### Added
 
 - Added `--clean` option to `run:detached` command to delete workload when disconnecting. [PR 129](https://github.com/shakacode/heroku-to-control-plane/pull/129) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Added `--domain` option to `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Added `default_domain` config to specify domain for `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ apps:
     # This is relative to the `.controlplane/` directory.
     release_script: release_script
 
+    # default_domain is used for commands that require a domain
+    # including `maintenance`, `maintenance:on`, `maintenance:off`.
+    default_domain: domain.com
+
   my-app-other:
     <<: *common
 

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -101,6 +101,10 @@ apps:
     # This is relative to the `.controlplane/` directory.
     release_script: release_script
 
+    # default_domain is used for commands that require a domain
+    # including `maintenance`, `maintenance:on`, `maintenance:off`.
+    default_domain: domain.com
+
   my-app-other:
     <<: *common
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -125,6 +125,18 @@ module Command
       }
     end
 
+    def self.domain_option(required: false)
+      {
+        name: :domain,
+        params: {
+          banner: "DOMAIN_NAME",
+          desc: "Domain name",
+          type: :string,
+          required: required
+        }
+      }
+    end
+
     def self.upstream_token_option(required: false)
       {
         name: :upstream_token,

--- a/lib/command/maintenance.rb
+++ b/lib/command/maintenance.rb
@@ -4,7 +4,8 @@ module Command
   class Maintenance < Base
     NAME = "maintenance"
     OPTIONS = [
-      app_option(required: true)
+      app_option(required: true),
+      domain_option
     ].freeze
     DESCRIPTION = "Checks if maintenance mode is on or off for an app"
     LONG_DESCRIPTION = <<~DESC
@@ -20,7 +21,11 @@ module Command
       one_off_workload = config[:one_off_workload]
       maintenance_workload = config.current[:maintenance_workload] || "maintenance"
 
-      domain_data = cp.find_domain_for([one_off_workload, maintenance_workload])
+      domain_data = if config.domain
+                      cp.fetch_domain(config.domain)
+                    else
+                      cp.find_domain_for([one_off_workload, maintenance_workload])
+                    end
       unless domain_data
         raise "Can't find domain. " \
               "Maintenance mode is only supported for domains that use path based routing mode " \

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -4,7 +4,8 @@ module Command
   class MaintenanceOff < Base
     NAME = "maintenance:off"
     OPTIONS = [
-      app_option(required: true)
+      app_option(required: true),
+      domain_option
     ].freeze
     DESCRIPTION = "Disables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
@@ -18,7 +19,11 @@ module Command
       one_off_workload = config[:one_off_workload]
       maintenance_workload = config.current[:maintenance_workload] || "maintenance"
 
-      domain_data = cp.find_domain_for([one_off_workload, maintenance_workload])
+      domain_data = if config.domain
+                      cp.fetch_domain(config.domain)
+                    else
+                      cp.find_domain_for([one_off_workload, maintenance_workload])
+                    end
       unless domain_data
         raise "Can't find domain. " \
               "Maintenance mode is only supported for domains that use path based routing mode " \

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -4,7 +4,8 @@ module Command
   class MaintenanceOn < Base
     NAME = "maintenance:on"
     OPTIONS = [
-      app_option(required: true)
+      app_option(required: true),
+      domain_option
     ].freeze
     DESCRIPTION = "Enables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
@@ -18,7 +19,11 @@ module Command
       one_off_workload = config[:one_off_workload]
       maintenance_workload = config.current[:maintenance_workload] || "maintenance"
 
-      domain_data = cp.find_domain_for([one_off_workload, maintenance_workload])
+      domain_data = if config.domain
+                      cp.fetch_domain(config.domain)
+                    else
+                      cp.find_domain_for([one_off_workload, maintenance_workload])
+                    end
       unless domain_data
         raise "Can't find domain. " \
               "Maintenance mode is only supported for domains that use path based routing mode " \

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -38,6 +38,10 @@ class Config # rubocop:disable Metrics/ClassLength
     @location ||= load_location_from_options || load_location_from_env || load_location_from_file
   end
 
+  def domain
+    @domain ||= load_domain_from_options || load_domain_from_file
+  end
+
   def [](key)
     ensure_current_config!
 
@@ -251,6 +255,16 @@ class Config # rubocop:disable Metrics/ClassLength
     return unless current&.key?(:default_location)
 
     strip_str_and_validate(current.fetch(:default_location))
+  end
+
+  def load_domain_from_options
+    strip_str_and_validate(options[:domain])
+  end
+
+  def load_domain_from_file
+    return unless current&.key?(:default_domain)
+
+    strip_str_and_validate(current.fetch(:default_domain))
   end
 
   def warn_deprecated_options(app_options)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -269,6 +269,14 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def fetch_domain(domain)
+    domain_data = api.fetch_domain(org: org, domain: domain)
+    route = find_domain_route(domain_data)
+    return nil if route.nil?
+
+    domain_data
+  end
+
   def get_domain_workload(data)
     route = find_domain_route(data)
     route["workloadLink"].split("/").last

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -265,7 +265,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
       route = find_domain_route(domain_data)
       next false if route.nil?
 
-      workloads.any? { |workload| route["workloadLink"].split("/").last == workload }
+      workloads.any? { |workload| route["workloadLink"].match?(%r{/org/#{org}/gvc/#{gvc}/workload/#{workload}}) }
     end
   end
 

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -94,6 +94,10 @@ class ControlplaneApi # rubocop:disable Metrics/ClassLength
     api_json("/org/#{org}/gvc/#{gvc}/volumeset/#{volumeset}", method: :delete)
   end
 
+  def fetch_domain(org:, domain:)
+    api_json("/org/#{org}/domain/#{domain}", method: :get)
+  end
+
   def list_domains(org:)
     api_json("/org/#{org}/domain", method: :get)
   end


### PR DESCRIPTION
Fixes #130

Adds a `--domain` option to the `maintenance`, `maintenance:on` and `maintenance:off` commands, that allows providing the domain for cases where it cannot be automatically detected.

The domain can also be provided through `default_domain` in the `.controlplane/controlplane.yml` file.