### PR TITLE
Unbind identity from policy when deleting app in `delete` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _Please add entries here for your pull requests that are not yet released._
 - `run` command now uses a single reusable cron workload and works for both interactive and non-interactive jobs. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run:detached` command has been deprecated in favor of `run`. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `deploy-image` command now raises an error if image does not exist. [PR 153](https://github.com/shakacode/heroku-to-control-plane/pull/153) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `delete` command now unbinds identity from policy (if bound) when deleting app. [PR 170](https://github.com/shakacode/heroku-to-control-plane/pull/170) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.4.0] - 2024-03-20
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -106,6 +106,7 @@ cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --ima
 ### `delete`
 
 - Deletes the whole app (GVC with all workloads, all volumesets and all images) or a specific workload
+- Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
 - Will ask for explicit user confirmation
 
 ```sh

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -339,6 +339,11 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     perform!(cmd)
   end
 
+  def unbind_identity_from_policy(identity_link, policy)
+    cmd = "cpln policy remove-binding #{policy} --org #{org} --identity #{identity_link} --permission reveal"
+    perform!(cmd)
+  end
+
   # apply
   def apply_template(data) # rubocop:disable Metrics/MethodLength
     Tempfile.create do |f|

--- a/spec/dummy/.controlplane/controlplane.yml
+++ b/spec/dummy/.controlplane/controlplane.yml
@@ -156,6 +156,14 @@ apps:
     setup_app_templates:
       - app-without-identity
 
+  dummy-test-without-policy:
+    <<: *common
+
+    match_if_app_name_starts_with: true
+    secrets_policy_name: nonexistent
+    setup_app_templates:
+      - app
+
   dummy-test-info:
     <<: *common
 


### PR DESCRIPTION
We do not currently clean policy bindings, which can cause issues, as the maximum number of bindings is 200. Once that limit is reached, new bindings will fail to be created.

This PR fixes that by unbinding the identity from the policy when deleting an app in the `delete` command. However, it does not work retroactively (old bindings will have to be cleaned manually).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `delete` command to unbind the app from the secrets policy if both the identity and policy exist and are bound.

- **Documentation**
  - Updated command documentation to reflect the new unbinding functionality for the `delete` command.

- **Tests**
  - Added new test scenarios to verify the unbinding of identity from policy under various conditions.

- **Configuration**
  - Introduced a new dummy configuration for testing without a secrets policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->