### PR TITLE
Security: switch to using image's digest sha256 value on promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ _Please add entries here for your pull requests that have not yet been released.
 - Added `--docker-context` option to `build-image` command. [PR 250](https://github.com/shakacode/control-plane-flow/pull/250) by [Sergey Tarasov](https://github.com/dzirtusss).
 
 
+### Changed
+
+- Providing digest (SHA256 value) for image link on promotion from upstream. [PR 249](https://github.com/shakacode/control-plane-flow/pull/249) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
+
 ## [4.0.0] - 2024-08-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _Please add entries here for your pull requests that have not yet been released.
 ### Added
 
 - Added the GitHub Actions flow generator and readiness checks for staging, review-app, and production-promotion workflows. [PR 278](https://github.com/shakacode/control-plane-flow/pull/278) by [Justin Gordon](https://github.com/justin808).
+- Added `use-digest-image-ref` (also configurable through `use_digest_image_ref` in `controlplane.yml`) option to `deploy-image` and `promote-app-from-upstream` commands. [PR 249](https://github.com/shakacode/control-plane-flow/pull/249) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
 
 ### Breaking Changes
 
@@ -51,10 +52,6 @@ _Please add entries here for your pull requests that have not yet been released.
 
 - Added `--docker-context` option to `build-image` command. [PR 250](https://github.com/shakacode/control-plane-flow/pull/250) by [Sergey Tarasov](https://github.com/dzirtusss).
 
-
-### Changed
-
-- Providing digest (SHA256 value) for image link on promotion from upstream. [PR 249](https://github.com/shakacode/control-plane-flow/pull/249) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
 
 ## [4.0.0] - 2024-08-21
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ apps:
     # This is relative to the `.controlplane/` directory.
     release_script: release_script
 
+    # Used by the `cpflow deploy-image` and `cpflow promote-app-from-upstream` commands to include Docker image's digest (SHA256 value) in its reference.
+    use_digest_image_ref: true
+
     # default_domain is used for commands that require a domain
     # including `maintenance`, `maintenance:on`, `maintenance:off`.
     default_domain: domain.com

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -142,6 +142,7 @@ cpflow delete -a $APP_NAME -w $WORKLOAD_NAME
 - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
 - The release script is run in the context of `cpflow run` with the latest image
 - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
+- If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
 
 ```sh
 cpflow deploy-image -a $APP_NAME
@@ -356,6 +357,7 @@ cpflow open-console -a $APP_NAME
   - Runs `cpflow deploy-image` to deploy the image
   - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
   - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
+  - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
 
 ```sh
 cpflow promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -491,6 +491,17 @@ module Command
         }
       }
     end
+
+    def self.use_digest_ref_option(required: false)
+      {
+        name: :use_digest_ref,
+        params: {
+          desc: "Uses the image's digest (SHA256 value) for referencing the Docker image",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -492,9 +492,9 @@ module Command
       }
     end
 
-    def self.use_digest_ref_option(required: false)
+    def self.use_digest_image_ref_option(required: false)
       {
-        name: :use_digest_ref,
+        name: :use_digest_image_ref,
         params: {
           desc: "Uses the image's digest (SHA256 value) for referencing the Docker image",
           type: :boolean,

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -8,7 +8,7 @@ module Command
     OPTIONS = [
       app_option(required: true),
       run_release_phase_option,
-      use_digest_ref_option
+      use_digest_image_ref_option
     ].freeze
     DESCRIPTION = "Deploys the latest image to app workloads, and runs a release script (optional)"
     LONG_DESCRIPTION = <<~DESC
@@ -16,6 +16,7 @@ module Command
       - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
       - The release script is run in the context of `cpflow run` with the latest image
       - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
+      - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
     DESC
 
     def call # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
@@ -31,7 +32,7 @@ module Command
               "Use `cpflow build-image` first."
       end
 
-      image = "#{image_details['name']}@#{image_details['digest']}" if config.options[:use_digest_ref]
+      image = "#{image_details['name']}@#{image_details['digest']}" if config.use_digest_image_ref?
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -55,6 +55,7 @@ module Command
 
       digest = image_details["digest"]
       raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
+      # SHA-256 only; expand the regex if Control Plane ever returns sha512 or other digest algorithms.
       raise "Unexpected digest format for image '#{image}'." unless digest.match?(/\Asha256:[a-fA-F0-9]{64}\z/)
 
       "#{image}@#{digest}"

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -19,20 +19,11 @@ module Command
       - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
     DESC
 
-    def call # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    def call # rubocop:disable Metrics/MethodLength
       run_release_script if config.options[:run_release_phase]
 
       deployed_endpoints = {}
-
-      image = cp.latest_image
-      image_details = cp.fetch_image_details(image)
-      if image_details.nil?
-        raise "Image '#{image}' does not exist in the Docker repository on Control Plane " \
-              "(see https://console.cpln.io/console/org/#{config.org}/repository/#{config.app}). " \
-              "Use `cpflow build-image` first."
-      end
-
-      image = "#{image_details['name']}@#{image_details['digest']}" if config.use_digest_image_ref?
+      image = resolve_image_to_deploy
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)
@@ -54,6 +45,25 @@ module Command
     end
 
     private
+
+    def resolve_image_to_deploy
+      image = cp.latest_image
+      image_details = cp.fetch_image_details(image)
+      raise image_not_found_message(image) if image_details.nil?
+
+      return image unless config.use_digest_image_ref?
+
+      digest = image_details["digest"]
+      raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
+
+      "#{image_details['name']}@#{digest}"
+    end
+
+    def image_not_found_message(image)
+      "Image '#{image}' does not exist in the Docker repository on Control Plane " \
+        "(see https://console.cpln.io/console/org/#{config.org}/repository/#{config.app}). " \
+        "Use `cpflow build-image` first."
+    end
 
     def endpoint_for_workload(workload_data)
       endpoint = workload_data.dig("status", "endpoint")

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -48,18 +48,29 @@ module Command
 
     def resolve_image_to_deploy
       image = cp.latest_image
-      image_details = cp.fetch_image_details(image)
-      raise image_not_found_message(image) if image_details.nil?
+      image_details = fetch_image_details!(image)
 
       return image unless config.use_digest_image_ref?
 
+      # Control Plane accepts the tagged digest form returned here; latest_image currently returns app:N.
+      "#{image}@#{image_digest!(image, image_details)}"
+    end
+
+    def fetch_image_details!(image)
+      image_details = cp.fetch_image_details(image)
+      raise image_not_found_message(image) if image_details.nil?
+
+      image_details
+    end
+
+    def image_digest!(image, image_details)
       digest = image_details["digest"]
       raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
       # SHA-256 only; expand the regex if Control Plane ever returns sha512 or other digest algorithms.
       # OCI digests are always lowercase hex per the OCI image spec.
       raise "Unexpected digest format for image '#{image}'." unless digest.match?(/\Asha256:[a-f0-9]{64}\z/)
 
-      "#{image}@#{digest}"
+      digest
     end
 
     def image_not_found_message(image)

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -48,6 +48,8 @@ module Command
 
     def resolve_image_to_deploy
       image = cp.latest_image
+      # Preserve the pre-existing fail-fast check so missing images are reported
+      # before workloads are touched.
       image_details = fetch_image_details!(image)
 
       return image unless config.use_digest_image_ref?

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -7,7 +7,8 @@ module Command
     NAME = "deploy-image"
     OPTIONS = [
       app_option(required: true),
-      run_release_phase_option
+      run_release_phase_option,
+      use_digest_ref_option
     ].freeze
     DESCRIPTION = "Deploys the latest image to app workloads, and runs a release script (optional)"
     LONG_DESCRIPTION = <<~DESC
@@ -17,17 +18,20 @@ module Command
       - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
     DESC
 
-    def call # rubocop:disable Metrics/MethodLength
+    def call # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
       run_release_script if config.options[:run_release_phase]
 
       deployed_endpoints = {}
 
       image = cp.latest_image
-      if cp.fetch_image_details(image).nil?
+      image_details = cp.fetch_image_details(image)
+      if image_details.nil?
         raise "Image '#{image}' does not exist in the Docker repository on Control Plane " \
               "(see https://console.cpln.io/console/org/#{config.org}/repository/#{config.app}). " \
               "Use `cpflow build-image` first."
       end
+
+      image = "#{image_details['name']}@#{image_details['digest']}" if config.options[:use_digest_ref]
 
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -56,7 +56,8 @@ module Command
       digest = image_details["digest"]
       raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
       # SHA-256 only; expand the regex if Control Plane ever returns sha512 or other digest algorithms.
-      raise "Unexpected digest format for image '#{image}'." unless digest.match?(/\Asha256:[a-fA-F0-9]{64}\z/)
+      # OCI digests are always lowercase hex per the OCI image spec.
+      raise "Unexpected digest format for image '#{image}'." unless digest.match?(/\Asha256:[a-f0-9]{64}\z/)
 
       "#{image}@#{digest}"
     end

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -28,7 +28,7 @@ module Command
       config[:app_workloads].each do |workload|
         workload_data = cp.fetch_workload!(workload)
         workload_data.dig("spec", "containers").each do |container|
-          next unless container["image"].match?(%r{^/org/#{config.org}/image/#{config.app}:})
+          next unless container["image"].match?(%r{^/org/#{config.org}/image/#{config.app}[:@]})
 
           container_name = container["name"]
           step("Deploying image '#{image}' for workload '#{container_name}'") do
@@ -55,6 +55,7 @@ module Command
 
       digest = image_details["digest"]
       raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
+      raise "Unexpected digest format for image '#{image}'." unless digest.match?(/\Asha256:[a-fA-F0-9]{64}\z/)
 
       "#{image}@#{digest}"
     end

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -56,7 +56,7 @@ module Command
       digest = image_details["digest"]
       raise "Image '#{image}' does not have a digest available." if digest.nil? || digest.empty?
 
-      "#{image_details['name']}@#{digest}"
+      "#{image}@#{digest}"
     end
 
     def image_not_found_message(image)

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -5,7 +5,8 @@ module Command
     NAME = "promote-app-from-upstream"
     OPTIONS = [
       app_option(required: true),
-      upstream_token_option(required: true)
+      upstream_token_option(required: true),
+      use_digest_image_ref_option
     ].freeze
     DESCRIPTION = "Copies the latest image from upstream, runs a release script (optional), and deploys the image"
     LONG_DESCRIPTION = <<~DESC
@@ -15,6 +16,7 @@ module Command
         - Runs `cpflow deploy-image` to deploy the image
         - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
         - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
+        - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
     DESC
 
     def call
@@ -32,7 +34,8 @@ module Command
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      run_cpflow_command("deploy-image", "-a", config.app, "--use-digest-ref", *args)
+      args.push("--use-digest-image-ref") if config.use_digest_image_ref?
+      run_cpflow_command("deploy-image", "-a", config.app, *args)
     end
   end
 end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -32,7 +32,7 @@ module Command
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      run_cpflow_command("deploy-image", "-a", config.app, *args)
+      run_cpflow_command("deploy-image", "-a", config.app, "--use-digest-ref", *args)
     end
   end
 end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -34,9 +34,9 @@ module Command
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      # Always forward the resolved value as an explicit CLI flag so the deploy-image
-      # subprocess uses what was resolved here (CLI beats YAML), not what its own
-      # Config would re-resolve from YAML alone.
+      # Always forward the resolved value as an explicit CLI flag so the in-process
+      # deploy-image invocation uses what was resolved here (CLI beats YAML), not
+      # what its own fresh Config would re-resolve from YAML alone.
       args.push(config.use_digest_image_ref? ? "--use-digest-image-ref" : "--no-use-digest-image-ref")
       run_cpflow_command("deploy-image", "-a", config.app, *args)
     end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -33,12 +33,17 @@ module Command
 
     def deploy_image
       args = []
-      args.push("--run-release-phase") if config.current[:release_script]
-      # Always forward the resolved value as an explicit CLI flag so the in-process
-      # deploy-image invocation uses what was resolved here (CLI beats YAML), not
-      # what its own fresh Config would re-resolve from YAML alone.
-      args.push(config.use_digest_image_ref? ? "--use-digest-image-ref" : "--no-use-digest-image-ref")
+      args.push("--run-release-phase") if config.current&.dig(:release_script)
+      digest_image_ref_option = deploy_image_digest_ref_option
+      args.push(digest_image_ref_option) if digest_image_ref_option
       run_cpflow_command("deploy-image", "-a", config.app, *args)
+    end
+
+    def deploy_image_digest_ref_option
+      # Forward explicit false so a parent CLI override is not lost when the child command re-reads YAML.
+      return "--no-use-digest-image-ref" if config.options[:use_digest_image_ref] == false
+
+      "--use-digest-image-ref" if config.use_digest_image_ref?
     end
   end
 end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -34,7 +34,7 @@ module Command
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      args.push("--use-digest-image-ref") if config.use_digest_image_ref?
+      args.push(config.use_digest_image_ref? ? "--use-digest-image-ref" : "--no-use-digest-image-ref")
       run_cpflow_command("deploy-image", "-a", config.app, *args)
     end
   end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -34,6 +34,9 @@ module Command
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
+      # Always forward the resolved value as an explicit CLI flag so the deploy-image
+      # subprocess uses what was resolved here (CLI beats YAML), not what its own
+      # Config would re-resolve from YAML alone.
       args.push(config.use_digest_image_ref? ? "--use-digest-image-ref" : "--no-use-digest-image-ref")
       run_cpflow_command("deploy-image", "-a", config.app, *args)
     end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -145,6 +145,10 @@ class Config # rubocop:disable Metrics/ClassLength
                                 end&.last
   end
 
+  def use_digest_image_ref?
+    current&.dig(:use_digest_image_ref) || options[:use_digest_image_ref]
+  end
+
   private
 
   def ensure_current_config!

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -150,7 +150,7 @@ class Config # rubocop:disable Metrics/ClassLength
     # (both short-circuit YAML), absent → nil (fall through to YAML).
     return options[:use_digest_image_ref] unless options[:use_digest_image_ref].nil?
 
-    current&.dig(:use_digest_image_ref) || false
+    current&.dig(:use_digest_image_ref) == true
   end
 
   private

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -146,6 +146,8 @@ class Config # rubocop:disable Metrics/ClassLength
   end
 
   def use_digest_image_ref?
+    # Three-state: --use-digest-image-ref → true, --no-use-digest-image-ref → false
+    # (both short-circuit YAML), absent → nil (fall through to YAML).
     return options[:use_digest_image_ref] unless options[:use_digest_image_ref].nil?
 
     current&.dig(:use_digest_image_ref) || false

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -146,7 +146,9 @@ class Config # rubocop:disable Metrics/ClassLength
   end
 
   def use_digest_image_ref?
-    current&.dig(:use_digest_image_ref) || options[:use_digest_image_ref]
+    return options[:use_digest_image_ref] unless options[:use_digest_image_ref].nil?
+
+    current&.dig(:use_digest_image_ref) || false
   end
 
   private

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -47,6 +47,17 @@ describe Command::DeployImage do
     end
   end
 
+  context "with --use-digest-ref option" do
+    let!(:app) { dummy_test_app("rails-non-app-image", create_if_not_exists: true) }
+
+    it "deploys latest image with digest reference", :slow do
+      result = run_cpflow_command("deploy-image", "-a", app, "--use-digest-ref")
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)
+    end
+  end
+
   context "when 'release_script' is not defined" do
     let!(:app) { dummy_test_app("nothing") }
 

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -47,11 +47,11 @@ describe Command::DeployImage do
     end
   end
 
-  context "with --use-digest-ref option" do
+  context "with --use-digest-image-ref option" do
     let!(:app) { dummy_test_app("rails-non-app-image", create_if_not_exists: true) }
 
     it "deploys latest image with digest reference", :slow do
-      result = run_cpflow_command("deploy-image", "-a", app, "--use-digest-ref")
+      result = run_cpflow_command("deploy-image", "-a", app, "--use-digest-image-ref")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -48,7 +48,16 @@ describe Command::DeployImage do
   end
 
   context "with --use-digest-image-ref option" do
-    let!(:app) { dummy_test_app("rails-non-app-image", create_if_not_exists: true) }
+    let!(:app) { dummy_test_app("rails-non-app-image") }
+
+    before do
+      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
+    end
+
+    after do
+      run_cpflow_command!("delete", "-a", app, "--yes")
+    end
 
     it "deploys latest image with digest reference", :slow do
       result = run_cpflow_command("deploy-image", "-a", app, "--use-digest-image-ref")

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -51,7 +51,7 @@ describe Command::DeployImage do
     let!(:app) { dummy_test_app("rails-non-app-image") }
 
     before do
-      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+      run_cpflow_command!("apply-template", "app", "rails", "rails-with-non-app-image", "-a", app)
       run_cpflow_command!("build-image", "-a", app)
     end
 
@@ -63,7 +63,7 @@ describe Command::DeployImage do
       result = run_cpflow_command("deploy-image", "-a", app, "--use-digest-image-ref")
 
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-f0-9]{64}'/)
     end
   end
 
@@ -83,7 +83,7 @@ describe Command::DeployImage do
       result = run_cpflow_command("deploy-image", "-a", app)
 
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-f0-9]{64}'/)
     end
 
     it "deploys without digest reference when --no-use-digest-image-ref overrides YAML", :slow do

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -76,6 +76,13 @@ describe Command::DeployImage do
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)
     end
+
+    it "deploys without digest reference when --no-use-digest-image-ref overrides YAML", :slow do
+      result = run_cpflow_command("deploy-image", "-a", app, "--no-use-digest-image-ref")
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+(?!@)'/)
+    end
   end
 
   context "when 'release_script' is not defined" do

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -58,6 +58,26 @@ describe Command::DeployImage do
     end
   end
 
+  context "with use_digest_image_ref from YAML file" do
+    let!(:app) { dummy_test_app("use-digest-image-ref") }
+
+    before do
+      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
+    end
+
+    after do
+      run_cpflow_command!("delete", "-a", app, "--yes")
+    end
+
+    it "deploys latest image with digest reference", :slow do
+      result = run_cpflow_command("deploy-image", "-a", app)
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+@sha256:[a-fA-F0-9]{64}'/)
+    end
+  end
+
   context "when 'release_script' is not defined" do
     let!(:app) { dummy_test_app("nothing") }
 

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -81,7 +81,8 @@ describe Command::DeployImage do
       result = run_cpflow_command("deploy-image", "-a", app, "--no-use-digest-image-ref")
 
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+(?!@)'/)
+      expect(result[:stderr]).to match(/Deploying image '#{app}:\d+'/)
+      expect(result[:stderr]).not_to include("@sha256:")
     end
   end
 

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -14,6 +14,26 @@ describe Command::DeployImage do
       command
     end
 
+    context "when digest mode is enabled" do
+      it "returns the latest image with its digest reference" do
+        digest = "sha256:#{'a' * 64}"
+        command = build_command(image_details: { "digest" => digest })
+
+        expect(command.send(:resolve_image_to_deploy)).to eq("test-app:1@#{digest}")
+      end
+    end
+
+    context "when digest mode is disabled" do
+      it "returns the latest image without validating the digest" do
+        command = build_command(
+          image_details: { "digest" => "sha512:#{'a' * 128}" },
+          use_digest_image_ref: false
+        )
+
+        expect(command.send(:resolve_image_to_deploy)).to eq("test-app:1")
+      end
+    end
+
     context "when the image does not exist" do
       it "raises the image not found error" do
         command = build_command(image_details: nil)

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Command::DeployImage do
+  describe "#resolve_image_to_deploy" do
+    def build_command(image_details:, use_digest_image_ref: true)
+      image = "test-app:1"
+      config = instance_double(Config, app: "test-app", org: "test-org", use_digest_image_ref?: use_digest_image_ref)
+      cp = instance_double(Controlplane, latest_image: image, fetch_image_details: image_details)
+
+      command = described_class.new(config)
+      allow(command).to receive(:cp).and_return(cp)
+      command
+    end
+
+    context "when the image does not exist" do
+      it "raises the image not found error" do
+        command = build_command(image_details: nil)
+
+        expect { command.send(:resolve_image_to_deploy) }
+          .to raise_error(/Image 'test-app:1' does not exist in the Docker repository/)
+      end
+    end
+
+    context "when the image has no digest" do
+      it "raises a digest availability error" do
+        command = build_command(image_details: { "digest" => nil })
+
+        expect { command.send(:resolve_image_to_deploy) }
+          .to raise_error("Image 'test-app:1' does not have a digest available.")
+      end
+    end
+
+    context "when the image has an empty digest" do
+      it "raises a digest availability error" do
+        command = build_command(image_details: { "digest" => "" })
+
+        expect { command.send(:resolve_image_to_deploy) }
+          .to raise_error("Image 'test-app:1' does not have a digest available.")
+      end
+    end
+
+    context "when the image has an invalid digest format" do
+      it "raises a digest format error" do
+        command = build_command(image_details: { "digest" => "sha512:#{'a' * 128}" })
+
+        expect { command.send(:resolve_image_to_deploy) }
+          .to raise_error("Unexpected digest format for image 'test-app:1'.")
+      end
+    end
+  end
+end

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -30,6 +30,7 @@ describe Command::PromoteAppFromUpstream do
       expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
       expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
       expect(result[:stderr]).not_to include("Running release script")
+      expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
       expect(result[:stderr]).to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end
@@ -64,6 +65,7 @@ describe Command::PromoteAppFromUpstream do
       expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
       expect(result[:stderr]).to include("Running release script")
       expect(result[:stderr]).to include("Failed to run release script")
+      expect(result[:stderr]).not_to include("Deploying image")
       expect(result[:stderr]).not_to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end
@@ -98,6 +100,7 @@ describe Command::PromoteAppFromUpstream do
       expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
       expect(result[:stderr]).to include("Running release script")
       expect(result[:stderr]).to include("Finished running release script")
+      expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
       expect(result[:stderr]).to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -3,58 +3,81 @@
 require "spec_helper"
 
 describe Command::PromoteAppFromUpstream do
-  context "when release script is not provided" do
-    let!(:token) { Shell.cmd("cpln", "profile", "token", "default")[:output].strip }
-    let!(:upstream_app) { dummy_test_app }
-    let!(:app) { dummy_test_app("nothing") }
+  subject(:result) do
+    run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token, *extra_args)
+  end
 
-    before do
-      stub_env("CPLN_UPSTREAM", upstream_app)
-      # Ideally, we should have a different org, but for testing purposes, this works
-      stub_env("CPLN_ORG_UPSTREAM", dummy_test_org)
+  let(:upstream_app) { dummy_test_app }
+  let(:token) { Shell.cmd("cpln", "profile", "token", "default")[:output].strip }
+  let(:extra_args) { [] }
 
-      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
-      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
-      run_cpflow_command!("build-image", "-a", upstream_app)
-    end
+  before do
+    stub_env("CPLN_UPSTREAM", upstream_app)
+    # Ideally, we should have a different org, but for testing purposes, this works
+    stub_env("CPLN_ORG_UPSTREAM", dummy_test_org)
+    stub_env("APP_NAME", app)
 
-    after do
-      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
-      run_cpflow_command!("delete", "-a", app, "--yes")
-    end
+    run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+    run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
+    run_cpflow_command!("build-image", "-a", upstream_app)
+  end
 
-    it "copies latest image from upstream, skips release script and deploys image", :slow do
-      result = run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
+  after do
+    run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+    run_cpflow_command!("delete", "-a", app, "--yes")
+  end
 
+  shared_examples "copies latest image from upstream and deploys image" do |**options|
+    it "#{options[:runs_release_script] ? 'runs' : 'does not run'} release script", :slow do
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
       expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
-      expect(result[:stderr]).not_to include("Running release script")
-      expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
+
+      if options[:runs_release_script]
+        expect(result[:stderr]).to include("Running release script")
+      else
+        expect(result[:stderr]).not_to include("Running release script")
+      end
+
+      if options[:uses_digest_image_ref]
+        expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
+      else
+        expect(result[:stderr]).to match(/Deploying image '#{app}:1(?!@)'/)
+      end
+
       expect(result[:stderr]).to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end
 
-  context "when release script is invalid" do
-    let!(:token) { Shell.cmd("cpln", "profile", "token", "default")[:output].strip }
-    let!(:upstream_app) { dummy_test_app }
-    let!(:app) { dummy_test_app("invalid-release-script") }
+  context "when release script is not provided" do
+    let(:app) { dummy_test_app("nothing") }
 
-    before do
-      stub_env("CPLN_UPSTREAM", upstream_app)
-      # Ideally, we should have a different org, but for testing purposes, this works
-      stub_env("CPLN_ORG_UPSTREAM", dummy_test_org)
-      stub_env("APP_NAME", app)
+    it_behaves_like "copies latest image from upstream and deploys image",
+                    runs_release_script: false,
+                    uses_digest_image_ref: false
 
-      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
-      run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
-      run_cpflow_command!("build-image", "-a", upstream_app)
-      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+    context "with use_digest_image_ref from YAML file" do
+      let(:app) { dummy_test_app("use-digest-image-ref") }
+
+      it_behaves_like "copies latest image from upstream and deploys image",
+                      runs_release_script: false,
+                      uses_digest_image_ref: true
     end
 
-    after do
-      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
-      run_cpflow_command!("delete", "-a", app, "--yes")
+    context "with --use-digest-image-ref option" do
+      let(:extra_args) { ["--use-digest-image-ref"] }
+
+      it_behaves_like "copies latest image from upstream and deploys image",
+                      runs_release_script: false,
+                      uses_digest_image_ref: true
+    end
+  end
+
+  context "when release script is invalid" do
+    let(:app) { dummy_test_app("invalid-release-script") }
+
+    before do
+      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
     it "copies latest image from upstream, fails to run release script and fails to deploy image", :slow do
@@ -71,37 +94,14 @@ describe Command::PromoteAppFromUpstream do
   end
 
   context "when release script is valid" do
-    let!(:token) { Shell.cmd("cpln", "profile", "token", "default")[:output].strip }
-    let!(:upstream_app) { dummy_test_app }
-    let!(:app) { dummy_test_app }
+    let(:app) { dummy_test_app }
 
     before do
-      stub_env("CPLN_UPSTREAM", upstream_app)
-      # Ideally, we should have a different org, but for testing purposes, this works
-      stub_env("CPLN_ORG_UPSTREAM", dummy_test_org)
-      stub_env("APP_NAME", app)
-
-      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
-      run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
-      run_cpflow_command!("build-image", "-a", upstream_app)
       run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
-    after do
-      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
-      run_cpflow_command!("delete", "-a", app, "--yes")
-    end
-
-    it "copies latest image from upstream, runs release script and deploys image", :slow do
-      result = run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
-
-      expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
-      expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
-      expect(result[:stderr]).to include("Running release script")
-      expect(result[:stderr]).to include("Finished running release script")
-      expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
-      expect(result[:stderr]).to match(%r{rails: https://rails-.+?.cpln.app})
-    end
+    it_behaves_like "copies latest image from upstream and deploys image",
+                    runs_release_script: true,
+                    uses_digest_image_ref: false
   end
 end

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -62,6 +62,14 @@ describe Command::PromoteAppFromUpstream do
       it_behaves_like "copies latest image from upstream and deploys image",
                       runs_release_script: false,
                       uses_digest_image_ref: true
+
+      context "with --no-use-digest-image-ref CLI flag overriding YAML" do
+        let(:extra_args) { ["--no-use-digest-image-ref"] }
+
+        it_behaves_like "copies latest image from upstream and deploys image",
+                        runs_release_script: false,
+                        uses_digest_image_ref: false
+      end
     end
 
     context "with --use-digest-image-ref option" do

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -35,12 +35,13 @@ describe Command::PromoteAppFromUpstream do
 
       if options[:runs_release_script]
         expect(result[:stderr]).to include("Running release script")
+        expect(result[:stderr]).to include("Finished running release script")
       else
         expect(result[:stderr]).not_to include("Running release script")
       end
 
       if options[:uses_digest_image_ref]
-        expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-fA-F0-9]{64}'/)
+        expect(result[:stderr]).to match(/Deploying image '#{app}:1@sha256:[a-f0-9]{64}'/)
       else
         expect(result[:stderr]).to match(/Deploying image '#{app}:1(?!@)'/)
       end

--- a/spec/command/promote_app_from_upstream_unit_spec.rb
+++ b/spec/command/promote_app_from_upstream_unit_spec.rb
@@ -64,6 +64,25 @@ describe Command::PromoteAppFromUpstream do
       end
     end
 
+    context "when the current app config has a release script and digest mode resolves to true" do
+      let(:current) { { release_script: "release.sh" } }
+      let(:use_digest_image_ref) { true }
+
+      it "forwards the release phase and digest flags" do
+        command.send(:deploy_image)
+
+        expect(command)
+          .to have_received(:run_cpflow_command)
+          .with(
+            "deploy-image",
+            "-a",
+            "test-app",
+            "--run-release-phase",
+            "--use-digest-image-ref"
+          )
+      end
+    end
+
     context "when the current app config is missing" do
       let(:current) { nil }
 

--- a/spec/command/promote_app_from_upstream_unit_spec.rb
+++ b/spec/command/promote_app_from_upstream_unit_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Command::PromoteAppFromUpstream do
+  describe "#deploy_image" do
+    let(:command) { described_class.new(config) }
+    let(:config) do
+      instance_double(
+        Config,
+        app: "test-app",
+        current: current,
+        options: options,
+        use_digest_image_ref?: use_digest_image_ref
+      )
+    end
+    let(:current) { {} }
+    let(:options) { {} }
+    let(:use_digest_image_ref) { false }
+
+    before do
+      allow(command).to receive(:run_cpflow_command)
+    end
+
+    it "omits digest flags when digest mode is unset" do
+      command.send(:deploy_image)
+
+      expect(command).to have_received(:run_cpflow_command).with("deploy-image", "-a", "test-app")
+    end
+
+    context "when digest mode is explicitly disabled" do
+      let(:options) { { use_digest_image_ref: false } }
+
+      it "forwards the explicit disable flag" do
+        command.send(:deploy_image)
+
+        expect(command)
+          .to have_received(:run_cpflow_command)
+          .with("deploy-image", "-a", "test-app", "--no-use-digest-image-ref")
+      end
+    end
+
+    context "when digest mode resolves to true" do
+      let(:use_digest_image_ref) { true }
+
+      it "forwards the enable flag" do
+        command.send(:deploy_image)
+
+        expect(command)
+          .to have_received(:run_cpflow_command)
+          .with("deploy-image", "-a", "test-app", "--use-digest-image-ref")
+      end
+    end
+
+    context "when the current app config has a release script" do
+      let(:current) { { release_script: "release.sh" } }
+
+      it "forwards the release phase flag" do
+        command.send(:deploy_image)
+
+        expect(command)
+          .to have_received(:run_cpflow_command)
+          .with("deploy-image", "-a", "test-app", "--run-release-phase")
+      end
+    end
+
+    context "when the current app config is missing" do
+      let(:current) { nil }
+
+      it "still invokes deploy-image without release phase" do
+        command.send(:deploy_image)
+
+        expect(command).to have_received(:run_cpflow_command).with("deploy-image", "-a", "test-app")
+      end
+    end
+  end
+end

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -4,12 +4,14 @@ require "spec_helper"
 
 describe Config do
   describe "#use_digest_image_ref?" do
-    let(:config) do
+    def build_config(options:, current:)
       instance = described_class.allocate
       instance.instance_variable_set(:@options, options)
       allow(instance).to receive(:current).and_return(current)
       instance
     end
+
+    let(:config) { build_config(options: options, current: current) }
 
     context "when CLI flag is true" do
       let(:options) { { use_digest_image_ref: true } }

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Config do
+  describe "#use_digest_image_ref?" do
+    let(:config) do
+      instance = described_class.allocate
+      instance.instance_variable_set(:@options, options)
+      allow(instance).to receive(:current).and_return(current)
+      instance
+    end
+
+    context "when CLI flag is true" do
+      let(:options) { { use_digest_image_ref: true } }
+      let(:current) { { use_digest_image_ref: false } }
+
+      it "returns true even if YAML is false" do
+        expect(config.use_digest_image_ref?).to be(true)
+      end
+    end
+
+    context "when CLI flag is false" do
+      let(:options) { { use_digest_image_ref: false } }
+      let(:current) { { use_digest_image_ref: true } }
+
+      it "returns false even if YAML is true" do
+        expect(config.use_digest_image_ref?).to be(false)
+      end
+    end
+
+    context "when CLI flag is absent" do
+      let(:options) { {} }
+
+      context "with YAML use_digest_image_ref set to true" do
+        let(:current) { { use_digest_image_ref: true } }
+
+        it "returns true" do
+          expect(config.use_digest_image_ref?).to be(true)
+        end
+      end
+
+      context "with YAML use_digest_image_ref set to false" do
+        let(:current) { { use_digest_image_ref: false } }
+
+        it "returns false" do
+          expect(config.use_digest_image_ref?).to be(false)
+        end
+      end
+
+      context "without use_digest_image_ref in YAML" do
+        let(:current) { {} }
+
+        it "returns false" do
+          expect(config.use_digest_image_ref?).to be(false)
+        end
+      end
+
+      context "without a current app config" do
+        let(:current) { nil }
+
+        it "returns false" do
+          expect(config.use_digest_image_ref?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/.controlplane/controlplane.yml
+++ b/spec/dummy/.controlplane/controlplane.yml
@@ -133,6 +133,13 @@ apps:
     upstream: dummy-test-upstream
     release_script: release-invalid.sh
 
+  dummy-test-use-digest-image-ref-{GLOBAL_IDENTIFIER}:
+    <<: *common
+
+    match_if_app_name_starts_with: true
+    upstream: dummy-test-upstream
+    use_digest_image_ref: true
+
   dummy-test-external-maintenance-image-{GLOBAL_IDENTIFIER}:
     <<: *common
 


### PR DESCRIPTION
### What does this PR do?

This PR:
1. Adds new `--use-digest-ref` option to `cpflow deploy image` command. If it's true then docker image's reference will include image's digest (SHA256 value)
2. Passes `--use-digest-ref` option to `cpflow deploy image` command by default for `cpflow promote-app-from-upstream` command

### Issue

https://github.com/shakacode/control-plane-flow/issues/232

### Tests

RSpec specific pipeline - https://github.com/shakacode/control-plane-flow/actions/runs/12348992443/job/34458894605

<img width="912" alt="image" src="https://github.com/user-attachments/assets/510ac097-39a2-41f0-9912-ba5c695f95ff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for deploying/promoting images by digest (configurable via use_digest_image_ref and CLI).
  - Added --docker-context option for image builds.

- **Bug Fixes**
  - Fixed command execution issues and failures preventing app deletion.

- **Documentation**
  - Docs and changelog updated to document digest-image behavior and pre-deletion hook.

- **Tests**
  - Added and reorganized tests covering digest-based deployment and promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->