### PR TITLE
[codex] Fix generator edge cases and review workflows

### DIFF
--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -94,6 +94,7 @@ module Command
       command = normalized_asset_precompile_hook_command
       return "" unless command
 
+      # Folded YAML scalars carry a trailing newline even when they hold one command.
       stripped = command.strip
       return "" if stripped.empty?
       return "" unless single_line_asset_precompile_hook?(stripped)

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -93,9 +93,12 @@ module Command
     def asset_precompile_hook_run
       command = normalized_asset_precompile_hook_command
       return "" unless command
-      return "" unless single_line_asset_precompile_hook?(command)
 
-      "RUN #{command}\n\n"
+      stripped = command.strip
+      return "" if stripped.empty?
+      return "" unless single_line_asset_precompile_hook?(stripped)
+
+      "RUN #{stripped}\n\n"
     end
 
     def single_line_asset_precompile_hook?(command)

--- a/lib/core/github_flow_readiness_service.rb
+++ b/lib/core/github_flow_readiness_service.rb
@@ -3,6 +3,7 @@
 require "bundler"
 require "cgi"
 require "net/http"
+require "uri"
 require "yaml"
 
 require_relative "repo_introspection"
@@ -368,14 +369,28 @@ class GithubFlowReadinessService # rubocop:disable Metrics/ClassLength
   end
 
   def http_get(uri)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = true
+    http = build_http_client(uri)
+    http.use_ssl = uri.scheme == "https"
     http.open_timeout = 5
     http.read_timeout = 5
     http.get(uri.request_uri)
   rescue StandardError => e
     warn "github_flow_readiness: HTTP GET #{uri} failed: #{e.class}: #{e.message}" if ENV["CPFLOW_DEBUG"]
     nil
+  end
+
+  def build_http_client(uri)
+    proxy_uri = uri.find_proxy
+    return Net::HTTP.new(uri.host, uri.port) unless proxy_uri
+
+    Net::HTTP.new(
+      uri.host,
+      uri.port,
+      proxy_uri.hostname,
+      proxy_uri.port,
+      proxy_uri.user,
+      proxy_uri.password
+    )
   end
 
   def load_gem_dependencies

--- a/lib/core/repo_introspection.rb
+++ b/lib/core/repo_introspection.rb
@@ -101,6 +101,8 @@ module RepoIntrospection
     nested_sqlite_database_config?(config)
   end
 
+  # Returns true/false when a direct `url` or `adapter` key is conclusive, or nil
+  # when neither key is present so the caller can check nested sub-configs.
   def self.direct_sqlite_database_config?(config)
     url = config["url"]
     return sqlite_database_url?(url) if url.is_a?(String) && !url.strip.empty?
@@ -111,6 +113,8 @@ module RepoIntrospection
   end
 
   def self.nested_sqlite_database_config?(config)
+    # In Rails multi-database configs, hash values at this level are named
+    # connections such as primary:, cache:, or queue:. Scalar keys are ignored.
     sub_configs = config.values.select { |value| value.is_a?(Hash) }
     return false if sub_configs.empty?
 

--- a/lib/core/repo_introspection.rb
+++ b/lib/core/repo_introspection.rb
@@ -84,10 +84,37 @@ module RepoIntrospection
     production = parsed["production"]
     return false unless production.is_a?(Hash)
 
-    url = production["url"]
+    sqlite_database_config?(production)
+  end
+
+  # Recursively determines whether a database config hash uses SQLite. Handles both
+  # the single-database shape (top-level `adapter`/`url`) and Rails 6.1+ multi-database
+  # shape where each connection sits one level deeper (`primary:`, `cache:`, etc.).
+  # Returns false on any explicit non-SQLite adapter so a mixed config (e.g. Postgres
+  # primary + SQLite cache) keeps the Postgres scaffold rather than a volume scaffold.
+  def self.sqlite_database_config?(config)
+    return false unless config.is_a?(Hash)
+
+    direct_result = direct_sqlite_database_config?(config)
+    return direct_result unless direct_result.nil?
+
+    nested_sqlite_database_config?(config)
+  end
+
+  def self.direct_sqlite_database_config?(config)
+    url = config["url"]
     return sqlite_database_url?(url) if url.is_a?(String) && !url.strip.empty?
 
-    sqlite_adapter_in_hash?(production)
+    return sqlite_adapter_in_hash?(config) if config["adapter"].is_a?(String)
+
+    nil
+  end
+
+  def self.nested_sqlite_database_config?(config)
+    sub_configs = config.values.select { |value| value.is_a?(Hash) }
+    return false if sub_configs.empty?
+
+    sub_configs.all? { |sub| sqlite_database_config?(sub) }
   end
 
   def self.safe_load_database_yml(raw_contents)

