### PR TITLE
[codex] Trigger docs site rebuilds

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -9,6 +9,11 @@ on:
       - CONTRIBUTING.md
       - docs/**
   workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for forcing a docs rebuild"
+        required: false
+        default: "manual"
     # Non-main manual dispatches are skipped by the job guard below.
     # Only use this for forcing a rebuild from main.
 
@@ -38,9 +43,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
-          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}}'
+          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "reason": ${{ toJSON(inputs.reason || github.event_name) }}}'
 
       - name: Summarize docs dispatch
+        if: success()
         run: |
           {
             echo "### Docs site dispatch"
@@ -48,6 +54,7 @@ jobs:
             echo "- Event type: \`docs-updated\`"
             echo "- Source ref: \`${{ github.ref }}\`"
             echo "- Source SHA: \`${{ github.sha }}\`"
+            echo "- Reason: \`${{ inputs.reason || github.event_name }}\`"
             echo
             echo "Check the target repository workflow runs for downstream rebuild status."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 5
     steps:
-      - uses: actions/create-github-app-token@v1
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
@@ -19,9 +22,9 @@ jobs:
           owner: shakacode
           repositories: controlplaneflow-com
 
-      - uses: peter-evans/repository-dispatch@v3
+      - name: Dispatch docs-updated event
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
-

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -9,7 +9,7 @@ on:
       - CONTRIBUTING.md
       - docs/**
   workflow_dispatch:
-    # Dispatching from a non-main branch sends a non-main sha/ref in the payload.
+    # Non-main manual dispatches are skipped by the job guard below.
     # Only use this for forcing a rebuild from main.
 
 concurrency:
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     permissions: {}
     timeout-minutes: 5
     steps:

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: docs-dispatch
-  cancel-in-progress: true
+  cancel-in-progress: true  # only the most recent docs dispatch matters
 
 jobs:
   notify-docs-site:
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
@@ -28,7 +28,7 @@ jobs:
           repositories: controlplaneflow-com
 
       - name: Dispatch docs-updated event
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -9,6 +9,8 @@ on:
       - CONTRIBUTING.md
       - docs/**
   workflow_dispatch:
+    # Dispatching from a non-main branch sends a non-main sha/ref in the payload.
+    # Only use this for forcing a rebuild from main.
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -19,6 +19,8 @@ on:
     # Only use this for forcing a rebuild from main.
 
 concurrency:
+  # Include the ref so accidental non-main manual runs cannot cancel a main dispatch
+  # before the job guard skips them.
   group: ${{ github.workflow }}-${{ github.ref }}
   # Only the most recent docs dispatch for the same ref matters.
   # See CONTRIBUTING.md for manual cancellation/retry guidance.
@@ -63,6 +65,8 @@ jobs:
           DISPATCH_SHA: ${{ github.sha }}
         run: |
           safe_dispatch_reason=${DISPATCH_REASON//[^a-zA-Z0-9 _.\/-]/}
+          # Ref and SHA come from GitHub; the job guard restricts ref to main,
+          # and the SHA is the triggering commit id.
           {
             echo "### Docs site dispatch"
             echo "- Target repository: \`shakacode/controlplaneflow-com\`"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - README.md
+      - CHANGELOG.md
+      - CONTRIBUTING.md
       - docs/**
   workflow_dispatch: {}
 
 concurrency:
-  group: docs-dispatch
+  group: ${{ github.workflow }}
   cancel-in-progress: true  # only the most recent docs dispatch matters
 
 jobs:

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -1,4 +1,5 @@
 name: Trigger docs site rebuild
+run-name: Docs dispatch (${{ github.event_name == 'workflow_dispatch' && inputs.reason || github.event_name }}) @ ${{ github.sha }}
 
 on:
   push:
@@ -61,13 +62,14 @@ jobs:
           DISPATCH_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
         run: |
+          safe_dispatch_reason=${DISPATCH_REASON//\`/}
           {
             echo "### Docs site dispatch"
             echo "- Target repository: \`shakacode/controlplaneflow-com\`"
             echo "- Event type: \`docs-updated\`"
             echo "- Source ref: \`${DISPATCH_REF}\`"
             echo "- Source SHA: \`${DISPATCH_SHA}\`"
-            echo "- Reason: \`${DISPATCH_REASON}\`"
+            echo "- Reason: \`${safe_dispatch_reason}\`"
             echo "- Dispatch outcome: \`${DISPATCH_OUTCOME}\`"
             echo
             if [ "$DISPATCH_OUTCOME" = "success" ]; then

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -35,5 +35,4 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
-          client-payload: >-
-            {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}}
+          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}}'

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - README.md
       - docs/**
+  workflow_dispatch: {}
+
+concurrency:
+  group: docs-dispatch
+  cancel-in-progress: true
 
 jobs:
   notify-docs-site:
@@ -28,3 +33,4 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
+          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}'

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -71,7 +71,7 @@ jobs:
             if [ "$DISPATCH_OUTCOME" = "success" ]; then
               echo "Check the target repository workflow runs for downstream rebuild status."
             elif [ "$DISPATCH_OUTCOME" = "skipped" ]; then
-              echo "Dispatch was skipped because the ref is not main or a prior step failed."
+              echo "Dispatch was skipped because a prior step did not complete successfully."
             else
               echo "Inspect this job's logs before checking the target repository workflow runs."
             fi

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -44,7 +44,12 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
-          client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "reason": ${{ toJSON(inputs.reason || github.event_name) }}}'
+          client-payload: |
+            {
+              "sha": ${{ toJSON(github.sha) }},
+              "ref": ${{ toJSON(github.ref) }},
+              "reason": ${{ toJSON(inputs.reason || github.event_name) }}
+            }
 
       - name: Summarize docs dispatch
         if: always()

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -18,8 +18,8 @@ on:
     # Only use this for forcing a rebuild from main.
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true  # only the most recent docs dispatch matters
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true  # only the most recent docs dispatch for the same ref matters
 
 jobs:
   notify-docs-site:
@@ -38,6 +38,7 @@ jobs:
           repositories: controlplaneflow-com
 
       - name: Dispatch docs-updated event
+        id: dispatch
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -46,8 +47,9 @@ jobs:
           client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}, "reason": ${{ toJSON(inputs.reason || github.event_name) }}}'
 
       - name: Summarize docs dispatch
-        if: success()
+        if: always()
         env:
+          DISPATCH_OUTCOME: ${{ steps.dispatch.outcome || 'not-run' }}
           DISPATCH_REASON: ${{ inputs.reason || github.event_name }}
           DISPATCH_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
@@ -59,6 +61,11 @@ jobs:
             echo "- Source ref: \`${DISPATCH_REF}\`"
             echo "- Source SHA: \`${DISPATCH_SHA}\`"
             echo "- Reason: \`${DISPATCH_REASON}\`"
+            echo "- Dispatch outcome: \`${DISPATCH_OUTCOME}\`"
             echo
-            echo "Check the target repository workflow runs for downstream rebuild status."
+            if [ "$DISPATCH_OUTCOME" = "success" ]; then
+              echo "Check the target repository workflow runs for downstream rebuild status."
+            else
+              echo "Inspect this job's logs before checking the target repository workflow runs."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Summarize docs dispatch
         if: always()
         env:
-          DISPATCH_OUTCOME: ${{ steps.dispatch.outcome || 'not-run' }}
+          DISPATCH_OUTCOME: ${{ steps.dispatch.outcome }}
           DISPATCH_REASON: ${{ inputs.reason || github.event_name }}
           DISPATCH_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
@@ -70,6 +70,8 @@ jobs:
             echo
             if [ "$DISPATCH_OUTCOME" = "success" ]; then
               echo "Check the target repository workflow runs for downstream rebuild status."
+            elif [ "$DISPATCH_OUTCOME" = "skipped" ]; then
+              echo "Dispatch was skipped because the ref is not main or a prior step failed."
             else
               echo "Inspect this job's logs before checking the target repository workflow runs."
             fi

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -1,0 +1,27 @@
+name: Trigger docs site rebuild
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - README.md
+      - docs/**
+
+jobs:
+  notify-docs-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.DOCS_DISPATCH_APP_KEY }}
+          owner: shakacode
+          repositories: controlplaneflow-com
+
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: shakacode/controlplaneflow-com
+          event-type: docs-updated
+

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -33,4 +33,5 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
-          client-payload: '{"sha": "${{ github.sha }}", "ref": "${{ github.ref }}"}'
+          client-payload: >-
+            {"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}}

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -72,7 +72,9 @@ jobs:
               echo "Check the target repository workflow runs for downstream rebuild status."
             elif [ "$DISPATCH_OUTCOME" = "skipped" ]; then
               echo "Dispatch was skipped because a prior step did not complete successfully."
+            elif [ "$DISPATCH_OUTCOME" = "failure" ]; then
+              echo "Dispatch step failed. Inspect this job's logs and verify the App token has Contents: Write on the target repo."
             else
-              echo "Inspect this job's logs before checking the target repository workflow runs."
+              echo "Dispatch outcome: ${DISPATCH_OUTCOME}. Inspect this job's logs before checking the target repository workflow runs."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -20,7 +20,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Only the most recent docs dispatch for the same ref matters.
-  # Re-run a canceled manual dispatch if another main run does not replace it.
+  # Manually re-trigger a canceled manual dispatch if no main run replaces it.
   cancel-in-progress: true
 
 jobs:
@@ -76,6 +76,8 @@ jobs:
               echo "Dispatch was skipped because a prior step did not complete successfully."
             elif [ "$DISPATCH_OUTCOME" = "failure" ]; then
               echo "Dispatch step failed. Inspect this job's logs and verify the App token has Contents: Write on the target repo."
+            elif [ "$DISPATCH_OUTCOME" = "cancelled" ]; then
+              echo "Dispatch was cancelled by a newer run for the same ref. The newer run will dispatch instead."
             else
               echo "Dispatch outcome: ${DISPATCH_OUTCOME}. Inspect this job's logs before checking the target repository workflow runs."
             fi

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -62,7 +62,7 @@ jobs:
           DISPATCH_REF: ${{ github.ref }}
           DISPATCH_SHA: ${{ github.sha }}
         run: |
-          safe_dispatch_reason=${DISPATCH_REASON//\`/}
+          safe_dispatch_reason=${DISPATCH_REASON//[^a-zA-Z0-9 _.\/-]/}
           {
             echo "### Docs site dispatch"
             echo "- Target repository: \`shakacode/controlplaneflow-com\`"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -8,7 +8,7 @@ on:
       - CHANGELOG.md
       - CONTRIBUTING.md
       - docs/**
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -47,14 +47,18 @@ jobs:
 
       - name: Summarize docs dispatch
         if: success()
+        env:
+          DISPATCH_REASON: ${{ inputs.reason || github.event_name }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
         run: |
           {
             echo "### Docs site dispatch"
             echo "- Target repository: \`shakacode/controlplaneflow-com\`"
             echo "- Event type: \`docs-updated\`"
-            echo "- Source ref: \`${{ github.ref }}\`"
-            echo "- Source SHA: \`${{ github.sha }}\`"
-            echo "- Reason: \`${{ inputs.reason || github.event_name }}\`"
+            echo "- Source ref: \`${DISPATCH_REF}\`"
+            echo "- Source SHA: \`${DISPATCH_SHA}\`"
+            echo "- Reason: \`${DISPATCH_REASON}\`"
             echo
             echo "Check the target repository workflow runs for downstream rebuild status."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -20,7 +20,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Only the most recent docs dispatch for the same ref matters.
-  # Manually re-trigger a canceled manual dispatch if no main run replaces it.
+  # See CONTRIBUTING.md for manual cancellation/retry guidance.
   cancel-in-progress: true
 
 jobs:
@@ -77,7 +77,7 @@ jobs:
             elif [ "$DISPATCH_OUTCOME" = "failure" ]; then
               echo "Dispatch step failed. Inspect this job's logs and verify the App token has Contents: Write on the target repo."
             elif [ "$DISPATCH_OUTCOME" = "cancelled" ]; then
-              echo "Dispatch was cancelled by a newer run for the same ref. The newer run will dispatch instead."
+              echo "Dispatch step was interrupted mid-execution. Check the target repo's workflow runs because the event may or may not have been received."
             else
               echo "Dispatch outcome: ${DISPATCH_OUTCOME}. Inspect this job's logs before checking the target repository workflow runs."
             fi

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -39,3 +39,15 @@ jobs:
           repository: shakacode/controlplaneflow-com
           event-type: docs-updated
           client-payload: '{"sha": ${{ toJSON(github.sha) }}, "ref": ${{ toJSON(github.ref) }}}'
+
+      - name: Summarize docs dispatch
+        run: |
+          {
+            echo "### Docs site dispatch"
+            echo "- Target repository: \`shakacode/controlplaneflow-com\`"
+            echo "- Event type: \`docs-updated\`"
+            echo "- Source ref: \`${{ github.ref }}\`"
+            echo "- Source SHA: \`${{ github.sha }}\`"
+            echo
+            echo "Check the target repository workflow runs for downstream rebuild status."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -19,12 +19,14 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true  # only the most recent docs dispatch for the same ref matters
+  # Only the most recent docs dispatch for the same ref matters.
+  # Re-run a canceled manual dispatch if another main run does not replace it.
+  cancel-in-progress: true
 
 jobs:
   notify-docs-site:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'  # skip non-main workflow_dispatch runs
     permissions: {}
     timeout-minutes: 5
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ It requires these repository secrets:
 - `DOCS_DISPATCH_APP_ID`: the GitHub App ID used to create the dispatch token
 - `DOCS_DISPATCH_APP_KEY`: the GitHub App private key PEM for that app
 
-The app must be installed on `shakacode/controlplaneflow-com` with **Contents: Write** permission, which is the minimum
-permission required to create `repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild,
-check the target repo's workflow runs for the matching `docs-updated` event.
+GitHub documents the repository dispatch endpoint as requiring **Contents: Write** for GitHub App installation tokens.
+Install the app on `shakacode/controlplaneflow-com` with that permission. If the dispatch succeeds but the docs site does
+not rebuild, check the target repo's workflow runs for the matching `docs-updated` event.
 
 Manual runs should be started from `main`; non-main manual dispatches are skipped before token generation or docs-site
 notification. The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ It requires these repository secrets:
 - `DOCS_DISPATCH_APP_ID`: the GitHub App ID used to create the dispatch token
 - `DOCS_DISPATCH_APP_KEY`: the GitHub App private key PEM for that app
 
-The app must be installed with access to `shakacode/controlplaneflow-com` and enough permission to create
-`repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild, check the target repo's
-workflow runs for the matching `docs-updated` event.
+The app must be installed on `shakacode/controlplaneflow-com` with **Contents: Write** permission, which is the minimum
+permission required to create `repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild,
+check the target repo's workflow runs for the matching `docs-updated` event.
 
 Manual runs should be started from `main`; non-main manual dispatches are skipped before notifying the docs site. The
 workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be superseded by a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,11 @@ If the job fails and the summary shows `Dispatch outcome: skipped`, the dispatch
 failed. Check the `Generate GitHub App token` step first, including the App ID, private key secret, installation, and target
 repository permissions.
 
+If a manual dispatch is canceled and no later successful `main` run replaces it, re-trigger the manual run from `main`. If
+the run is canceled while the dispatch step is already executing, the target repo may already have received the event; check
+the target repo workflow runs before re-triggering. Duplicate dispatches are harmless, but they can rebuild the docs site
+twice.
+
 ## Testing
 
 We use real apps for the tests. You'll need to have full access to a Control Plane org, and then set it as the env var `CPLN_ORG` when running the tests (or in the `.env` file):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ The app must be installed with access to `shakacode/controlplaneflow-com` and en
 `repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild, check the target repo's
 workflow runs for the matching `docs-updated` event.
 
-Manual runs should be started from `main`. Choosing another branch sends that branch's `sha` and `ref` to the docs site.
-The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be superseded by a
+Manual runs should be started from `main`; non-main manual dispatches are skipped before notifying the docs site. The
+workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be superseded by a
 concurrent push to `main`; that is expected because the newest docs state wins.
 
 ## Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,9 @@ The app must be installed on `shakacode/controlplaneflow-com` with **Contents: W
 permission required to create `repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild,
 check the target repo's workflow runs for the matching `docs-updated` event.
 
-Manual runs should be started from `main`; non-main manual dispatches are skipped before notifying the docs site. The
-workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be superseded by a
-concurrent push to `main`; that is expected because the newest docs state wins.
+Manual runs should be started from `main`; non-main manual dispatches are skipped before token generation or docs-site
+notification. The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be
+superseded by a concurrent push to `main`; that is expected because the newest docs state wins.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,18 @@ gem install overcommit
 overcommit --install
 ```
 
+## Docs Site Dispatch
+
+The `trigger-docs-site.yml` workflow notifies `shakacode/controlplaneflow-com` when docs-related files change on `main`.
+It requires these repository secrets:
+
+- `DOCS_DISPATCH_APP_ID`: the GitHub App ID used to create the dispatch token
+- `DOCS_DISPATCH_APP_KEY`: the GitHub App private key PEM for that app
+
+The app must be installed with access to `shakacode/controlplaneflow-com` and enough permission to create
+`repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild, check the target repo's
+workflow runs for the matching `docs-updated` event.
+
 ## Testing
 
 We use real apps for the tests. You'll need to have full access to a Control Plane org, and then set it as the env var `CPLN_ORG` when running the tests (or in the `.env` file):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,12 @@ rebuild, check the target repo's workflow runs for the matching `docs-updated` e
 
 Manual runs should be started from `main`; non-main manual dispatches are skipped before token generation or docs-site
 notification. The GitHub Actions run can therefore finish without dispatching anything when a non-main ref is selected.
-The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be
-superseded by a concurrent push to `main`; that is expected because the newest docs state wins.
+The workflow deduplicates runs by workflow and ref with `cancel-in-progress: true`, so consecutive `main` runs can
+supersede one another; that is expected because the newest docs state wins.
+
+If the job fails and the summary shows `Dispatch outcome: skipped`, the dispatch step did not run because an earlier step
+failed. Check the `Generate GitHub App token` step first, including the App ID, private key secret, installation, and target
+repository permissions.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,10 @@ The app must be installed with access to `shakacode/controlplaneflow-com` and en
 `repository_dispatch` events. If the dispatch succeeds but the docs site does not rebuild, check the target repo's
 workflow runs for the matching `docs-updated` event.
 
+Manual runs should be started from `main`. Choosing another branch sends that branch's `sha` and `ref` to the docs site.
+The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be superseded by a
+concurrent push to `main`; that is expected because the newest docs state wins.
+
 ## Testing
 
 We use real apps for the tests. You'll need to have full access to a Control Plane org, and then set it as the env var `CPLN_ORG` when running the tests (or in the `.env` file):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,14 @@ It requires these repository secrets:
 - `DOCS_DISPATCH_APP_ID`: the GitHub App ID used to create the dispatch token
 - `DOCS_DISPATCH_APP_KEY`: the GitHub App private key PEM for that app
 
-GitHub documents the repository dispatch endpoint as requiring **Contents: Write** for GitHub App installation tokens.
-Install the app on `shakacode/controlplaneflow-com` with that permission. If the dispatch succeeds but the docs site does
-not rebuild, check the target repo's workflow runs for the matching `docs-updated` event.
+GitHub's REST docs for the repository dispatch endpoint list **Contents: Write** as the required repository permission for
+GitHub App installation tokens. This is separate from **Actions: Write**, which is used by other workflow APIs. Install
+the app on `shakacode/controlplaneflow-com` with **Contents: Write**. If the dispatch succeeds but the docs site does not
+rebuild, check the target repo's workflow runs for the matching `docs-updated` event.
 
 Manual runs should be started from `main`; non-main manual dispatches are skipped before token generation or docs-site
-notification. The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be
+notification. The GitHub Actions run can therefore finish without dispatching anything when a non-main ref is selected.
+The workflow also uses a single concurrency group with `cancel-in-progress: true`, so a manual run can be
 superseded by a concurrent push to `main`; that is expected because the newest docs state wins.
 
 ## Testing

--- a/spec/command/latest_image_spec.rb
+++ b/spec/command/latest_image_spec.rb
@@ -14,7 +14,7 @@ describe Command::LatestImage do
     end
   end
 
-  context "when images have been built" do
+  context "when images have been built", :slow do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     it "displays latest image for app" do


### PR DESCRIPTION
## Summary
- add the docs site dispatch workflow for control-plane-flow
- notify shakacode/controlplaneflow-com with the docs-updated event when README.md, CHANGELOG.md, CONTRIBUTING.md, or docs/** changes on main
- intentionally pin the dispatch actions by SHA because this workflow handles GitHub App credentials and cross-repo dispatch

## Validation
- actionlint .github/workflows/trigger-docs-site.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that uses GitHub App credentials to trigger a cross-repository `repository_dispatch`, which can fail or be misconfigured and involves sensitive secrets/permissions. Runtime code is unaffected aside from a minor test-tag change.
> 
> **Overview**
> Adds a new `trigger-docs-site.yml` GitHub Actions workflow that, on docs-related changes to `main` (or manual dispatch), generates a GitHub App installation token and sends a `repository_dispatch` (`docs-updated`) to `shakacode/controlplaneflow-com`, with concurrency deduping and a run summary for troubleshooting.
> 
> Documents required secrets/permissions and operational guidance in `CONTRIBUTING.md`, and tags the "images have been built" scenario in `latest_image_spec` as `:slow` so it can be excluded from fast test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f37feee498ed761b121c104e1c42a6c3985bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated documentation site rebuild when documentation files are updated on the main branch.

* **Documentation**
  * Added workflow documentation and troubleshooting guidance in contribution guidelines.

* **Tests**
  * Optimized test categorization with performance tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/280)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->