### PR TITLE
Redact sensitive data from trace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ _Please add entries here for your pull requests that have not yet been released.
 
 - Fixed issue where `run` command could hang indefinitely when updating runner workload. [PR 260](https://github.com/shakacode/control-plane-flow/pull/260) by [Sergey Tarasov](https://github.com/dzirtusss).
 
+### Changed
+
+- Redact sensitive data (Authorization headers, tokens) from `--trace` output. [PR 261](https://github.com/shakacode/control-plane-flow/pull/261) by [Sergey Tarasov](https://github.com/dzirtusss).
+
 ## [4.1.1] - 2025-03-14
 
 

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -25,7 +25,7 @@ class Config # rubocop:disable Metrics/ClassLength
     return unless trace_mode
 
     ControlplaneApiDirect.trace = trace_mode
-    Shell.warn("Trace mode is enabled, this will print sensitive information to the console.")
+    Shell.warn("Trace mode is enabled. Sensitive data is redacted, but please review output before sharing.")
   end
 
   def org


### PR DESCRIPTION
## Summary

- Add `RedactedDebugOutput` class to filter sensitive data from `--trace` output
- Whitelist safe headers (Content-Type, Host, etc.) and redact all others
- Redact long token-like strings (50+ chars) in request/response bodies
- Update trace warning message to reflect that sensitive data is now redacted

### Before

```
Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6...
```

### After

```
Authorization: [REDACTED]
```