### PR TITLE
Fix issue that doesn't switch profile back to `default` if an error happens while running `copy-image-from-upstream` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed issue where cpln profile was not switched back to `default` if an error happened while running `copy-image-from-upstream` command. [PR 135](https://github.com/shakacode/heroku-to-control-plane/pull/135) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Added
 
 - Added `--domain` option to `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -38,6 +38,7 @@ module Command
       pull_image_from_upstream
       push_image_to_app
     ensure
+      cp.profile_switch("default")
       delete_upstream_profile
     end
 


### PR DESCRIPTION
In the `copy-image-from-upstream` command, since we temporarily switch profiles to be able to fetch the image from the upstream, if an error happens, the profile won't be switched back to the `default` one, which will lead to an error when trying to run `cpln` commands after that.

This PR fixes that.