### PR TITLE
Various improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Renamed template substitution variable `APP_GVC` to `{{APP_NAME}}` (used by `apply-template` and `setup-app` commands). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `setup-app` command now automatically binds the app to the secrets policy, as long as both the identity and the policy exist. Added `--skip-secret-access-binding` option to prevent this behavior. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Local API token is now refreshed when it is about to expire. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `apply-template` command now exits with non-zero code if failed to apply any templates. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.3.0] - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Added
 
-- Added new template substitution variables (used by `apply-template` and `setup-app` commands): `{{APP_LOCATION_LINK}}`, `{{APP_IMAGE_LINK}}`, `{{APP_IDENTITY}}` and `{{APP_IDENTITY_LINK}}`. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Added new template substitution variables (used by `apply-template` and `setup-app` commands): `{{APP_LOCATION_LINK}}`, `{{APP_IMAGE_LINK}}`, `{{APP_IDENTITY}}`, `{{APP_IDENTITY_LINK}}`, `{{APP_SECRETS}}` and `{{APP_SECRETS_POLICY}}`. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Changed
 
 - Template substitution (used by `apply-template` and `setup-app` commands) now uses double braces (e.g., `APP_ORG` -> `{{APP_ORG}}`). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Renamed template substitution variable `APP_GVC` to `{{APP_NAME}}` (used by `apply-template` and `setup-app` commands). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `setup-app` command now automatically binds the app to the secrets policy, as long as both the identity and the policy exist. Added `--skip-secret-access-binding` option to prevent this behavior. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.3.0] - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### Added
 
 - Added new template substitution variables (used by `apply-template` and `setup-app` commands): `{{APP_LOCATION_LINK}}`, `{{APP_IMAGE_LINK}}`, `{{APP_IDENTITY}}`, `{{APP_IDENTITY_LINK}}`, `{{APP_SECRETS}}` and `{{APP_SECRETS_POLICY}}`. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Added `--run-release-phase` option to `deploy-image` command to run release script before deploying (same step as in `promote-app-from-upstream` command). [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Please add entries here for your pull requests that are not yet released._
 - Template substitution (used by `apply-template` and `setup-app` commands) now uses double braces (e.g., `APP_ORG` -> `{{APP_ORG}}`). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Renamed template substitution variable `APP_GVC` to `{{APP_NAME}}` (used by `apply-template` and `setup-app` commands). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `setup-app` command now automatically binds the app to the secrets policy, as long as both the identity and the policy exist. Added `--skip-secret-access-binding` option to prevent this behavior. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Local API token is now refreshed when it is about to expire. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.3.0] - 2024-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Added
