### PR TITLE
Improve template parsing in `apply-template` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Changed
+
+- Improved template parsing in `apply-template` command when handling templates with multiple items in the same file. [PR 152](https://github.com/shakacode/heroku-to-control-plane/pull/152) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `apply-template` command now raises an error if duplicate templates are found. [PR 152](https://github.com/shakacode/heroku-to-control-plane/pull/152) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.4.0] - 2024-03-20
 
 ### Added

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -40,40 +40,18 @@ module Command
       ```
     EX
 
-    def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def call # rubocop:disable Metrics/MethodLength
       ensure_templates!
 
+      @deprecated_variables = []
       @created_items = []
       @failed_templates = []
       @skipped_templates = []
 
-      @asked_for_confirmation = false
-
-      pending_templates = templates.select do |template|
-        if template == "gvc"
-          confirm_app(template)
-        else
-          confirm_workload(template)
-        end
-      end
-
-      progress.puts if @asked_for_confirmation
-
-      @deprecated_variables = []
-
-      pending_templates.each do |template, filename|
-        step("Applying template '#{template}'", abort_on_error: false) do
-          items = apply_template(filename)
-          if items
-            items.each do |item|
-              report_success(item)
-            end
-          else
-            report_failure(template)
-          end
-
-          $CHILD_STATUS.success?
-        end
+      templates = parse_templates
+      pending_templates = confirm_templates(templates)
+      pending_templates.each do |template|
+        apply_template(template)
       end
 
       warn_deprecated_variables
@@ -87,22 +65,70 @@ module Command
 
     private
 
-    def templates
-      @templates ||= config.args.to_h do |template|
-        [template, "#{config.app_cpln_dir}/templates/#{template}.yml"]
+    def template_filename(name)
+      "#{config.app_cpln_dir}/templates/#{name}.yml"
+    end
+
+    def template_kind(template)
+      case template["kind"]
+      when "gvc" then "app"
+      else template["kind"]
       end
     end
 
     def ensure_templates!
-      missing_templates = templates.reject { |_template, filename| File.exist?(filename) }.to_h
+      missing_templates = config.args.reject { |name| File.exist?(template_filename(name)) }
       return if missing_templates.empty?
 
-      missing_templates_str = missing_templates.map do |template, filename|
-        "  - #{template} (#{filename})"
+      missing_templates_str = missing_templates.map do |name|
+        "  - #{name} (#{template_filename(name)})"
       end.join("\n")
       progress.puts("#{Shell.color('Missing templates:', :red)}\n#{missing_templates_str}\n\n")
 
       raise "Can't find templates above, please create them."
+    end
+
+    def parse_templates
+      config.args.each_with_object([]) do |name, templates|
+        data = File.read(template_filename(name))
+        data = replace_variables(data)
+        templates_data = data.split(/^---\s*$/)
+        templates_data.each do |template_data|
+          template = YAML.safe_load(template_data)
+          templates.push(template)
+        end
+      end
+    end
+
+    def confirm_templates(templates)
+      @asked_for_confirmation = false
+
+      pending_templates = templates.select do |template|
+        case template["kind"]
+        when "gvc" then confirm_app(template)
+        when "workload" then confirm_workload(template)
+        else true
+        end
+      end
+
+      progress.puts if @asked_for_confirmation
+
+      pending_templates
+    end
+
+    def apply_template(template) # rubocop:disable Metrics/MethodLength
+      step("Applying template for #{template_kind(template)} '#{template['name']}'", abort_on_error: false) do
+        items = cp.apply_hash(template)
+        if items
+          items.each do |item|
+            report_success(item)
+          end
+        else
+          report_failure(template)
+        end
+
+        $CHILD_STATUS.success?
+      end
     end
 
     def confirm_apply(message)
@@ -113,10 +139,10 @@ module Command
     end
 
     def confirm_app(template)
-      app = cp.fetch_gvc
+      app = cp.fetch_gvc(template["name"])
       return true unless app
 
-      confirmed = confirm_apply("App '#{config.app}' already exists, do you want to re-create it?")
+      confirmed = confirm_apply("App '#{template['name']}' already exists, do you want to re-create it?")
       return true if confirmed
 
       report_skipped(template)
@@ -124,40 +150,37 @@ module Command
     end
 
     def confirm_workload(template)
-      workload = cp.fetch_workload(template)
+      workload = cp.fetch_workload(template["name"])
       return true unless workload
 
-      confirmed = confirm_apply("Workload '#{template}' already exists, do you want to re-create it?")
+      confirmed = confirm_apply("Workload '#{template['name']}' already exists, do you want to re-create it?")
       return true if confirmed
 
       report_skipped(template)
       false
     end
 
-    def apply_template(filename) # rubocop:disable Metrics/MethodLength
-      data = File.read(filename)
-                 .gsub("{{APP_ORG}}", config.org)
-                 .gsub("{{APP_NAME}}", config.app)
-                 .gsub("{{APP_LOCATION}}", config.location)
-                 .gsub("{{APP_LOCATION_LINK}}", app_location_link)
-                 .gsub("{{APP_IMAGE}}", latest_image)
-                 .gsub("{{APP_IMAGE_LINK}}", app_image_link)
-                 .gsub("{{APP_IDENTITY}}", app_identity)
-                 .gsub("{{APP_IDENTITY_LINK}}", app_identity_link)
-                 .gsub("{{APP_SECRETS}}", app_secrets)
-                 .gsub("{{APP_SECRETS_POLICY}}", app_secrets_policy)
+    def replace_variables(data) # rubocop:disable Metrics/MethodLength
+      data = data
+             .gsub("{{APP_ORG}}", config.org)
+             .gsub("{{APP_NAME}}", config.app)
+             .gsub("{{APP_LOCATION}}", config.location)
+             .gsub("{{APP_LOCATION_LINK}}", app_location_link)
+             .gsub("{{APP_IMAGE}}", latest_image)
+             .gsub("{{APP_IMAGE_LINK}}", app_image_link)
+             .gsub("{{APP_IDENTITY}}", app_identity)
+             .gsub("{{APP_IDENTITY_LINK}}", app_identity_link)
+             .gsub("{{APP_SECRETS}}", app_secrets)
+             .gsub("{{APP_SECRETS_POLICY}}", app_secrets_policy)
 
       find_deprecated_variables(data)
 
       # Kept for backwards compatibility
-      data = data
-             .gsub("APP_ORG", config.org)
-             .gsub("APP_GVC", config.app)
-             .gsub("APP_LOCATION", config.location)
-             .gsub("APP_IMAGE", latest_image)
-
-      # Don't read in YAML.safe_load as that doesn't handle multiple documents
-      cp.apply_template(data)
+      data
+        .gsub("APP_ORG", config.org)
+        .gsub("APP_GVC", config.app)
+        .gsub("APP_LOCATION", config.location)
+        .gsub("APP_IMAGE", latest_image)
     end
 
     def new_variables
@@ -205,14 +228,14 @@ module Command
     def print_failed_templates
       return unless @failed_templates.any?
 
-      failed = @failed_templates.map { |template| "  - #{template}" }.join("\n")
+      failed = @failed_templates.map { |template| "  - [#{template_kind(template)}] #{template['name']}" }.join("\n")
       progress.puts("\n#{Shell.color('Failed to apply templates:', :red)}\n#{failed}")
     end
 
     def print_skipped_templates
       return unless @skipped_templates.any?
 
-      skipped = @skipped_templates.map { |template| "  - #{template}" }.join("\n")
+      skipped = @skipped_templates.map { |template| "  - [#{template_kind(template)}] #{template['name']}" }.join("\n")
       progress.puts("\n#{Shell.color('Skipped templates (already exist):', :blue)}\n#{skipped}")
     end
   end


### PR DESCRIPTION
This PR:

- Improves template parsing in the `apply-template` command when handling templates with multiple items in the same file
- Changes the `apply-template` command to raise an error if duplicate templates are found