### PR TITLE
Raise error if org does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Changed
 
+- An error is now raised if the org does not exist. [PR 167](https://github.com/shakacode/heroku-to-control-plane/pull/167) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run` command now uses a single reusable cron workload and works for both interactive and non-interactive jobs. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run:detached` command has been deprecated in favor of `run`. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `deploy-image` command now raises an error if image does not exist. [PR 153](https://github.com/shakacode/heroku-to-control-plane/pull/153) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -8,6 +8,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     @api = ControlplaneApi.new
     @gvc = config.app
     @org = config.org
+
+    ensure_org_exists! if org
   end
 
   # profile
@@ -403,6 +405,18 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   private
+
+  def org_exists?
+    items = api.list_orgs["items"]
+    items.any? { |item| item["name"] == org }
+  end
+
+  def ensure_org_exists!
+    return if org_exists?
+
+    raise "Can't find org '#{org}', please create it in the Control Plane dashboard " \
+          "or ensure that the name is correct."
+  end
 
   # `output_mode` can be :all, :errors_only or :none.
   # If not provided, it will be determined based on the `HIDE_COMMAND_OUTPUT` env var

--- a/lib/core/controlplane_api.rb
+++ b/lib/core/controlplane_api.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ControlplaneApi # rubocop:disable Metrics/ClassLength
+  def list_orgs
+    api_json("/org", method: :get)
+  end
+
   def gvc_list(org:)
     api_json("/org/#{org}/gvc", method: :get)
   end

--- a/spec/core/controlplane_spec.rb
+++ b/spec/core/controlplane_spec.rb
@@ -3,10 +3,19 @@
 require "spec_helper"
 
 describe Controlplane do
-  let!(:fake_config) { Struct.new(:app, :org).new("my-app", "my-org") }
-  let!(:described_instance) { described_class.new(fake_config) }
+  describe "#initialize" do
+    let!(:fake_config) { Struct.new(:app, :org).new("my-app", "my-org") }
+
+    it "raises error if org does not exist" do
+      expect do
+        described_class.new(fake_config)
+      end.to raise_error(include("Can't find org 'my-org'"))
+    end
+  end
 
   describe "#build_command" do
+    let!(:fake_config) { Struct.new(:app, :org).new("my-app", nil) }
+    let!(:described_instance) { described_class.new(fake_config) }
     let!(:original_cmd) { "cmd" }
 
     before do


### PR DESCRIPTION
Fixes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to verify the existence of an organization before proceeding with commands.
	- Introduced a new method to list all organizations.
- **Bug Fixes**
	- Improved error handling in the `deploy-image` command.
- **Refactor**
	- Updated the `run` command behavior and deprecated the `run:detached` command.
- **Tests**
	- Added tests to ensure organizational checks are in place during initialization and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->