### PR TITLE
Raise error if image does not exist in `deploy-image` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Changed
+
+- `deploy-image` command now raises an error if image does not exist. [PR 153](https://github.com/shakacode/heroku-to-control-plane/pull/153) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [1.4.0] - 2024-03-20
 
 ### Added

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -20,7 +20,7 @@ module Command
       deployed_endpoints = {}
 
       image = latest_image
-      raise "Image '#{image}' does not exist." if cp.fetch_image(image).nil?
+      raise "Image '#{image}' does not exist." if cp.fetch_image_details(image).nil?
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -20,7 +20,11 @@ module Command
       deployed_endpoints = {}
 
       image = latest_image
-      raise "Image '#{image}' does not exist." if cp.fetch_image_details(image).nil?
+      if cp.fetch_image_details(image).nil?
+        raise "Image '#{image}' does not exist in the Docker repository on Control Plane " \
+              "(see https://console.cpln.io/console/org/#{config.org}/repository/#{config.app}). " \
+              "Use `cpl build-image` first."
+      end
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -20,6 +20,7 @@ module Command
       deployed_endpoints = {}
 
       image = latest_image
+      raise "Image '#{image}' does not exist." if cp.fetch_image(image).nil?
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -58,8 +58,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     image_push(image) if push
   end
 
-  def fetch_image(image)
-    api.fetch_image(org: org, image: image)
+  def fetch_image_details(image)
+    api.fetch_image_details(org: org, image: image)
   end
 
   def image_delete(image)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -58,6 +58,10 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     image_push(image) if push
   end
 
+  def fetch_image(image)
+    api.fetch_image(org: org, image: image)
+  end
+
   def image_delete(image)
     api.image_delete(org: org, image: image)
   end

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -25,7 +25,7 @@ class ControlplaneApi # rubocop:disable Metrics/ClassLength
     query("/org/#{org}/image", terms)
   end
 
-  def fetch_image(org:, image:)
+  def fetch_image_details(org:, image:)
     api_json("/org/#{org}/image/#{image}", method: :get)
   end
 

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -25,6 +25,10 @@ class ControlplaneApi # rubocop:disable Metrics/ClassLength
     query("/org/#{org}/image", terms)
   end
 
+  def fetch_image(org:, image:)
+    api_json("/org/#{org}/image/#{image}", method: :get)
+  end
+
   def image_delete(org:, image:)
     api_json("/org/#{org}/image/#{image}", method: :delete)
   end


### PR DESCRIPTION
This PR changes the `deploy-image` command to to raise an error if the image does not exist.