### PR TITLE
cpl doctor command, including validation for duplicate app matching when prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed app matching when name starts with (the wrong config was being used in some cases - see PR for more details). [PR 150](https://github.com/shakacode/heroku-to-control-plane/pull/150) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.4.0] - 2024-03-20
 
 ### Added

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -116,11 +116,10 @@ class Config # rubocop:disable Metrics/ClassLength
   def find_app_config(app_name1)
     @app_configs ||= {}
 
-    @app_configs[app_name1] ||= apps.filter_map do |app_name2, app_config|
+    @app_configs[app_name1] ||= apps.find do |app_name2, app_config|
                                   next unless app_matches?(app_name1, app_name2, app_config)
 
                                   app_config[:name] = app_name2
-                                  app_config
                                 end&.last
   end
 


### PR DESCRIPTION
Add controlplane.yml verification, first check is invalid prefixes that collide with other apps or prefixes



There's currently a bug where if there's an app defined after another app (both with `match_if_app_name_starts_with` set to `true`), and the name of the second app is a prefix in the name of the first app, and we try to run commands for apps with a name matching the first app, the second app will be used instead.

For example, let's say that we have this in `.controlplane/controlplane.yml`:

```yml
app-test-other:
  <<: *common
  match_if_app_name_starts_with: true

app-test:
  <<: *common
  match_if_app_name_starts_with: true
```

If we call a command like `cpl deploy-image -a app-test-other-123`, it will use the config from `app-test` instead of the one from `app-test-other`.

This PR fixes that by immediately returning an exit code of 1 from any cpl command.

Maybe add a `cpl doctor` command, like `brew doctor`, giving helpful tips and verifying configuration.
