### PR TITLE
Show common options in help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _Please add entries here for your pull requests that are not yet released._
 
 ### Changed
 
+- Common options are now shown in help. [PR 169](https://github.com/shakacode/heroku-to-control-plane/pull/169) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run` command now uses a single reusable cron workload and works for both interactive and non-interactive jobs. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run:detached` command has been deprecated in favor of `run`. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `deploy-image` command now raises an error if image does not exist. [PR 153](https://github.com/shakacode/heroku-to-control-plane/pull/153) by [Rafael Gomes](https://github.com/rafaelgomesxyz).


### PR DESCRIPTION
Fixes #122 

![common_options](https://github.com/shakacode/heroku-to-control-plane/assets/25509361/db73c546-df7e-49e6-8396-74209f786f4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced help display to include common options.
	- Unified `run` command for both interactive and non-interactive jobs.
- **Bug Fixes**
	- `deploy-image` command now checks and raises an error if the image does not exist.
- **Refactor**
	- Improved processing of non-boolean options and command parameters.
- **Deprecations**
	- Deprecated the `run:detached` command in favor of a more streamlined `run`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->