--- a/lib/core/repo_introspection.rb
+++ b/lib/core/repo_introspection.rb
@@ -87,7 +87,7 @@ module RepoIntrospection
     sqlite_database_config?(production)
   end
 
-  # Recursively determines whether a database config hash uses SQLite. Handles both
+  # Determines whether a database config hash uses SQLite. Handles both
   # the single-database shape (top-level `adapter`/`url`) and Rails 6.1+ multi-database
   # shape where each connection sits one level deeper (`primary:`, `cache:`, etc.).
   # Returns false on any explicit non-SQLite adapter so a mixed config (e.g. Postgres
@@ -113,12 +113,17 @@ module RepoIntrospection
   end
 
   def self.nested_sqlite_database_config?(config)
-    # In Rails multi-database configs, hash values at this level are named
-    # connections such as primary:, cache:, or queue:. Scalar keys are ignored.
-    sub_configs = config.values.select { |value| value.is_a?(Hash) }
+    # In Rails multi-database configs, hash values with adapter/url keys are named
+    # connections such as primary:, cache:, or queue:. Scalar and incidental hash
+    # settings are ignored.
+    sub_configs = config.values.select { |value| database_connection_config?(value) }
     return false if sub_configs.empty?
 
     sub_configs.all? { |sub| sqlite_database_config?(sub) }
+  end
+
+  def self.database_connection_config?(config)
+    config.is_a?(Hash) && (config.key?("adapter") || config.key?("url"))
   end
 
   def self.safe_load_database_yml(raw_contents)

--- a/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
@@ -57,6 +57,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate required secrets and variables
+        id: config
         uses: ./.github/actions/cpflow-validate-config
         env:
           CPLN_TOKEN_STAGING: ${{ secrets.CPLN_TOKEN_STAGING }}
@@ -70,6 +71,7 @@ jobs:
           pull_request_friendly: "true"
 
       - name: Setup environment
+        if: steps.config.outputs.ready == 'true'
         uses: ./.github/actions/cpflow-setup-environment
         with:
           token: ${{ secrets.CPLN_TOKEN_STAGING }}
@@ -78,6 +80,7 @@ jobs:
           cpflow_version: ${{ vars.CPFLOW_VERSION }}
 
       - name: Set workflow links
+        if: steps.config.outputs.ready == 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -89,6 +92,7 @@ jobs:
             );
 
       - name: Create initial PR comment
+        if: steps.config.outputs.ready == 'true'
         id: create-comment
         uses: actions/github-script@v7
         with:
@@ -102,6 +106,7 @@ jobs:
             core.setOutput("comment-id", comment.data.id);
 
       - name: Delete review app
+        if: steps.config.outputs.ready == 'true'
         uses: ./.github/actions/cpflow-delete-control-plane-app
         with:
           app_name: ${{ env.APP_NAME }}
@@ -109,12 +114,15 @@ jobs:
           review_app_prefix: ${{ vars.REVIEW_APP_PREFIX }}
 
       - name: Finalize delete status