+
+- Added new template substitution variables (used by `apply-template` and `setup-app` commands): `{{APP_LOCATION_LINK}}`, `{{APP_IMAGE_LINK}}`, `{{APP_IDENTITY}}` and `{{APP_IDENTITY_LINK}}`. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
+### Changed
+
+- Template substitution (used by `apply-template` and `setup-app` commands) now uses double braces (e.g., `APP_ORG` -> `{{APP_ORG}}`). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Renamed template substitution variable `APP_GVC` to `{{APP_NAME}}` (used by `apply-template` and `setup-app` commands). This change is backwards compatible. [PR 146](https://github.com/shakacode/heroku-to-control-plane/pull/146) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.3.0] - 2024-03-19
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     cpl (1.3.0)
       debug (~> 1.7.1)
       dotenv (~> 2.8.1)
+      jwt (~> 2.8.1)
       psych (~> 5.1.0)
       thor (~> 1.2.1)
 
@@ -13,6 +14,7 @@ GEM
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    base64 (0.2.0)
     childprocess (4.1.0)
     crack (0.4.5)
       rexml
@@ -29,6 +31,8 @@ GEM
       rdoc
       reline (>= 0.4.2)
     json (2.6.3)
+    jwt (2.8.1)
+      base64
     overcommit (0.60.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ aliases:
 
     # Allows running the command `cpl setup-app`
     # instead of `cpl apply-template gvc redis postgres memcached rails sidekiq`.
+    #
+    # Note:
+    # 1. These names correspond to files in the `./controlplane/templates` directory.
+    # 2. Each file can contain many objects, such as in the case of templates that create a resource, like `postgres`.
+    # 3. While the naming often corresponds to a workload or other object name, the naming is arbitrary. 
+    #    Naming does not need to match anything other than the file name without the `.yml` extension.
     setup_app_templates:
       - gvc
 
@@ -210,6 +216,8 @@ aliases:
     # Workloads that are for the application itself and are using application Docker images.
     # These are updated with the new image when running the `deploy-image` command,
     # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
+    # On the other hand, if you have a workload for Redis, that would NOT use the application Docker image
+    # and not be listed here.
     app_workloads:
       - rails
       - sidekiq

--- a/README.md
+++ b/README.md
@@ -202,11 +202,14 @@ aliases:
     one_off_workload: rails
 
     # Workloads that are for the application itself and are using application Docker images.
+    # These are updated with the new image when running the `deploy-image` command,
+    # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
     app_workloads:
       - rails
       - sidekiq
 
     # Additional "service type" workloads, using non-application Docker images.
+    # These are only used by the `info`, `ps:` and `run:cleanup` commands in order to get all of the defined workloads.
     additional_workloads:
       - redis
       - postgres

--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ aliases:
     # instead of `cpl apply-template gvc redis postgres memcached rails sidekiq`.
     setup_app_templates:
       - gvc
+
+      # These templates are only required if using secrets.
+      - identity
+      - secrets
+      - secrets-policy
+
       - redis
       - postgres
       - memcached

--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "debug",    "~> 1.7.1"
   spec.add_dependency "dotenv",   "~> 2.8.1"
+  spec.add_dependency "jwt",      "~> 2.8.1"
   spec.add_dependency "psych",    "~> 5.1.0"
   spec.add_dependency "thor",     "~> 1.2.1"
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,12 +23,12 @@ This `-a` option is used in most of the commands and will pick all other app con
 ```
 {{APP_ORG}}           - organization name
 {{APP_NAME}}          - GVC/app name
-{{APP_LOCATION}}      - default location
-{{APP_LOCATION_LINK}} - full link for default location, ready to be used in `staticPlacement.locationLinks`
+{{APP_LOCATION}}      - location, per YML file, ENV, or command line arg
+{{APP_LOCATION_LINK}} - full link for location, ready to be used for the value of `staticPlacement.locationLinks` in the templates
 {{APP_IMAGE}}         - latest app image
-{{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used in `containers[].image`
+{{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used for the value of `containers[].image` in the templates
 {{APP_IDENTITY}}      - default identity
-{{APP_IDENTITY_LINK}} - full link for default identity, ready to be used in `identityLink`
+{{APP_IDENTITY_LINK}} - full link for identity, ready to be used for the value of `identityLink` in the templates
 ```
 
 ```sh
@@ -116,7 +116,7 @@ cpl delete -a $APP_NAME
 
 - Deploys the latest image to app workloads
 - Optionally runs a release script before deploying if specified through `release_script` in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
-- The deploy will fail if the release script exits with a non-zero code
+- The deploy will fail if the release script exits with a non-zero code or doesn't exist
 
 ```sh
 cpl deploy-image -a $APP_NAME
@@ -258,7 +258,7 @@ cpl open-console -a $APP_NAME
 - It performs the following steps:
   - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
   - Runs `cpl deploy-image` to deploy the image
-  - If `release_script` is specified in the `.controlplane/controlplane.yml` file, passes `--run-release-phase` to `cpl deploy-image`
+  - If `.controlplane/controlplane.yml` includes the `release_script`, `cpl deploy-image` will use the `--run-release-phase` option
   - The deploy will fail if the release script exits with a non-zero code
 
 ```sh

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -403,6 +403,8 @@ cpl run:detached -a $APP_NAME --use-local-token -- rails db:migrate:status
 - Creates an app and all its workloads
 - Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
 - This should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+- Automatically binds the app to the secrets policy, as long as both the identity and the policy exist
+- Use `--skip-secret-access-binding` to prevent the automatic bind
 
 ```sh
 cpl setup-app -a $APP_NAME

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,10 +21,14 @@ This `-a` option is used in most of the commands and will pick all other app con
 **Preprocessed template variables:**
 
 ```
-APP_GVC      - basically GVC or app name
-APP_LOCATION - default location
-APP_ORG      - organization
-APP_IMAGE    - will use latest app image
+{{APP_ORG}}           - organization name
+{{APP_NAME}}          - GVC/app name
+{{APP_LOCATION}}      - default location
+{{APP_LOCATION_LINK}} - full link for default location, ready to be used in `staticPlacement.locationLinks`
+{{APP_IMAGE}}         - latest app image
+{{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used in `containers[].image`
+{{APP_IDENTITY}}      - default identity
+{{APP_IDENTITY_LINK}} - full link for default identity, ready to be used in `identityLink`
 ```
 
 ```sh

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,6 +115,8 @@ cpl delete -a $APP_NAME
 ### `deploy-image`
 
 - Deploys the latest image to app workloads
+- Optionally runs a release script before deploying if specified through `release_script` in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
+- The deploy will fail if the release script exits with a non-zero code
 
 ```sh
 cpl deploy-image -a $APP_NAME
@@ -255,8 +257,9 @@ cpl open-console -a $APP_NAME
 - Copies the latest image from upstream, runs a release script (optional), and deploys the image
 - It performs the following steps:
   - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
-  - Runs a release script if specified through `release_script` in the `.controlplane/controlplane.yml` file
   - Runs `cpl deploy-image` to deploy the image
+  - If `release_script` is specified in the `.controlplane/controlplane.yml` file, passes `--run-release-phase` to `cpl deploy-image`
+  - The deploy will fail if the release script exits with a non-zero code
 
 ```sh
 cpl promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -85,7 +85,17 @@ For storing ENVs in the source code, we can use a level of indirection so that y
 code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then have the secret value stored at the org
 level, which applies to your GVCs mapped to that org.
 
-Here is how you do this:
+You can do this during the initial app setup, like this:
+
+1. Add the templates for `identity`, `secrets` and `secrets-policy` to `.controlplane/templates`
+2. Ensure that the templates are listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
+3. Run `cpl setup-app -a $APP_NAME`
+4. The identity, secrets and secrets policy will be automatically created, along with the proper binding
+5. In the upper left "Manage Org" menu, click on "Secrets"
+6. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there
+7. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/$APP_PREFIX-secrets.SOME_VAR`)
+
+You can also do it manually after. Here is how you do this:
 
 1. In the upper left "Manage Org" menu, click on "Secrets"
 2. Create a secret with `Secret Type: Dictionary` (e.g., `my-secrets`) and add the secret env vars there

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -37,11 +37,14 @@ aliases:
     one_off_workload: rails
 
     # Workloads that are for the application itself and are using application Docker images.
+    # These are updated with the new image when running the `deploy-image` command,
+    # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
     app_workloads:
       - rails
       - sidekiq
 
     # Additional "service type" workloads, using non-application Docker images.
+    # These are only used by the `info`, `ps:` and `run:cleanup` commands in order to get all of the defined workloads.
     additional_workloads:
       - redis
       - postgres

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -25,6 +25,12 @@ aliases:
 
     # Allows running the command `cpl setup-app`
     # instead of `cpl apply-template gvc redis postgres memcached rails sidekiq`.
+    #
+    # Note:
+    # 1. These names correspond to files in the `./controlplane/templates` directory.
+    # 2. Each file can contain many objects, such as in the case of templates that create a resource, like `postgres`.
+    # 3. While the naming often corresponds to a workload or other object name, the naming is arbitrary. 
+    #    Naming does not need to match anything other than the file name without the `.yml` extension.
     setup_app_templates:
       - gvc
 
@@ -45,6 +51,8 @@ aliases:
     # Workloads that are for the application itself and are using application Docker images.
     # These are updated with the new image when running the `deploy-image` command,
     # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
+    # On the other hand, if you have a workload for Redis, that would NOT use the application Docker image
+    # and not be listed here.
     app_workloads:
       - rails
       - sidekiq

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -25,8 +25,14 @@ aliases:
 
     # Allows running the command `cpl setup-app`
     # instead of `cpl apply-template gvc redis postgres memcached rails sidekiq`.
-    setup:
+    setup_app_templates:
       - gvc
+
+      # These templates are only required if using secrets.
+      - identity
+      - secrets
+      - secrets-policy
+
       - redis
       - postgres
       - memcached

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -40,7 +40,7 @@ module Command
       ```
     EX
 
-    def call # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
+    def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       ensure_templates!
 
       @created_items = []
@@ -77,6 +77,8 @@ module Command
       print_created_items
       print_failed_templates
       print_skipped_templates
+
+      exit(1) if @failed_templates.any?
     end
 
     private

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -20,10 +20,14 @@ module Command
       **Preprocessed template variables:**
 
       ```
-      APP_GVC      - basically GVC or app name
-      APP_LOCATION - default location
-      APP_ORG      - organization
-      APP_IMAGE    - will use latest app image
+      {{APP_ORG}}           - organization name
+      {{APP_NAME}}          - GVC/app name
+      {{APP_LOCATION}}      - default location
+      {{APP_LOCATION_LINK}} - full link for default location, ready to be used in `staticPlacement.locationLinks`
+      {{APP_IMAGE}}         - latest app image
+      {{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used in `containers[].image`
+      {{APP_IDENTITY}}      - default identity
+      {{APP_IDENTITY_LINK}} - full link for default identity, ready to be used in `identityLink`
       ```
     DESC
     EXAMPLES = <<~EX
@@ -124,11 +128,20 @@ module Command
       false
     end
 
-    def apply_template(filename)
+    def apply_template(filename) # rubocop:disable Metrics/MethodLength
       data = File.read(filename)
+                 .gsub("{{APP_ORG}}", config.org)
+                 .gsub("{{APP_NAME}}", config.app)
+                 .gsub("{{APP_LOCATION}}", config.location)
+                 .gsub("{{APP_LOCATION_LINK}}", app_location_link)
+                 .gsub("{{APP_IMAGE}}", latest_image)
+                 .gsub("{{APP_IMAGE_LINK}}", app_image_link)
+                 .gsub("{{APP_IDENTITY}}", app_identity)
+                 .gsub("{{APP_IDENTITY_LINK}}", app_identity_link)
+                 # Kept for backwards compatibility
+                 .gsub("APP_ORG", config.org)
                  .gsub("APP_GVC", config.app)
                  .gsub("APP_LOCATION", config.location)
-                 .gsub("APP_ORG", config.org)
                  .gsub("APP_IMAGE", latest_image)
 
       # Don't read in YAML.safe_load as that doesn't handle multiple documents

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -138,6 +138,8 @@ module Command
                  .gsub("{{APP_IMAGE_LINK}}", app_image_link)
                  .gsub("{{APP_IDENTITY}}", app_identity)
                  .gsub("{{APP_IDENTITY_LINK}}", app_identity_link)
+                 .gsub("{{APP_SECRETS}}", app_secrets)
+                 .gsub("{{APP_SECRETS_POLICY}}", app_secrets_policy)
                  # Kept for backwards compatibility
                  .gsub("APP_ORG", config.org)
                  .gsub("APP_GVC", config.app)

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -22,12 +22,12 @@ module Command
       ```
       {{APP_ORG}}           - organization name
       {{APP_NAME}}          - GVC/app name
-      {{APP_LOCATION}}      - default location
-      {{APP_LOCATION_LINK}} - full link for default location, ready to be used in `staticPlacement.locationLinks`
+      {{APP_LOCATION}}      - location, per YML file, ENV, or command line arg
+      {{APP_LOCATION_LINK}} - full link for location, ready to be used for the value of `staticPlacement.locationLinks` in the templates
       {{APP_IMAGE}}         - latest app image
-      {{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used in `containers[].image`
+      {{APP_IMAGE_LINK}}    - full link for latest app image, ready to be used for the value of `containers[].image` in the templates
       {{APP_IDENTITY}}      - default identity
-      {{APP_IDENTITY_LINK}} - full link for default identity, ready to be used in `identityLink`
+      {{APP_IDENTITY_LINK}} - full link for identity, ready to be used for the value of `identityLink` in the templates
       ```
     DESC
     EXAMPLES = <<~EX

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -249,6 +249,17 @@ module Command
       }
     end
 
+    def self.skip_secret_access_binding_option(required: false)
+      {
+        name: :skip_secret_access_binding,
+        params: {
+          desc: "Skips secret access binding",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
+
     def self.all_options
       methods.grep(/_option$/).map { |method| send(method.to_s) }
     end
@@ -390,6 +401,14 @@ module Command
 
     def app_identity_link
       "/org/#{config.org}/gvc/#{config.app}/identity/#{app_identity}"
+    end
+
+    def app_secrets
+      "#{config.app_prefix}-secrets"
+    end
+
+    def app_secrets_policy
+      "#{app_secrets}-policy"
     end
 
     private

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -395,7 +395,7 @@ module Command
     end
 
     def perform!(cmd)
-      system(cmd) || exit(false)
+      system(cmd) || exit(1)
     end
 
     def app_location_link

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -260,6 +260,17 @@ module Command
       }
     end
 
+    def self.run_release_phase_option(required: false)
+      {
+        name: :run_release_phase,
+        params: {
+          desc: "Runs release phase",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
+
     def self.all_options
       methods.grep(/_option$/).map { |method| send(method.to_s) }
     end
@@ -383,7 +394,7 @@ module Command
       @cp ||= Controlplane.new(config)
     end
 
-    def perform(cmd)
+    def perform!(cmd)
       system(cmd) || exit(false)
     end
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -376,6 +376,22 @@ module Command
       system(cmd) || exit(false)
     end
 
+    def app_location_link
+      "/org/#{config.org}/location/#{config.location}"
+    end
+
+    def app_image_link
+      "/org/#{config.org}/image/#{latest_image}"
+    end
+
+    def app_identity
+      "#{config.app}-identity"
+    end
+
+    def app_identity_link
+      "/org/#{config.org}/gvc/#{config.app}/identity/#{app_identity}"
+    end
+
     private
 
     # returns 0 if no prior image

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "date"
-
 module Command
   class CleanupStaleApps < Base
     NAME = "cleanup-stale-apps"

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -4,14 +4,19 @@ module Command
   class DeployImage < Base
     NAME = "deploy-image"
     OPTIONS = [
-      app_option(required: true)
+      app_option(required: true),
+      run_release_phase_option
     ].freeze
-    DESCRIPTION = "Deploys the latest image to app workloads"
+    DESCRIPTION = "Deploys the latest image to app workloads, and runs a release script (optional)"
     LONG_DESCRIPTION = <<~DESC
       - Deploys the latest image to app workloads
+      - Optionally runs a release script before deploying if specified through `release_script` in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
+      - The deploy will fail if the release script exits with a non-zero code
     DESC
 
     def call # rubocop:disable Metrics/MethodLength
+      run_release_script if config.options[:run_release_phase]
+
       deployed_endpoints = {}
 
       image = latest_image
@@ -33,6 +38,19 @@ module Command
       deployed_endpoints.each do |workload, endpoint|
         progress.puts("  - #{workload}: #{endpoint}")
       end
+    end
+
+    private
+
+    def run_release_script
+      release_script_name = config[:release_script]
+      release_script_path = Pathname.new("#{config.app_cpln_dir}/#{release_script_name}").expand_path
+
+      raise "Can't find release script in '#{release_script_path}'." unless File.exist?(release_script_path)
+
+      progress.puts("Running release script...\n\n")
+      perform!("bash #{release_script_path}")
+      progress.puts
     end
   end
 end

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -11,7 +11,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Deploys the latest image to app workloads
       - Optionally runs a release script before deploying if specified through `release_script` in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
-      - The deploy will fail if the release script exits with a non-zero code
+      - The deploy will fail if the release script exits with a non-zero code or doesn't exist
     DESC
 
     def call # rubocop:disable Metrics/MethodLength

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -12,47 +12,27 @@ module Command
       - Copies the latest image from upstream, runs a release script (optional), and deploys the image
       - It performs the following steps:
         - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
-        - Runs a release script if specified through `release_script` in the `.controlplane/controlplane.yml` file
         - Runs `cpl deploy-image` to deploy the image
+        - If `release_script` is specified in the `.controlplane/controlplane.yml` file, passes `--run-release-phase` to `cpl deploy-image`
+        - The deploy will fail if the release script exits with a non-zero code
     DESC
 
     def call
-      check_release_script
       copy_image_from_upstream
-      run_release_script
       deploy_image
     end
 
     private
-
-    def check_release_script
-      release_script_name = config.current[:release_script]
-      unless release_script_name
-        progress.puts("Can't find option 'release_script' for app '#{config.app}' in 'controlplane.yml'. " \
-                      "Skipping release script.\n\n")
-        return
-      end
-
-      @release_script_path = Pathname.new("#{config.app_cpln_dir}/#{release_script_name}").expand_path
-
-      raise "Can't find release script in '#{@release_script_path}'." unless File.exist?(@release_script_path)
-    end
 
     def copy_image_from_upstream
       Cpl::Cli.start(["copy-image-from-upstream", "-a", config.app, "-t", config.options[:upstream_token]])
       progress.puts
     end
 
-    def run_release_script
-      return unless @release_script_path
-
-      progress.puts("Running release script...\n\n")
-      perform("bash #{@release_script_path}")
-      progress.puts
-    end
-
     def deploy_image
-      Cpl::Cli.start(["deploy-image", "-a", config.app])
+      args = []
+      args.push("--run-release-phase") if config.current[:release_script]
+      Cpl::Cli.start(["deploy-image", "-a", config.app, *args])
     end
   end
 end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -13,7 +13,7 @@ module Command
       - It performs the following steps:
         - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
         - Runs `cpl deploy-image` to deploy the image
-        - If `release_script` is specified in the `.controlplane/controlplane.yml` file, passes `--run-release-phase` to `cpl deploy-image`
+        - If `.controlplane/controlplane.yml` includes the `release_script`, `cpl deploy-image` will use the `--run-release-phase` option
         - The deploy will fail if the release script exits with a non-zero code
     DESC
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -104,7 +104,8 @@ module Command
       container_spec["env"] << { "name" => "CONTROLPLANE_RUNNER", "value" => runner_script }
 
       if config.options["use_local_token"]
-        container_spec["env"] << { "name" => "CONTROLPLANE_TOKEN", "value" => ControlplaneApiDirect.new.api_token }
+        container_spec["env"] << { "name" => "CONTROLPLANE_TOKEN",
+                                   "value" => ControlplaneApiDirect.new.api_token[:token] }
       end
 
       # Create workload clone

--- a/lib/command/run_detached.rb
+++ b/lib/command/run_detached.rb
@@ -98,7 +98,8 @@ module Command
       container_spec.delete("ports")
 
       container_spec["env"] ||= []
-      container_spec["env"] << { "name" => "CONTROLPLANE_TOKEN", "value" => ControlplaneApiDirect.new.api_token }
+      container_spec["env"] << { "name" => "CONTROLPLANE_TOKEN",
+                                 "value" => ControlplaneApiDirect.new.api_token[:token] }
       container_spec["env"] << { "name" => "CONTROLPLANE_RUNNER", "value" => runner_script }
 
       # Create workload clone

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -4,16 +4,19 @@ module Command
   class SetupApp < Base
     NAME = "setup-app"
     OPTIONS = [
-      app_option(required: true)
+      app_option(required: true),
+      skip_secret_access_binding_option
     ].freeze
     DESCRIPTION = "Creates an app and all its workloads"
     LONG_DESCRIPTION = <<~DESC
       - Creates an app and all its workloads
       - Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
       - This should only be used for temporary apps like review apps, never for persistent apps like production (to update workloads for those, use 'cpl apply-template' instead)
+      - Automatically binds the app to the secrets policy, as long as both the identity and the policy exist
+      - Use `--skip-secret-access-binding` to prevent the automatic bind
     DESC
 
-    def call
+    def call # rubocop:disable Metrics/MethodLength
       templates = config[:setup_app_templates]
 
       app = cp.fetch_gvc
@@ -24,6 +27,15 @@ module Command
       end
 
       Cpl::Cli.start(["apply-template", *templates, "-a", config.app])
+
+      return if config.options[:skip_secret_access_binding] ||
+                cp.fetch_identity(app_identity).nil? ||
+                cp.fetch_policy(app_secrets_policy).nil?
+
+      progress.puts
+      step("Binding identity to policy") do
+        cp.bind_identity_to_policy(app_identity_link, app_secrets_policy)
+      end
     end
   end
 end

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -28,11 +28,16 @@ module Command
 
       Cpl::Cli.start(["apply-template", *templates, "-a", config.app])
 
-      return if config.options[:skip_secret_access_binding] ||
-                cp.fetch_identity(app_identity).nil? ||
-                cp.fetch_policy(app_secrets_policy).nil?
+      return if config.options[:skip_secret_access_binding]
 
       progress.puts
+
+      if cp.fetch_identity(app_identity).nil? || cp.fetch_policy(app_secrets_policy).nil?
+        raise "Can't bind identity to policy: identity '#{app_identity}' or " \
+              "policy '#{app_secrets_policy}' doesn't exist. " \
+              "Please create them or use `--skip-secret-access-binding` to ignore this message."
+      end
+
       step("Binding identity to policy") do
         cp.bind_identity_to_policy(app_identity_link, app_secrets_policy)
       end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -34,6 +34,10 @@ class Config # rubocop:disable Metrics/ClassLength
     @app ||= load_app_from_options || load_app_from_env
   end
 
+  def app_prefix
+    current&.fetch(:name)
+  end
+
   def location
     @location ||= load_location_from_options || load_location_from_env || load_location_from_file
   end
@@ -111,8 +115,12 @@ class Config # rubocop:disable Metrics/ClassLength
 
   def find_app_config(app_name1)
     @app_configs ||= {}
-    @app_configs[app_name1] ||= apps.find do |app_name2, app_config|
-                                  app_matches?(app_name1, app_name2, app_config)
+
+    @app_configs[app_name1] ||= apps.filter_map do |app_name2, app_config|
+                                  next unless app_matches?(app_name1, app_name2, app_config)
+
+                                  app_config[:name] = app_name2
+                                  app_config
                                 end&.last
   end
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -300,6 +300,24 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.log_get(org: org, gvc: gvc, workload: workload, from: from, to: to)
   end
 
+  # identities
+
+  def fetch_identity(identity, a_gvc = gvc)
+    api.fetch_identity(org: org, gvc: a_gvc, identity: identity)
+  end
+
+  # policies
+
+  def fetch_policy(policy)
+    api.fetch_policy(org: org, policy: policy)
+  end
+
+  def bind_identity_to_policy(identity_link, policy)
+    cmd = "cpln policy add-binding #{policy} --org #{org} --identity #{identity_link} --permission reveal"
+    cmd += "> /dev/null 2>&1"
+    perform!(cmd)
+  end
+
   # apply
   def apply_template(data) # rubocop:disable Metrics/MethodLength
     Tempfile.create do |f|

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -314,7 +314,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   def bind_identity_to_policy(identity_link, policy)
     cmd = "cpln policy add-binding #{policy} --org #{org} --identity #{identity_link} --permission reveal"
-    cmd += "> /dev/null 2>&1"
+    cmd += " > /dev/null" if Shell.should_hide_output?
     perform!(cmd)
   end
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -335,7 +335,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
         Shell.debug("CMD", cmd)
 
         result = `#{cmd}`
-        $CHILD_STATUS.success? ? parse_apply_result(result) : exit(false)
+        $CHILD_STATUS.success? ? parse_apply_result(result) : exit(1)
       end
     end
   end
@@ -388,14 +388,14 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   def perform!(cmd, sensitive_data_pattern: nil)
     Shell.debug("CMD", cmd, sensitive_data_pattern: sensitive_data_pattern)
 
-    system(cmd) || exit(false)
+    system(cmd) || exit(1)
   end
 
   def perform_yaml(cmd)
     Shell.debug("CMD", cmd)
 
     result = `#{cmd}`
-    $CHILD_STATUS.success? ? YAML.safe_load(result) : exit(false)
+    $CHILD_STATUS.success? ? YAML.safe_load(result) : exit(1)
   end
 
   def gvc_org

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -106,6 +106,14 @@ class ControlplaneApi # rubocop:disable Metrics/ClassLength
     api_json("/org/#{org}/domain/#{domain}", method: :patch, body: data)
   end
 
+  def fetch_identity(org:, gvc:, identity:)
+    api_json("/org/#{org}/gvc/#{gvc}/identity/#{identity}", method: :get)
+  end
+
+  def fetch_policy(org:, policy:)
+    api_json("/org/#{org}/policy/#{policy}", method: :get)
+  end
+
   private
 
   def fetch_query_pages(result)

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "date"
 require "dotenv/load"
 require "cgi"
 require "json"
+require "jwt"
 require "net/http"
 require "pathname"
 require "tempfile"

--- a/lib/generator_templates/controlplane.yml
+++ b/lib/generator_templates/controlplane.yml
@@ -19,10 +19,13 @@ aliases:
     one_off_workload: rails
 
     # Workloads that are for the application itself and are using application Docker images.
+    # These are updated with the new image when running the `deploy-image` command,
+    # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
     app_workloads:
       - rails
 
     # Additional "service type" workloads, using non-application Docker images.
+    # These are only used by the `info`, `ps:` and `run:cleanup` commands in order to get all of the defined workloads.
     additional_workloads:
       - postgres
 

--- a/lib/generator_templates/controlplane.yml
+++ b/lib/generator_templates/controlplane.yml
@@ -21,6 +21,8 @@ aliases:
     # Workloads that are for the application itself and are using application Docker images.
     # These are updated with the new image when running the `deploy-image` command,
     # and are also used by the `info`, `ps:`, and `run:cleanup` commands in order to get all of the defined workloads.
+    # On the other hand, if you have a workload for Redis, that would NOT use the application Docker image
+    # and not be listed here.
     app_workloads:
       - rails
 

--- a/lib/generator_templates/templates/gvc.yml
+++ b/lib/generator_templates/templates/gvc.yml
@@ -1,15 +1,15 @@
 # Template setup of the GVC, roughly corresponding to a Heroku app
 kind: gvc
-name: APP_GVC
+name: {{APP_NAME}}
 spec:
   # For using templates for test apps, put ENV values here, stored in git repo.
   # Production apps will have values configured manually after app creation.
   env:
     - name: DATABASE_URL
-      # Password does not matter because host postgres.APP_GVC.cpln.local can only be accessed
+      # Password does not matter because host postgres.{{APP_NAME}}.cpln.local can only be accessed
       # locally within CPLN GVC, and postgres running on a CPLN workload is something only for a
       # test app that lacks persistence.
-      value: 'postgres://the_user:the_password@postgres.APP_GVC.cpln.local:5432/APP_GVC'
+      value: 'postgres://the_user:the_password@postgres.{{APP_NAME}}.cpln.local:5432/{{APP_NAME}}'
     - name: RAILS_ENV
       value: production
     - name: RAILS_SERVE_STATIC_FILES
@@ -18,4 +18,4 @@ spec:
   # Part of standard configuration
   staticPlacement:
     locationLinks:
-      - /org/APP_ORG/location/APP_LOCATION
+      - {{APP_LOCATION_LINK}}

--- a/lib/generator_templates/templates/postgres.yml
+++ b/lib/generator_templates/templates/postgres.yml
@@ -106,7 +106,7 @@ bindings:
 #      - use
 #      - view
     principalLinks:
-      - //gvc/APP_GVC/identity/postgres-poc-identity
+      - //gvc/{{APP_NAME}}/identity/postgres-poc-identity
 targetKind: secret
 targetLinks:
   - //secret/postgres-poc-credentials

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -14,7 +14,7 @@ spec:
           value: debug
       # Inherit other ENV values from GVC
       inheritEnv: true
-      image: '/org/APP_ORG/image/APP_IMAGE'
+      image: {{APP_IMAGE_LINK}}
       # 512 corresponds to a standard 1x dyno type
       memory: 512Mi
       ports:

--- a/spec/core/controlplane_api_direct_spec.rb
+++ b/spec/core/controlplane_api_direct_spec.rb
@@ -37,18 +37,20 @@ describe ControlplaneApiDirect do
     it "returns token from CPLN_TOKEN" do
       allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return("token_1")
 
-      token = described_instance.api_token
+      result = described_instance.api_token
 
-      expect(token).to eq("token_1")
+      expect(result[:token]).to eq("token_1")
+      expect(result[:comes_from_profile]).to be(false)
     end
 
     it "returns token from 'cpln profile token'" do
       allow(ENV).to receive(:fetch).with("CPLN_TOKEN", nil).and_return(nil)
       allow(described_instance).to receive(:`).with("cpln profile token").and_return("token_2")
 
-      token = described_instance.api_token
+      result = described_instance.api_token
 
-      expect(token).to eq("token_2")
+      expect(result[:token]).to eq("token_2")
+      expect(result[:comes_from_profile]).to be(true)
     end
 
     it "raises error if token is not found" do

--- a/templates/daily-task.yml
+++ b/templates/daily-task.yml
@@ -18,7 +18,7 @@ spec:
         - rails
         - db:prepare
       inheritEnv: true
-      image: "/org/APP_ORG/image/APP_IMAGE"
+      image: {{APP_IMAGE_LINK}}
   defaultOptions:
     autoscaling:
       minScale: 1
@@ -28,4 +28,4 @@ spec:
     external:
       outboundAllowCIDR:
         - 0.0.0.0/0
-  identityLink: /org/APP_ORG/gvc/APP_GVC/identity/APP_GVC-identity
+  identityLink: {{APP_IDENTITY_LINK}}

--- a/templates/daily-task.yml
+++ b/templates/daily-task.yml
@@ -28,4 +28,5 @@ spec:
     external:
       outboundAllowCIDR:
         - 0.0.0.0/0
+  # Identity is used for binding workload to secrets
   identityLink: {{APP_IDENTITY_LINK}}

--- a/templates/gvc.yml
+++ b/templates/gvc.yml
@@ -1,13 +1,13 @@
 kind: gvc
-name: APP_GVC
+name: {{APP_NAME}}
 spec:
   env:
     - name: MEMCACHE_SERVERS
-      value: memcached.APP_GVC.cpln.local
+      value: memcached.{{APP_NAME}}.cpln.local
     - name: REDIS_URL
-      value: redis://redis.APP_GVC.cpln.local:6379
+      value: redis://redis.{{APP_NAME}}.cpln.local:6379
     - name: DATABASE_URL
-      value: postgres://postgres:password123@postgres.APP_GVC.cpln.local:5432/APP_GVC
+      value: postgres://postgres:password123@postgres.{{APP_NAME}}.cpln.local:5432/{{APP_NAME}}
   staticPlacement:
     locationLinks:
-      - /org/APP_ORG/location/APP_LOCATION
+      - {{APP_LOCATION_LINK}}

--- a/templates/identity.yml
+++ b/templates/identity.yml
@@ -1,2 +1,2 @@
 kind: identity
-name: APP_GVC-identity
+name: {{APP_IDENTITY}}

--- a/templates/identity.yml
+++ b/templates/identity.yml
@@ -1,2 +1,3 @@
+# Identity is needed to access secrets
 kind: identity
 name: {{APP_IDENTITY}}

--- a/templates/rails.yml
+++ b/templates/rails.yml
@@ -23,4 +23,5 @@ spec:
         - 0.0.0.0/0
       outboundAllowCIDR:
         - 0.0.0.0/0
+  # Identity is used for binding workload to secrets
   identityLink: {{APP_IDENTITY_LINK}}

--- a/templates/rails.yml
+++ b/templates/rails.yml
@@ -7,7 +7,7 @@ spec:
       cpu: 512m
       memory: 1Gi
       inheritEnv: true
-      image: "/org/APP_ORG/image/APP_IMAGE"
+      image: {{APP_IMAGE_LINK}}
       ports:
         - number: 3000
           protocol: http
@@ -23,4 +23,4 @@ spec:
         - 0.0.0.0/0
       outboundAllowCIDR:
         - 0.0.0.0/0
-  identityLink: /org/APP_ORG/gvc/APP_GVC/identity/APP_GVC-identity
+  identityLink: {{APP_IDENTITY_LINK}}

--- a/templates/secrets-policy.yml
+++ b/templates/secrets-policy.yml
@@ -1,0 +1,4 @@
+# Policy is needed to allow identities to access secrets
+kind: policy
+name: {{APP_SECRETS_POLICY}}
+targetKind: secret

--- a/templates/secrets.yml
+++ b/templates/secrets.yml
@@ -1,0 +1,3 @@
+kind: secret
+name: {{APP_SECRETS}}
+type: dictionary

--- a/templates/sidekiq.yml
+++ b/templates/sidekiq.yml
@@ -34,4 +34,5 @@ spec:
     external:
       outboundAllowCIDR:
         - 0.0.0.0/0
+  # Identity is used for binding workload to secrets
   identityLink: {{APP_IDENTITY_LINK}}

--- a/templates/sidekiq.yml
+++ b/templates/sidekiq.yml
@@ -13,7 +13,7 @@ spec:
         - "-C"
         - config/sidekiq.yml
       inheritEnv: true
-      image: "/org/APP_ORG/image/APP_IMAGE"
+      image: {{APP_IMAGE_LINK}}
       ports:
         - number: 7433
           protocol: http
@@ -34,4 +34,4 @@ spec:
     external:
       outboundAllowCIDR:
         - 0.0.0.0/0
-  identityLink: /org/APP_ORG/gvc/APP_GVC/identity/APP_GVC-identity
+  identityLink: {{APP_IDENTITY_LINK}}


### PR DESCRIPTION
- Adds comments regarding `app_workloads` and `additional_workloads`, to improve documentation
- Changes template substitution to use double braces (e.g., `APP_ORG` -> `{{APP_ORG}}`) (backwards compatible)
- Renames template substitution variable `APP_GVC` to `{{APP_NAME}}` (backwards compatible)
- Adds new template substitution variables: `{{APP_LOCATION_LINK}}`, `{{APP_IMAGE_LINK}}`, `{{APP_IDENTITY}}`, `{{APP_IDENTITY_LINK}}`, `{{APP_SECRETS}}` and `{{APP_SECRETS_POLICY}}`
- Changes `setup-app` command to automatically bind the app to the secrets policy, as long as both the identity and the policy exist
- Adds `--skip-secret-access-binding` option to `setup-app` command to prevent behavior above
- Adds `--run-release-phase` option to `deploy-image` command to run release script before deploying (same step as in `promote-app-from-upstream` command)
- Refreshes local API token when it is about to expire
- Changes `apply-template` command to exit with non-zero code if failed to apply any templates