### PR TITLE
Revert incorrect changes from #159

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -47,7 +47,7 @@ Note how the templates correspond to files in the `.controlplane/templates/` dir
 `cpl setup-app` and `cpl apply-template` commands.
 
 Ensure that env vars point to the Heroku add-ons in the template for the app (`.controlplane/templates/app.yml`). See
-[this example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/app.yml).
+[this example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/gvc.yml).
 
 After that, create a Dockerfile in `.controlplane/Dockerfile` for your deployment. See
 [this example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/Dockerfile).

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -124,10 +124,7 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
 
     LogHelpers.write_command_result_to_log(result)
 
-    if result[:status].nonzero? && raise_errors
-      cmd = args.join(" ")
-      raise "Command '#{cmd}' failed:  #{result.to_json}"
-    end
+    raise result.to_json if result[:status].nonzero? && raise_errors
 
     result
   end


### PR DESCRIPTION
Reverts some incorrect changes from #159:

- We cannot rename `https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/gvc.yml` to `https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/app.yml` yet, because this references a file in another repo, so we have to rename the file in that repo first.

- Changing from:

 ```
raise result.to_json if result[:status].nonzero? && raise_errors
```

to:

```
if result[:status].nonzero? && raise_errors
  cmd = args.join(" ")
  raise "Command '#{cmd}' failed:  #{result.to_json}"
end
```

is redundant, because we already log the command:

https://github.com/shakacode/heroku-to-control-plane/blob/74f584801230c0fbe0e98baa82436652ef56b51e/spec/support/command_helpers.rb#L105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the migration guide to reference the correct configuration file.
- **Refactor**
	- Improved error handling in command execution to enhance reliability and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->