-        if: always()
+        if: always() && steps.config.outputs.ready == 'true'
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
-            const success = "${{ job.status }}" === "success";
+            const commentId = Number(process.env.COMMENT_ID);
+            const success = process.env.JOB_STATUS === "success";
             const body = success
               ? [
                   `✅ Review app for PR #${process.env.PR_NUMBER} is deleted`,

--- a/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
@@ -113,6 +113,8 @@ jobs:
           cpln_org: ${{ vars.CPLN_ORG_STAGING }}
           review_app_prefix: ${{ vars.REVIEW_APP_PREFIX }}
 
+      # Finalizer still runs after delete failures, but only after config validation
+      # created the initial PR comment and workflow link env vars it updates.
       - name: Finalize delete status
         if: always() && steps.config.outputs.ready == 'true'
         uses: actions/github-script@v7

--- a/lib/github_flow_templates/.github/workflows/cpflow-deploy-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-deploy-review-app.yml
@@ -303,9 +303,11 @@ jobs:
       - name: Update PR comment with build status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
+            const commentId = Number(process.env.COMMENT_ID);
             if (!Number.isFinite(commentId) || commentId <= 0) {
               core.warning("Skipping PR comment update because no comment id was created.");
               return;
@@ -342,9 +344,11 @@ jobs:
       - name: Update PR comment with deploy status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
+            const commentId = Number(process.env.COMMENT_ID);
             if (!Number.isFinite(commentId) || commentId <= 0) {
               core.warning("Skipping PR comment update because no comment id was created.");
               return;
@@ -396,12 +400,17 @@ jobs:
       - name: Finalize deployment status
         if: always() && steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         uses: actions/github-script@v7
+        env:
+          COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
+          DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}
+          APP_URL: ${{ steps.workload.outputs.workload_url }}
+          JOB_STATUS: ${{ job.status }}
         with:
           script: |
-            const commentId = Number("${{ steps.create-comment.outputs.comment-id }}");
-            const deploymentId = "${{ steps.init-deployment.outputs.result }}";
-            const appUrl = "${{ steps.workload.outputs.workload_url }}";
-            const success = "${{ job.status }}" === "success";
+            const commentId = Number(process.env.COMMENT_ID);
+            const deploymentId = process.env.DEPLOYMENT_ID;
+            const appUrl = process.env.APP_URL;
+            const success = process.env.JOB_STATUS === "success";
 
             if (deploymentId) {
               await github.rest.repos.createDeploymentStatus({

--- a/lib/github_flow_templates/.github/workflows/cpflow-deploy-staging.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-deploy-staging.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Checkout repository
         if: steps.check-branch.outputs.is_deployable == 'true'
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Validate required secrets and variables
         if: steps.check-branch.outputs.is_deployable == 'true'

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -207,6 +207,34 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       )
     end
 
+    it "gates delete-review-app downstream steps on cpflow-validate-config readiness" do
+      contents = delete_review_workflow_path.read
+
+      expect(contents).to include("id: config")
+      expect(contents).to match(/steps\.config\.outputs\.ready == 'true'/)
+      expect(contents).to include("if: always() && steps.config.outputs.ready == 'true'")
+    end
+
+    it "routes github-script step outputs through env vars instead of inline expressions" do
+      review_contents = review_app_workflow_path.read
+
+      expect(review_contents).not_to include('Number("${{ steps.create-comment.outputs.comment-id }}")')
+      expect(review_contents).not_to include('"${{ steps.init-deployment.outputs.result }}"')
+      expect(review_contents).not_to include('"${{ steps.workload.outputs.workload_url }}"')
+      expect(review_contents).not_to include('"${{ job.status }}"')
+      expect(review_contents).to include("COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}")
+      expect(review_contents).to include("DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}")
+      expect(review_contents).to include("APP_URL: ${{ steps.workload.outputs.workload_url }}")
+      expect(review_contents).to include("JOB_STATUS: ${{ job.status }}")
+
+      delete_contents = delete_review_workflow_path.read
+
+      expect(delete_contents).not_to include('Number("${{ steps.create-comment.outputs.comment-id }}")')
+      expect(delete_contents).not_to include('"${{ job.status }}"')
+      expect(delete_contents).to include("COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}")
+      expect(delete_contents).to include("JOB_STATUS: ${{ job.status }}")
+    end
+
     it "uses shell env vars for stale review cleanup inputs" do
       contents = cleanup_stale_review_apps_workflow_path.read
 
@@ -241,7 +269,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
     end
 
     it "does not persist checkout credentials in staging jobs" do
-      expect(staging_workflow_path.read.scan("persist-credentials: false").length).to eq(2)
+      expect(staging_workflow_path.read.scan("persist-credentials: false").length).to eq(3)
     end
 
     it "documents the branch-filter trade-off and sets staging concurrency/vars" do

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -212,6 +212,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
       expect(contents).to include("id: config")
       expect(contents).to match(/steps\.config\.outputs\.ready == 'true'/)
+      expect(contents).to include("Finalizer still runs after delete failures")
       expect(contents).to include("if: always() && steps.config.outputs.ready == 'true'")
     end
 

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -294,6 +294,66 @@ describe Command::Generate, :enable_validations, :without_config_file do
     end
   end
 
+  context "when production uses sqlite3 in a nested database config" do
+    before do
+      FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))
+      GENERATOR_PLAYGROUND_PATH.join("config/database.yml").write(<<~YAML)
+        production:
+          primary:
+            adapter: sqlite3
+            database: db/production.sqlite3
+          cache:
+            adapter: sqlite3
+            database: db/production_cache.sqlite3
+      YAML
+    end
+
+    it "generates sqlite-backed persistent volume templates instead of postgres" do
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Cpflow::Cli.start([described_class::NAME])
+
+        controlplane_content = controlplane_config_file_path.read
+
+        expect(controlplane_content).to include("- db")
+        expect(controlplane_content).to include("- storage")
+        expect(controlplane_content).not_to include("- postgres")
+        expect(postgres_template_path).not_to exist
+        expect(db_template_path).to exist
+        expect(storage_template_path).to exist
+      end
+    end
+  end
+
+  context "when production has a nested database config with a non-sqlite adapter" do
+    before do
+      FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))
+      GENERATOR_PLAYGROUND_PATH.join("config/database.yml").write(<<~YAML)
+        production:
+          primary:
+            adapter: postgresql
+            database: app_production
+          cache:
+            adapter: sqlite3
+            database: db/production_cache.sqlite3
+      YAML
+    end
+
+    it "keeps the postgres-backed templates because the primary database is non-sqlite" do
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Cpflow::Cli.start([described_class::NAME])
+
+        controlplane_content = controlplane_config_file_path.read
+
+        expect(controlplane_content).to include("- postgres")
+        expect(controlplane_content).not_to include("- db")
+        expect(controlplane_content).not_to include("- storage")
+        expect(postgres_template_path).to exist
+        expect(db_template_path).not_to exist
+        expect(storage_template_path).not_to exist
+      end
+    end
+  end
+
   context "when shakapacker config defines a precompile hook" do
     before do
       FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))
