### PR TITLE
[codex] Document Control Plane service templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ For the typical Rails app, this means:
 | --------------- | -------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | web traffic     | `rails`, `sinatra`   | `web` dyno    | workload with app image                                                                                           |
 | background jobs | `sidekiq`, `resque`  | `worker` dyno | workload with app image                                                                                           |
-| db              | `postgres`, `mysql`  | add-on        | external provider or can be set up for development/testing with Docker image (lacks persistence between restarts) |
-| in-memory db    | `redis`, `memcached` | add-on        | external provider or can be set up for development/testing with Docker image (lacks persistence between restarts) |
+| db              | `postgres`, `mysql`  | add-on        | external provider, Control Plane Template Catalog, or a development/testing workload template                        |
+| in-memory db    | `redis`, `memcached` | add-on        | external provider, Control Plane Template Catalog, or a development/testing workload template                        |
 | others          | `mailtrap`           | add-on        | external provider or can be set up for development/testing with Docker image (lacks persistence between restarts) |
 
 ## Migration Strategy
@@ -493,8 +493,10 @@ aws-rds-single-pg-instance
   mydb-review-333
 ```
 
-Additionally, we provide a default `postgres` template in this repository optimized for Control Plane and suitable for
-development purposes.
+If you want to run PostgreSQL on Control Plane instead of keeping a Heroku add-on or moving to RDS, review the
+[Control Plane PostgreSQL template](https://shakadocs.controlplane.com/template-catalog/templates/postgres). It includes
+persistent storage and optional scheduled backups. Additionally, we provide a default `postgres` template in this
+repository optimized for Control Plane and suitable for development purposes.
 
 ## In-memory Databases
 
@@ -503,7 +505,9 @@ E.g., Redis, Memcached.
 For development purposes, it's useful to set those up as Control Plane workloads, as in most cases, they don't keep any
 valuable data and can be safely restarted, which doesn't affect application performance.
 
-For production purposes or where restarts are not an option, you should use external cloud services.
+For production purposes or where restarts are not an option, you should use an external cloud service or review the
+[Control Plane Redis template](https://shakadocs.controlplane.com/template-catalog/templates/redis), which includes
+master-replica deployment, Redis Sentinel, optional persistent storage, and optional backups.
 
 We provide default `redis` and `memcached` templates in this repository optimized for Control Plane and suitable for
 development purposes.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ For the typical Rails app, this means:
 | --------------- | -------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------- |
 | web traffic     | `rails`, `sinatra`   | `web` dyno    | workload with app image                                                                                           |
 | background jobs | `sidekiq`, `resque`  | `worker` dyno | workload with app image                                                                                           |
-| db              | `postgres`, `mysql`  | add-on        | external provider, Control Plane Template Catalog, or a development/testing workload template                        |
-| in-memory db    | `redis`, `memcached` | add-on        | external provider, Control Plane Template Catalog, or a development/testing workload template                        |
+| db              | `postgres`, `mysql`  | add-on        | external provider, [Control Plane Template Catalog](https://shakadocs.controlplane.com/template-catalog/templates/postgres), or a development/testing workload template |
+| in-memory db    | `redis`, `memcached` | add-on        | external provider, [Control Plane Template Catalog](https://shakadocs.controlplane.com/template-catalog/templates/redis), or a development/testing workload template |
 | others          | `mailtrap`           | add-on        | external provider or can be set up for development/testing with Docker image (lacks persistence between restarts) |
 
 ## Migration Strategy
@@ -494,7 +494,7 @@ aws-rds-single-pg-instance
 ```
 
 If you want to run PostgreSQL on Control Plane instead of keeping a Heroku add-on or moving to RDS, review the
