### PR TITLE
Change precedence for `CPLN_ORG_UPSTREAM` env var in `copy-image-from-upstream` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed issue where cpln profile was not switched back to `default` if an error happened while running `copy-image-from-upstream` command. [PR 135](https://github.com/shakacode/heroku-to-control-plane/pull/135) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Added
 
 - Added `--domain` option to `maintenance`, `maintenance:on` and `maintenance:off` commands. [PR 131](https://github.com/shakacode/heroku-to-control-plane/pull/131) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Fixed
 
 - Fixed issue where cpln profile was not switched back to `default` if an error happened while running `copy-image-from-upstream` command. [PR 135](https://github.com/shakacode/heroku-to-control-plane/pull/135) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Fixed issue that didn't allow using upstream with `match_if_app_name_starts_with` set to `true` in `copy-image-from-upstream` command. [PR 136](https://github.com/shakacode/heroku-to-control-plane/pull/136) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Changed
 
 - `build-image` command now accepts extra options and passes them to `docker build`. [PR 126](https://github.com/shakacode/heroku-to-control-plane/pull/126) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `CPLN_ORG_UPSTREAM` env var now takes precedence over config from `controlplane.yml` in `copy-image-from-upstream` command. [PR 137](https://github.com/shakacode/heroku-to-control-plane/pull/137) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.2.0] - 2024-01-03
 

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -38,6 +38,7 @@ module Command
       pull_image_from_upstream
       push_image_to_app
     ensure
+      cp.profile_switch("default")
       delete_upstream_profile
     end
 

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -29,7 +29,7 @@ module Command
       ensure_docker_running!
 
       @upstream = config[:upstream]
-      @upstream_org = config.apps[@upstream.to_sym][:cpln_org] || ENV.fetch("CPLN_ORG_UPSTREAM", nil)
+      @upstream_org = config.find_app_config(@upstream)&.dig(:cpln_org) || ENV.fetch("CPLN_ORG_UPSTREAM", nil)
       ensure_upstream_org!
 
       create_upstream_profile

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -29,7 +29,7 @@ module Command
       ensure_docker_running!
 
       @upstream = config[:upstream]
-      @upstream_org = config.find_app_config(@upstream)&.dig(:cpln_org) || ENV.fetch("CPLN_ORG_UPSTREAM", nil)
+      @upstream_org = ENV.fetch("CPLN_ORG_UPSTREAM", nil) || config.find_app_config(@upstream)&.dig(:cpln_org)
       ensure_upstream_org!
 
       create_upstream_profile

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -102,6 +102,13 @@ class Config # rubocop:disable Metrics/ClassLength
     end
   end
 
+  def find_app_config(app_name1)
+    @app_configs ||= {}
+    @app_configs[app_name1] ||= apps.find do |app_name2, app_config|
+                                  app_matches?(app_name1, app_name2, app_config)
+                                end&.last
+  end
+
   private
 
   def ensure_current_config!
@@ -125,13 +132,6 @@ class Config # rubocop:disable Metrics/ClassLength
       (app_name1.to_s == app_name2.to_s ||
         (app_options[:match_if_app_name_starts_with] && app_name1.to_s.start_with?(app_name2.to_s))
       )
-  end
-
-  def find_app_config(app_name1)
-    @app_configs ||= {}
-    @app_configs[app_name1] ||= apps.find do |app_name2, app_config|
-                                  app_matches?(app_name1, app_name2, app_config)
-                                end&.last
   end
 
   def ensure_app!

--- a/spec/command/copy_image_from_upstream_spec.rb
+++ b/spec/command/copy_image_from_upstream_spec.rb
@@ -8,6 +8,7 @@ describe Command::CopyImageFromUpstream do
     allow(ENV).to receive(:fetch).with("CPLN_ENDPOINT", "https://api.cpln.io").and_return("https://api.cpln.io")
     allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token")
     allow(ENV).to receive(:fetch).with("CPLN_ORG", nil).and_return(nil)
+    allow(ENV).to receive(:fetch).with("CPLN_ORG_UPSTREAM", nil).and_return(nil)
     allow(ENV).to receive(:fetch).with("CPLN_APP", nil).and_return(nil)
     allow_any_instance_of(Config).to receive(:config_file_path).and_return("spec/fixtures/config.yml")
     allow_any_instance_of(described_class).to receive(:ensure_docker_running!)


### PR DESCRIPTION
**NOTE:** On top of #136 

Environment variables should take precedence over the `controlplane.yml` file. This is currently not true for the `CPLN_ORG_UPSTREAM` env var in the `copy-image-from-upstream` command.

This PR changes that.