### PR TITLE
Improve domain workload matching for `maintenance` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _Please add entries here for your pull requests that are not yet released._
 - `CPLN_ORG_UPSTREAM` env var now takes precedence over config from `controlplane.yml` in `copy-image-from-upstream` command. [PR 137](https://github.com/shakacode/heroku-to-control-plane/pull/137) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `info` command now works properly for apps with `match_if_app_name_starts_with` set to `true`.[PR 139](https://github.com/shakacode/heroku-to-control-plane/pull/139) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `info` command now lists workloads in the same order as `controlplane.yml`. [PR 139](https://github.com/shakacode/heroku-to-control-plane/pull/139) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Improved domain workload matching for `maintenance`, `maintenance:on` and `maintenance:off` commands (instead of matching only by workload, it now matches by org + app + workload, which is more accurate). [PR 140](https://github.com/shakacode/heroku-to-control-plane/pull/140) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.2.0] - 2024-01-03
 

--- a/lib/command/maintenance.rb
+++ b/lib/command/maintenance.rb
@@ -32,8 +32,7 @@ module Command
               "and have a route configured for the prefix '/' on either port 80 or 443."
       end
 
-      domain_workload = cp.get_domain_workload(domain_data)
-      if domain_workload == maintenance_workload
+      if cp.domain_workload_matches?(domain_data, maintenance_workload)
         puts "on"
       else
         puts "off"

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -31,8 +31,7 @@ module Command
       end
 
       domain = domain_data["name"]
-      domain_workload = cp.get_domain_workload(domain_data)
-      if domain_workload == one_off_workload
+      if cp.domain_workload_matches?(domain_data, one_off_workload)
         progress.puts("Maintenance mode is already disabled for app '#{config.app}'.")
         return
       end

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -31,8 +31,7 @@ module Command
       end
 
       domain = domain_data["name"]
-      domain_workload = cp.get_domain_workload(domain_data)
-      if domain_workload == maintenance_workload
+      if cp.domain_workload_matches?(domain_data, maintenance_workload)
         progress.puts("Maintenance mode is already enabled for app '#{config.app}'.")
         return
       end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -277,9 +277,9 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     domain_data
   end
 
-  def get_domain_workload(data)
+  def domain_workload_matches?(data, workload)
     route = find_domain_route(data)
-    route["workloadLink"].split("/").last
+    route["workloadLink"].match?(%r{/org/#{org}/gvc/#{gvc}/workload/#{workload}})
   end
 
   def set_domain_workload(data, workload)


### PR DESCRIPTION
Improves the domain workload matching for the `maintenance`, `maintenance:on` and `maintenance:off` commands to  match by org + app + workload (which is more accurate) instead of only by workload.