### PR TITLE
Shorten review app command quick reference

### DIFF
--- a/lib/github_flow_templates/.github/workflows/cpflow-review-app-help.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-review-app-help.yml
@@ -28,13 +28,11 @@ jobs:
             const body = [
               "# Review app commands",
               "",
-              "Repo owners, members, and collaborators can use these commands:",
-              "",
               "- `+review-app-deploy` - create or redeploy this PR's review app.",
               "- `+review-app-delete` - delete this PR's review app and temporary resources.",
               "- `+review-app-help` - show setup details and workflow behavior.",
               "",
-              "For setup details, repo owners, members, and collaborators can comment `+review-app-help`."
+              "For setup details, comment `+review-app-help`."
             ].join("\n");
 
             await github.rest.issues.createComment({

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -270,13 +270,11 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
     it "pins the +review-app-* commands in the PR-open message" do
       pr_open_help = pr_open_help_workflow_path.read
 
-      expect(pr_open_help).to include('"Repo owners, members, and collaborators can use these commands:"')
+      expect(pr_open_help).to include('"# Review app commands"')
       expect(pr_open_help).to include("- `+review-app-deploy` - create or redeploy this PR's review app.")
       expect(pr_open_help).to include("- `+review-app-delete` - delete this PR's review app and temporary resources.")
       expect(pr_open_help).to include("- `+review-app-help` - show setup details and workflow behavior.")
-      expect(pr_open_help).to include(
-        '"For setup details, repo owners, members, and collaborators can comment `+review-app-help`."'
-      )
+      expect(pr_open_help).to include('"For setup details, comment `+review-app-help`."')
     end
 
     it "pins the +review-app-* commands in the long-form help markdown" do


### PR DESCRIPTION
## Summary
- shorten the generated PR-open review app command comment
- keep the quick reference to the three +review-app-* commands plus the setup-help pointer
- update the generator spec to pin the shorter public copy

## Validation
- CPLN_ORG=test-org bundle exec rspec spec/command/generate_github_actions_spec.rb spec/command/ai_github_flow_prompt_spec.rb
- ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path, aliases: true); puts path }' lib/github_flow_templates/.github/workflows/cpflow-review-app-help.yml lib/github_flow_templates/.github/workflows/cpflow-help-command.yml lib/github_flow_templates/.github/workflows/cpflow-deploy-review-app.yml lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to the PR-open review app help comment plus a matching spec update; no workflow behavior or permissions are modified.
> 
> **Overview**
> Shortens the PR-open quick-reference comment emitted by `cpflow-review-app-help.yml` by removing the repeated “repo owners/members/collaborators” phrasing while keeping the three `+review-app-*` commands and the pointer to `+review-app-help`.
> 
> Updates `generate_github_actions_spec.rb` to assert against the new header and closing line so the generator test suite pins the revised public copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c4ff540b721aad806b69ca1c261983d8e04451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->