### PR TITLE
[codex] Document update changelog release command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,6 @@ cpflow test
 
 ## Releasing
 
-See [Releasing the Gem](./docs/releasing.md) for the changelog-first Ruby gem release process. In short: merge the
-versioned changelog section first, then run `bundle exec rake release`. This project releases only the `cpflow`
-RubyGem; there is no npm publishing step.
+See [Releasing the Gem](./docs/releasing.md) for the changelog-first Ruby gem release process. In short: run
+`/update-changelog release`, merge the generated changelog PR, then run `bundle exec rake release`. This project
+releases only the `cpflow` RubyGem; there is no npm publishing step.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -10,19 +10,29 @@ the React on Rails release flow but without any npm publishing steps.
 Always update `CHANGELOG.md` before running the release task.
 
 1. Ensure all desired changes are merged to `main`.
-2. Move the relevant `Unreleased` entries into a versioned header:
+2. Run `/update-changelog release` to find merged PRs, add entries under the
+   right headings, compute the next version, stamp the version header, update
+   compare links, and open a changelog PR. Use `/update-changelog rc`,
+   `/update-changelog beta`, or an explicit version like
+   `/update-changelog 4.2.0.rc.1` when preparing a prerelease or fixed target
+   version.
+3. Review the generated changelog PR and verify the version number matches the
+   intended release level:
+   - Breaking changes: major
+   - Added features or enhancements: minor
+   - Fixes, improvements, deprecations, removals, or security updates: patch
+4. Merge the changelog PR before releasing.
+
+If updating the changelog manually, move the relevant `Unreleased` entries into
+a versioned header:
 
    ```markdown
    ## [4.2.0] - 2026-05-05
    ```
 
-3. Verify the version number matches the intended release level:
-   - Breaking changes: major
-   - Added features or enhancements: minor
-   - Fixes, improvements, deprecations, removals, or security updates: patch
-4. Update the compare links at the bottom of `CHANGELOG.md`, including the
-   `Unreleased` link and the new version link.
-5. Commit, push, review, and merge the changelog update before releasing.
+Then update the compare links at the bottom of `CHANGELOG.md`, including the
+`Unreleased` link and the new version link, and merge those changelog changes
+before releasing.
 
 The release task reads the latest versioned `CHANGELOG.md` header and can create
 the GitHub release from that section automatically.


### PR DESCRIPTION
## Summary

- Add the missing `/update-changelog release` command to the gem release process.
- Document prerelease and explicit-version variants for changelog generation.
- Update the short contributing release pointer to mention the changelog command.

## Test Plan

- `git diff --check`
- `bundle exec rake check_command_docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change that updates the documented gem release workflow; no runtime behavior is modified.
> 
> **Overview**
> Updates the documented gem release process to explicitly require running `/update-changelog release` *before* `bundle exec rake release`, and adjusts `CONTRIBUTING.md` to match.
> 
> Expands `docs/releasing.md` with guidance on prerelease and explicit-version variants (`rc`, `beta`, or a pinned version) and clarifies the manual fallback steps for updating `CHANGELOG.md` and compare links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5aebf073bd9b01d9124b7ebe87bc86663bb2298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->