@@ -338,6 +398,30 @@ describe Command::Generate, :enable_validations, :without_config_file do
 
         expect(dockerfile_content).not_to include("RUN rake react_on_rails:generate_packs")
         expect(dockerfile_content).not_to include("USER root")
+      end
+    end
+  end
+
+  context "when shakapacker config defines a folded single-command precompile hook" do
+    before do
+      FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))
+      GENERATOR_PLAYGROUND_PATH.join("config/shakapacker.yml").write(<<~YAML)
+        default: &default
+          precompile_hook: >
+            rake react_on_rails:generate_packs
+      YAML
+    end
+
+    it "emits the folded scalar as a single RUN line ahead of assets:precompile" do
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Cpflow::Cli.start([described_class::NAME])
+
+        dockerfile_content = dockerfile_path.read
+
+        expect(dockerfile_content).to include("RUN bundle exec rake react_on_rails:generate_packs\n")
+        expect(
+          dockerfile_content.index("RUN bundle exec rake react_on_rails:generate_packs")
+        ).to be < dockerfile_content.index("RUN rails assets:precompile")
       end
     end
   end

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -324,6 +324,34 @@ describe Command::Generate, :enable_validations, :without_config_file do
     end
   end
 
+  context "when production uses sqlite3 URLs in a nested database config" do
+    before do
+      FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))
+      GENERATOR_PLAYGROUND_PATH.join("config/database.yml").write(<<~YAML)
+        production:
+          primary:
+            url: sqlite3:db/production.sqlite3
+          cache:
+            url: sqlite3:db/production_cache.sqlite3
+      YAML
+    end
+
+    it "generates sqlite-backed persistent volume templates instead of postgres" do
+      inside_dir(GENERATOR_PLAYGROUND_PATH) do
+        Cpflow::Cli.start([described_class::NAME])
+
+        controlplane_content = controlplane_config_file_path.read
+
+        expect(controlplane_content).to include("- db")
+        expect(controlplane_content).to include("- storage")
+        expect(controlplane_content).not_to include("- postgres")
+        expect(postgres_template_path).not_to exist
+        expect(db_template_path).to exist
+        expect(storage_template_path).to exist
+      end
+    end
+  end
+
   context "when production has a nested database config with a non-sqlite adapter" do
     before do
       FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH.join("config"))

--- a/spec/core/github_flow_readiness_service_spec.rb
+++ b/spec/core/github_flow_readiness_service_spec.rb
@@ -409,4 +409,33 @@ describe GithubFlowReadinessService do
   it "treats invalid npm package registry URLs as unknown availability" do
     expect(service.send(:fetch_versions_from_npm, "bad package")).to be_nil
   end
+
+  it "honors HTTPS proxy environment variables for registry HTTP requests" do
+    response = instance_double(Net::HTTPSuccess)
+    http = instance_spy(Net::HTTP)
+
+    with_temporary_env("https_proxy" => "http://proxy.example:3128") do
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(http).to receive(:get).with("/api/v1/versions/rails.json").and_return(response)
+
+      expect(service.send(:http_get, URI("https://rubygems.org/api/v1/versions/rails.json"))).to be(response)
+
+      expect(Net::HTTP).to have_received(:new)
+        .with("rubygems.org", 443, "proxy.example", 3128, nil, nil)
+      expect(http).to have_received(:use_ssl=).with(true)
+      expect(http).to have_received(:open_timeout=).with(5)
+      expect(http).to have_received(:read_timeout=).with(5)
+      expect(http).to have_received(:get).with("/api/v1/versions/rails.json")
+    end
+  end
+
+  def with_temporary_env(values)
+    previous = values.to_h { |key, _value| [key, ENV.fetch(key, nil)] }
+    values.each { |key, value| ENV[key] = value }
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+  end
 end