-[Control Plane PostgreSQL template](https://shakadocs.controlplane.com/template-catalog/templates/postgres). It includes
+[Control Plane PostgreSQL Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/postgres). It includes
 persistent storage and optional scheduled backups. Additionally, we provide a default `postgres` template in this
 repository optimized for Control Plane and suitable for development purposes.
 
@@ -506,7 +506,7 @@ For development purposes, it's useful to set those up as Control Plane workloads
 valuable data and can be safely restarted, which doesn't affect application performance.
 
 For production purposes or where restarts are not an option, you should use an external cloud service or review the
-[Control Plane Redis template](https://shakadocs.controlplane.com/template-catalog/templates/redis), which includes
+[Control Plane Redis Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/redis), which includes
 master-replica deployment, Redis Sentinel, optional persistent storage, and optional backups.
 
 We provide default `redis` and `memcached` templates in this repository optimized for Control Plane and suitable for

--- a/docs/migrating-heroku-to-control-plane.md
+++ b/docs/migrating-heroku-to-control-plane.md
@@ -21,8 +21,7 @@ add-ons to Control Plane later once the app works as expected.
 
 If you are ready to replace Heroku add-ons as part of the migration, review the Control Plane Template Catalog options for
 [PostgreSQL](https://shakadocs.controlplane.com/template-catalog/templates/postgres) and
-[Redis](https://shakadocs.controlplane.com/template-catalog/templates/redis). They are especially useful when you are coming
-from an environment where managed database and Redis add-ons were already provisioned for you.
+[Redis](https://shakadocs.controlplane.com/template-catalog/templates/redis).
 
 First, create a new Heroku app with all the add-ons, copying the data from the current staging app.
 

--- a/docs/migrating-heroku-to-control-plane.md
+++ b/docs/migrating-heroku-to-control-plane.md
@@ -19,6 +19,11 @@ without compromising your current environment.
 Consider migrating just the web dyno first, and get other types of dynos working afterward. You can also move the
 add-ons to Control Plane later once the app works as expected.
 
+If you are ready to replace Heroku add-ons as part of the migration, review the Control Plane Template Catalog options for
+[PostgreSQL](https://shakadocs.controlplane.com/template-catalog/templates/postgres) and
+[Redis](https://shakadocs.controlplane.com/template-catalog/templates/redis). They are especially useful when you are coming
+from an environment where managed database and Redis add-ons were already provisioned for you.
+
 First, create a new Heroku app with all the add-ons, copying the data from the current staging app.
 
 Then, copy project-specific configs to a `.controlplane/` directory at the top of your project. `cpflow` will pick those up
@@ -236,11 +241,19 @@ For the review app resources, these should be handled as env vars in the templat
 Notice that `APP_GVC` is the app name, which is used as the database name on RDS, so that each review app gets its own
 database on the one RDS instance used for all review apps, which would be, e.g., `my-app-review-1234`.
 
+For teams that prefer a Control Plane-hosted PostgreSQL workload over RDS for some environments, see the
+[PostgreSQL Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/postgres) for the current
+supported template, storage, PgBouncer, and backup options.
+
 ### Redis and Memcached for Review Apps
 
 So long as no persistence is needed for Redis and Memcached, we have templates for workloads that should be sufficient
 for review apps in the `templates/` directory of this repository. Using these templates results in considerable cost
 savings compared to paying for the resources on Heroku.
+
+For Redis environments that need more than the simple review-app template, see the
+[Redis Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/redis) for Sentinel, persistence,
+public access, and backup options.
 
 ```yaml
 - name: MEMCACHE_SERVERS

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -2,7 +2,7 @@
 
 If you are replacing Heroku Postgres or another pre-provisioned database service, also review the
 [Control Plane PostgreSQL Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/postgres). The
-catalog template covers a single-replica PostgreSQL workload with persistent storage, optional PgBouncer, and optional
+catalog template covers a single-instance PostgreSQL workload with persistent storage, optional PgBouncer, and optional
 scheduled backups.
 
 One of the biggest problems that will appear when moving from Heroku infrastructure is migrating the database. And

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -1,5 +1,10 @@
 # Migrating Postgres database from Heroku infrastructure
 
+If you are replacing Heroku Postgres or another pre-provisioned database service, also review the
+[Control Plane PostgreSQL Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/postgres). The
+catalog template covers a single-replica PostgreSQL workload with persistent storage, optional PgBouncer, and optional
+scheduled backups.
+
 One of the biggest problems that will appear when moving from Heroku infrastructure is migrating the database. And
 despite it being rather easy if done between Heroku-hosted databases or non-Heroku-hosted databases (as Postgres has
 tools to do that naturally) it is not easily possible between Heroku and anything outside Heroku,

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -3,6 +3,8 @@
 If you are replacing a Heroku Redis add-on or another pre-provisioned Redis service, also review the
 [Control Plane Redis Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/redis). The catalog
 template covers a Redis master-replica deployment with Redis Sentinel, optional persistent storage, and optional backups.
+It is the better fit when you need Redis Sentinel, public endpoint access, or backup options beyond what the `redis` and
+`redis2` repo templates provide.
 
 There are two templates examples in this repo:
 - `redis` - basic non-persistent template. It is good for review-apps or staging or where no persistence is required

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,5 +1,9 @@
 # Migrating Redis databases
 
+If you are replacing a Heroku Redis add-on or another pre-provisioned Redis service, also review the
+[Control Plane Redis Template Catalog page](https://shakadocs.controlplane.com/template-catalog/templates/redis). The catalog
+template covers a Redis master-replica deployment with Redis Sentinel, optional persistent storage, and optional backups.
+
 There are two templates examples in this repo:
 - `redis` - basic non-persistent template. It is good for review-apps or staging or where no persistence is required
 - `redis2` - basic persistent template. Good for production where persistence is needed, but cluster is overkill.


### PR DESCRIPTION
## Summary

This updates the Heroku migration docs to point database and Redis users to the Control Plane Template Catalog. It adds PostgreSQL and Redis catalog links in the README, migration guide, and dedicated migration pages while preserving the affiliate-safe `shakadocs.controlplane.com` host.

## Checks

- `git diff --check origin/main...`
- `./script/check_cpln_links README.md docs/migrating-heroku-to-control-plane.md docs/redis.md docs/postgres.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add/clarify links to the Control Plane Template Catalog; no runtime or configuration behavior changes.
> 
> **Overview**
> Updates the Heroku migration docs to explicitly point database and Redis users to the **Control Plane Template Catalog**.
> 
> Clarifies in `README.md` and `docs/migrating-heroku-to-control-plane.md` that Postgres/Redis can be provided either externally or via catalog-backed templates (with notes about persistence/backups/Sentinel), and adds short catalog references to the dedicated `docs/postgres.md` and `docs/redis.md` pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df8f4ec71d8e85035bef4ff185e46c836b89cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->