### PR TITLE
Update CHANGELOG.md for 5.0.0.rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
-### Changed
-
-- Renamed the generated review-app PR comment commands to a namespaced `+review-app-*` family: `/deploy-review-app` → `+review-app-deploy`, `/delete-review-app` → `+review-app-delete`, and `/help` → `+review-app-help`. The `+` prefix is used instead of `/` to avoid collision with GitHub's reserved slash-command surface and with other bots that listen on `/help`, and to make the three commands obviously part of one namespaced family. Repos that ran `cpflow generate-github-actions` against 5.0.0.rc.0 must regenerate the generated `.github/workflows/cpflow-*.yml` files and `.github/cpflow-help.md`, then update saved instructions or runbooks. [PR 285](https://github.com/shakacode/control-plane-flow/pull/285) by [Justin Gordon](https://github.com/justin808).
-
-## [5.0.0.rc.0] - 2026-05-05
+## [5.0.0.rc.1] - 2026-05-11
 
 ### Breaking Changes
 
@@ -26,12 +22,13 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Added
 
-- Added the GitHub Actions flow generator and readiness checks for staging, review-app, and production-promotion workflows. [PR 278](https://github.com/shakacode/control-plane-flow/pull/278) by [Justin Gordon](https://github.com/justin808).
-- Added `use-digest-image-ref` (also configurable through `use_digest_image_ref` in `controlplane.yml`) option to `deploy-image` and `promote-app-from-upstream` commands. [PR 249](https://github.com/shakacode/control-plane-flow/pull/249) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
+- **Added the GitHub Actions flow generator and readiness checks for staging, review-app, and production-promotion workflows.** [PR 278](https://github.com/shakacode/control-plane-flow/pull/278) by [Justin Gordon](https://github.com/justin808).
+- **Added `use-digest-image-ref` (also configurable through `use_digest_image_ref` in `controlplane.yml`) option to `deploy-image` and `promote-app-from-upstream` commands.** [PR 249](https://github.com/shakacode/control-plane-flow/pull/249) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
 
 ### Changed
 
-- Updated runtime dependencies: `dotenv` (~> 2.8.1 → ~> 3.1), `jwt` (~> 2.8.1 → ~> 3.1), `psych` (~> 5.1.0 → ~> 5.2), and `thor` (~> 1.2.1 → ~> 1.4). [PR 258](https://github.com/shakacode/control-plane-flow/pull/258) by [Justin Gordon](https://github.com/justin808).
+- **Renamed the generated review-app PR comment commands to a namespaced `+review-app-*` family.** [PR 285](https://github.com/shakacode/control-plane-flow/pull/285) by [Justin Gordon](https://github.com/justin808). `/deploy-review-app` → `+review-app-deploy`, `/delete-review-app` → `+review-app-delete`, and `/help` → `+review-app-help`. The `+` prefix avoids collision with GitHub's reserved slash-command surface and makes the three commands obviously part of one namespaced family. Repos that ran `cpflow generate-github-actions` against 5.0.0.rc.0 must regenerate the generated `.github/workflows/cpflow-*.yml` files and `.github/cpflow-help.md`, then update saved instructions or runbooks.
+- **Updated runtime dependencies: `dotenv` (~> 2.8.1 → ~> 3.1), `jwt` (~> 2.8.1 → ~> 3.1), `psych` (~> 5.1.0 → ~> 5.2), and `thor` (~> 1.2.1 → ~> 1.4).** [PR 258](https://github.com/shakacode/control-plane-flow/pull/258) by [Justin Gordon](https://github.com/justin808).
 
 ## [4.2.0] - 2026-02-19
 
@@ -316,8 +313,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.0...HEAD
-[5.0.0.rc.0]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v5.0.0.rc.0
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.1...HEAD
+[5.0.0.rc.1]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v5.0.0.rc.1
 [4.2.0]: https://github.com/shakacode/control-plane-flow/compare/v4.1.1...v4.2.0
 [4.1.1]: https://github.com/shakacode/control-plane-flow/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/shakacode/control-plane-flow/compare/v4.0.0...v4.1.0


### PR DESCRIPTION
## Summary

- Stamp `CHANGELOG.md` for `5.0.0.rc.1`.
- Collapse the prior `5.0.0.rc.0` prerelease section into the new rc.1 section.
- Move the PR 285 review-app command rename from `Unreleased` into `5.0.0.rc.1`.
- Update the `Unreleased` and `5.0.0.rc.1` compare links.

## Skipped

- PR 286: repo assistant workflow tooling, not cpflow user-visible behavior.
- PR 287: docs-only Control Plane service template links.

## Validation

- `git fetch origin main --tags`
- `git diff --check -- CHANGELOG.md`
- Verified the first version headers are `Unreleased -> 5.0.0.rc.1 -> 4.2.0`.
- Verified no `5.0.0.rc.0` header or compare link remains.

After this PR merges, run `bundle exec rake release` to publish the release candidate and create the GitHub release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that stamps the `5.0.0.rc.1` release notes and updates compare links, with no runtime code modifications.
> 
> **Overview**
> Stamps `CHANGELOG.md` for **`5.0.0.rc.1`** (2026-05-11) by moving the previously noted items (including the review-app command rename) out of `Unreleased` and consolidating prerelease notes under the new version header.
> 
> Updates the bottom compare links to point `Unreleased` at `v5.0.0.rc.1` and adds the `v4.2.0...v5.0.0.rc.1` diff link, removing references to `5.0.0.rc.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3430947ec0be4709a43ebcb496660f0e4b0258cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Actions flow generator and readiness checks.
  * Added `use-digest-image-ref` option for enhanced image reference handling.

* **Changed**
  * Renamed `review-app` PR comment commands to `+review-app-*` format.
  * Updated runtime dependencies: dotenv, jwt, psych, and thor.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->