### PR TITLE
Updates to `run` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Added
 
+- Added `--no-clean-on-failure` option to `run:detached` command to skip deletion of failed workload run. [PR 133](https://github.com/shakacode/heroku-to-control-plane/pull/133) by [Justin Gordon](https://github.com/justin808) and [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Added `--domain` option to `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Added `default_domain` config to specify domain for `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Added option to specify upstream for `copy-image-from-upstream` command through `CPLN_UPSTREAM` env var. [PR 138](https://github.com/shakacode/heroku-to-control-plane/pull/138) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -332,28 +332,25 @@ cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
 cpl run -a $APP_NAME
 
 # Need to quote COMMAND if setting ENV value or passing args.
-cpl run 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
-
-# COMMAND may also be passed at the end.
 cpl run -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
 # Runs command, displays output, and exits shell.
-cpl run ls / -a $APP_NAME
-cpl run rails db:migrate:status -a $APP_NAME
+cpl run -a $APP_NAME -- ls /
+cpl run -a $APP_NAME -- rails db:migrate:status
 
 # Runs command and keeps shell open.
-cpl run rails c -a $APP_NAME
+cpl run -a $APP_NAME -- rails c
 
 # Uses a different image (which may not be promoted yet).
-cpl run rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
-cpl run rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+cpl run -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
+cpl run -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
 
 # Uses a different workload than `one_off_workload` from `.controlplane/controlplane.yml`.
-cpl run bash -a $APP_NAME -w other-workload
+cpl run -a $APP_NAME -w other-workload -- bash
 
 # Overrides remote CPLN_TOKEN env variable with local token.
 # Useful when superuser rights are needed in remote container.
-cpl run bash -a $APP_NAME --use-local-token
+cpl run -a $APP_NAME --use-local-token -- bash
 ```
 
 ### `run:cleanup`
@@ -383,21 +380,18 @@ cpl run:cleanup -a $APP_NAME
 cpl run:detached rails db:prepare -a $APP_NAME
 
 # Need to quote COMMAND if setting ENV value or passing args.
-cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
-
-# COMMAND may also be passed at the end.
 cpl run:detached -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
 # Uses a different image (which may not be promoted yet).
-cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
-cpl run:detached rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+cpl run:detached -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
+cpl run:detached -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
 
 # Uses a different workload than `one_off_workload` from `.controlplane/controlplane.yml`.
-cpl run:detached rails db:migrate:status -a $APP_NAME -w other-workload
+cpl run:detached -a $APP_NAME -w other-workload -- rails db:migrate:status
 
 # Overrides remote CPLN_TOKEN env variable with local token.
 # Useful when superuser rights are needed in remote container.
-cpl run:detached rails db:migrate:status -a $APP_NAME --use-local-token
+cpl run:detached -a $APP_NAME --use-local-token -- rails db:migrate:status
 ```
 
 ### `setup-app`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -375,6 +375,9 @@ cpl run:cleanup -a $APP_NAME
 - Implemented with only async execution methods, more suitable for production tasks
 - Has alternative log fetch implementation with only JSON-polling and no WebSockets
 - Less responsive but more stable, useful for CI tasks
+- Deletes the workload whenever finished with success
+- Deletes the workload whenever finished with failure by default
+- Use `--no-clean-on-failure` to disable cleanup to help with debugging failed runs
 
 ```sh
 cpl run:detached rails db:prepare -a $APP_NAME

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative "../core/helpers"
+
 module Command
   class Base # rubocop:disable Metrics/ClassLength
     attr_reader :config
+
+    include Helpers
 
     # Used to call the command (`cpl NAME`)
     # NAME = ""

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -237,6 +237,18 @@ module Command
       }
     end
 
+    def self.clean_on_failure_option(required: false)
+      {
+        name: :clean_on_failure,
+        params: {
+          desc: "Deletes workload when finished with failure (success always deletes)",
+          type: :boolean,
+          required: required,
+          default: true
+        }
+      }
+    end
+
     def self.all_options
       methods.grep(/_option$/).map { |method| send(method.to_s) }
     end

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -61,7 +61,7 @@ module Command
     def create_upstream_profile
       step("Creating upstream profile") do
         loop do
-          @upstream_profile = "upstream-#{rand(1000..9999)}"
+          @upstream_profile = "upstream-#{random_four_digits}"
           break unless cp.profile_exists?(@upstream_profile)
         end
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -29,28 +29,25 @@ module Command
       cpl run -a $APP_NAME
 
       # Need to quote COMMAND if setting ENV value or passing args.
-      cpl run 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
-
-      # COMMAND may also be passed at the end.
       cpl run -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
       # Runs command, displays output, and exits shell.
-      cpl run ls / -a $APP_NAME
-      cpl run rails db:migrate:status -a $APP_NAME
+      cpl run -a $APP_NAME -- ls /
+      cpl run -a $APP_NAME -- rails db:migrate:status
 
       # Runs command and keeps shell open.
-      cpl run rails c -a $APP_NAME
+      cpl run -a $APP_NAME -- rails c
 
       # Uses a different image (which may not be promoted yet).
-      cpl run rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
-      cpl run rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+      cpl run -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
+      cpl run -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
 
       # Uses a different workload than `one_off_workload` from `.controlplane/controlplane.yml`.
-      cpl run bash -a $APP_NAME -w other-workload
+      cpl run -a $APP_NAME -w other-workload -- bash
 
       # Overrides remote CPLN_TOKEN env variable with local token.
       # Useful when superuser rights are needed in remote container.
-      cpl run bash -a $APP_NAME --use-local-token
+      cpl run -a $APP_NAME --use-local-token -- bash
       ```
     EX
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -54,31 +54,31 @@ module Command
       ```
     EX
 
-    attr_reader :location, :workload, :one_off, :container
+    attr_reader :location, :workload_to_clone, :workload_clone, :container
 
     def call # rubocop:disable Metrics/MethodLength
       @location = config.location
-      @workload = config.options["workload"] || config[:one_off_workload]
-      @one_off = "#{workload}-run-#{rand(1000..9999)}"
+      @workload_to_clone = config.options["workload"] || config[:one_off_workload]
+      @workload_clone = "#{workload_to_clone}-run-#{rand(1000..9999)}"
 
-      step("Cloning workload '#{workload}' on app '#{config.options[:app]}' to '#{one_off}'") do
+      step("Cloning workload '#{workload_to_clone}' on app '#{config.options[:app]}' to '#{workload_clone}'") do
         clone_workload
       end
 
-      wait_for_workload(one_off)
-      wait_for_replica(one_off, location)
+      wait_for_workload(workload_clone)
+      wait_for_replica(workload_clone, location)
       run_in_replica
     ensure
       progress.puts
-      ensure_workload_deleted(one_off)
+      ensure_workload_deleted(workload_clone)
     end
 
     private
 
     def clone_workload # rubocop:disable Metrics/MethodLength
       # Create a base copy of workload props
-      spec = cp.fetch_workload!(workload).fetch("spec")
-      container_spec = spec["containers"].detect { _1["name"] == workload } || spec["containers"].first
+      spec = cp.fetch_workload!(workload_to_clone).fetch("spec")
+      container_spec = spec["containers"].detect { _1["name"] == workload_to_clone } || spec["containers"].first
       @container = container_spec["name"]
 
       # remove other containers if any
@@ -111,7 +111,7 @@ module Command
       end
 
       # Create workload clone
-      cp.apply_hash("kind" => "workload", "name" => one_off, "spec" => spec)
+      cp.apply_hash("kind" => "workload", "name" => workload_clone, "spec" => spec)
     end
 
     def runner_script # rubocop:disable Metrics/MethodLength
@@ -141,7 +141,7 @@ module Command
     def run_in_replica
       progress.puts("Connecting...\n\n")
       command = %(bash -c 'eval "$CONTROLPLANE_RUNNER"')
-      cp.workload_exec(one_off, location: location, container: container, command: command)
+      cp.workload_exec(workload_clone, location: location, container: container, command: command)
     end
   end
 end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -59,7 +59,7 @@ module Command
     def call # rubocop:disable Metrics/MethodLength
       @location = config.location
       @workload_to_clone = config.options["workload"] || config[:one_off_workload]
-      @workload_clone = "#{workload_to_clone}-run-#{rand(1000..9999)}"
+      @workload_clone = "#{workload_to_clone}-run-#{random_four_digits}"
 
       step("Cloning workload '#{workload_to_clone}' on app '#{config.options[:app]}' to '#{workload_clone}'") do
         clone_workload

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -29,21 +29,18 @@ module Command
       cpl run:detached rails db:prepare -a $APP_NAME
 
       # Need to quote COMMAND if setting ENV value or passing args.
-      cpl run:detached 'LOG_LEVEL=warn rails db:migrate' -a $APP_NAME
-
-      # COMMAND may also be passed at the end.
       cpl run:detached -a $APP_NAME -- 'LOG_LEVEL=warn rails db:migrate'
 
       # Uses a different image (which may not be promoted yet).
-      cpl run:detached rails db:migrate -a $APP_NAME --image appimage:123 # Exact image name
-      cpl run:detached rails db:migrate -a $APP_NAME --image latest       # Latest sequential image
+      cpl run:detached -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
+      cpl run:detached -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
 
       # Uses a different workload than `one_off_workload` from `.controlplane/controlplane.yml`.
-      cpl run:detached rails db:migrate:status -a $APP_NAME -w other-workload
+      cpl run:detached -a $APP_NAME -w other-workload -- rails db:migrate:status
 
       # Overrides remote CPLN_TOKEN env variable with local token.
       # Useful when superuser rights are needed in remote container.
-      cpl run:detached rails db:migrate:status -a $APP_NAME --use-local-token
+      cpl run:detached -a $APP_NAME --use-local-token -- rails db:migrate:status
       ```
     EX
 

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -50,7 +50,7 @@ module Command
     def call # rubocop:disable Metrics/MethodLength
       @location = config.location
       @workload_to_clone = config.options["workload"] || config[:one_off_workload]
-      @workload_clone = "#{workload_to_clone}-runner-#{rand(1000..9999)}"
+      @workload_clone = "#{workload_to_clone}-runner-#{random_four_digits}"
 
       step("Cloning workload '#{workload_to_clone}' on app '#{config.options[:app]}' to '#{workload_clone}'") do
         clone_workload

--- a/lib/core/helpers.rb
+++ b/lib/core/helpers.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Helpers
   def strip_str_and_validate(str)
     return str if str.nil?
 
     str = str.strip
     str.empty? ? nil : str
+  end
+
+  def random_four_digits
+    SecureRandom.random_number(1000..9999)
   end
 end

--- a/spec/cpl_spec.rb
+++ b/spec/cpl_spec.rb
@@ -37,7 +37,9 @@ describe Cpl do
         args = [option_key_name, option_value]
       end
 
-      allow(Config).to receive(:new).with([], { option[:name].to_sym => option_value }, []).and_call_original
+      allow(Config).to receive(:new)
+        .with([], hash_including(option[:name].to_sym => option_value), [])
+        .and_call_original
 
       allow_any_instance_of(Config).to receive(:config_file_path).and_return("spec/fixtures/config.yml") # rubocop:disable RSpec/AnyInstance
       expect_any_instance_of(Command::Test).to receive(:call) # rubocop:disable RSpec/AnyInstance


### PR DESCRIPTION
Success deletes workload:

![success](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/0b09a296-6986-4837-aec8-98e66334cf34)

Failure w/ `--clean-on-failure` (default) deletes workload:

![failure_clean](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/abb2915f-7a3b-4e3c-a672-f424f2500479)

Failure w/ `--no-clean-on-failure` does not delete workload:

![failure_no_clean](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/fcc6a177-f67c-4b71-8f58-54a5f509bdac)

Exiting with `Ctrl + C` after schedule does not delete workload:

![exit](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/63d330ef-521b-4c2e-90d3-baf50ed26103)