### PR TITLE
Fix runner workload readiness logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Fixed
+
+- Fixed issue where `run` command could hang indefinitely when updating runner workload. [PR 260](https://github.com/shakacode/control-plane-flow/pull/260) by [Sergey Tarasov](https://github.com/dzirtusss).
+
 ## [4.1.1] - 2025-03-14
 
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -404,11 +404,12 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   # apply
-  def apply_template(data) # rubocop:disable Metrics/MethodLength
+  def apply_template(data, wait: false) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
     Tempfile.create do |f|
       f.write(data)
       f.rewind
       cmd = "cpln apply #{gvc_org} --file #{f.path}"
+      cmd += " --ready" if wait && ENV.fetch("DISABLE_APPLY_READY", nil).nil?
       if Shell.tmp_stderr
         cmd += " 2> #{Shell.tmp_stderr.path}" if Shell.should_hide_output?
 
@@ -429,8 +430,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def apply_hash(data)
-    apply_template(data.to_yaml)
+  def apply_hash(data, wait: false)
+    apply_template(data.to_yaml, wait: wait)
   end
 
   def parse_apply_result(result) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["HIDE_COMMAND_OUTPUT"] = "true"
 ENV["DISABLE_INTERRUPT_TRAP"] = "true"
 ENV["DISABLE_VALIDATIONS"] = "true"
+ENV["DISABLE_APPLY_READY"] = "true"
 
 require "rspec/retry"
 require "simplecov"


### PR DESCRIPTION
## Summary

- Fix runner workload update logic that could hang indefinitely
- Add `--ready` flag to `cpln apply` to ensure resources are ready before proceeding
- Remove redundant `wait_for_runner_workload_deploy` check (now handled by `--ready`)

### Problem

`cpln apply` for suspended cron workloads doesn't always update `lastProcessedVersion` in deployment status, causing the wait loop to hang indefinitely.

### Solution

Use `cpln apply --ready` flag which waits for the resource to be ready before returning, making the explicit wait check unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the run command could hang indefinitely when updating the runner workload.

* **New Behavior**
  * Deploy/apply operations now support readiness verification by default, ensuring readiness is checked before completion.

* **Chores / Tests**
  * Added an environment toggle to disable the readiness verification for test setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->