--- a/spec/core/github_flow_readiness_service_spec.rb
+++ b/spec/core/github_flow_readiness_service_spec.rb
@@ -414,28 +414,18 @@ describe GithubFlowReadinessService do
     response = instance_double(Net::HTTPSuccess)
     http = instance_spy(Net::HTTP)
 
-    with_temporary_env("https_proxy" => "http://proxy.example:3128") do
-      allow(Net::HTTP).to receive(:new).and_return(http)
-      allow(http).to receive(:get).with("/api/v1/versions/rails.json").and_return(response)
+    stub_env("https_proxy" => "http://proxy.example:3128")
 
-      expect(service.send(:http_get, URI("https://rubygems.org/api/v1/versions/rails.json"))).to be(response)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+    allow(http).to receive(:get).with("/api/v1/versions/rails.json").and_return(response)
 
-      expect(Net::HTTP).to have_received(:new)
-        .with("rubygems.org", 443, "proxy.example", 3128, nil, nil)
-      expect(http).to have_received(:use_ssl=).with(true)
-      expect(http).to have_received(:open_timeout=).with(5)
-      expect(http).to have_received(:read_timeout=).with(5)
-      expect(http).to have_received(:get).with("/api/v1/versions/rails.json")
-    end
-  end
+    expect(service.send(:http_get, URI("https://rubygems.org/api/v1/versions/rails.json"))).to be(response)
 
-  def with_temporary_env(values)
-    previous = values.to_h { |key, _value| [key, ENV.fetch(key, nil)] }
-    values.each { |key, value| ENV[key] = value }
-    yield
-  ensure
-    previous.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
+    expect(Net::HTTP).to have_received(:new)
+      .with("rubygems.org", 443, "proxy.example", 3128, nil, nil)
+    expect(http).to have_received(:use_ssl=).with(true)
+    expect(http).to have_received(:open_timeout=).with(5)
+    expect(http).to have_received(:read_timeout=).with(5)
+    expect(http).to have_received(:get).with("/api/v1/versions/rails.json")
   end
 end

--- a/spec/core/repo_introspection_spec.rb
+++ b/spec/core/repo_introspection_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe RepoIntrospection do
+  describe ".sqlite_database_in_production?" do
+    it "ignores incidental hash-valued production options when every database connection uses sqlite" do
+      Dir.mktmpdir("cpflow-repo-introspection") do |root|
+        config_dir = File.join(root, "config")
+        FileUtils.mkdir_p(config_dir)
+        File.write(
+          File.join(config_dir, "database.yml"),
+          <<~YAML
+            production:
+              primary:
+                adapter: sqlite3
+                database: db/production.sqlite3
+              cache:
+                adapter: sqlite3
+                database: db/production_cache.sqlite3
+              connected_to_all_handlers:
+                strategy: any_replica
+          YAML
+        )
+
+        expect(described_class.sqlite_database_in_production?(root)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fix generator handling for nested production SQLite configs and folded Shakapacker precompile hooks.
- Harden generated GitHub Actions by gating review-app delete steps on config readiness, moving github-script values into env vars, and disabling persisted checkout credentials in staging.
- Root cause: the generator only understood flat production database configs, preserved folded hook whitespace, and some workflow scripts referenced dynamic expressions inline after config validation could skip setup.

## Validation
- `CPLN_ORG=dummy-test bundle exec rspec spec/command/generate_spec.rb spec/command/generate_github_actions_spec.rb`
- `bundle exec rubocop lib/command/generate.rb lib/core/repo_introspection.rb spec/command/generate_spec.rb spec/command/generate_github_actions_spec.rb`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes generation logic that affects produced Control Plane templates and modifies GitHub Actions execution conditions, which could alter CI/CD behavior for review/staging deployments and deletions.
> 
> **Overview**
> Fixes generator edge cases by detecting SQLite in Rails multi-database `production` configs (including nested `adapter`/`url` entries) and by stripping folded YAML `precompile_hook` values so single-command hooks emit a valid single `RUN` line.
> 
> Hardens generated GitHub Actions workflows by gating delete-review-app steps on `cpflow-validate-config` readiness, routing `github-script` inputs/outputs through `env` variables (instead of inline expressions), and disabling persisted checkout credentials in the staging workflow. Adds/updates specs covering these cases, plus readiness checks now honor HTTPS proxy env vars for registry HTTP requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ff910ced7df1c685a13cbfa3917e427ec94537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->