### PR TITLE
Bump min `cpln` version to `2.0.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Please add entries here for your pull requests that are not yet released._
 ### BREAKING CHANGES
 
 - Commands that finished with a failure now exit with code `64` instead of `1`. [PR 132](https://github.com/shakacode/heroku-to-control-plane/pull/132) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Bumped minimum `cpln` version to `2.0.1` (`cpln workload cron get` is required). [PR 171](https://github.com/shakacode/heroku-to-control-plane/pull/171) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `run:cleanup` command has been removed. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `deploy-image` command now runs the release script in the context of the `run` command. [PR 151](https://github.com/shakacode/heroku-to-control-plane/pull/151) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 

--- a/lib/cpl/version.rb
+++ b/lib/cpl/version.rb
@@ -2,5 +2,5 @@
 
 module Cpl
   VERSION = "2.0.0.rc.1"
-  MIN_CPLN_VERSION = "0.0.71"
+  MIN_CPLN_VERSION = "2.0.1"
 end


### PR DESCRIPTION
`cpln workload cron get` is required, which is available since `2.0.1`: https://docs.controlplane.com/release-notes#cli-2.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased minimum `cpln` version requirement to `2.0.1` for enhanced compatibility and performance.
	- Updated exit codes for commands to better indicate failure states.
	- Adjusted execution context for the `deploy-image` command for more reliable deployments.

- **Chores**
	- Removed the obsolete `run:cleanup` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->