### PR TITLE
Relax thor dependency to ~> 1.3 for Rails 8 solid_queue compatibility (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- **Relaxed `thor` runtime dependency from `~> 1.4` to `~> 1.2`** so cpflow can be bundled into Rails 8 apps that pull in `solid_queue` 1.1.0 (Rails 8.0.x default), which pins `thor ~> 1.3.1`. The previous `~> 1.4` constraint had zero overlap with that pin and forced users to install cpflow globally instead of adding it to the Gemfile. [Issue 264](https://github.com/shakacode/control-plane-flow/issues/264).
+
 ## [5.0.0.rc.1] - 2026-05-11
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Relaxed `thor` runtime dependency from `~> 1.4` to `~> 1.2`** so cpflow can be bundled into Rails 8 apps that pull in `solid_queue` 1.1.0 (Rails 8.0.x default), which pins `thor ~> 1.3.1`. The previous `~> 1.4` constraint had zero overlap with that pin and forced users to install cpflow globally instead of adding it to the Gemfile. [Issue 264](https://github.com/shakacode/control-plane-flow/issues/264).
+- **Relaxed `thor` runtime dependency from `~> 1.4` to `~> 1.3`** so cpflow can be bundled into Rails 8 apps that pull in `solid_queue` 1.1.0 (Rails 8.0.x default), which pins `thor ~> 1.3.1`. The previous `~> 1.4` constraint had zero overlap with that pin and forced users to install cpflow globally instead of adding it to the Gemfile. [Issue 264](https://github.com/shakacode/control-plane-flow/issues/264) / [PR 291](https://github.com/shakacode/control-plane-flow/pull/291) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.0.0.rc.1] - 2026-05-11
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       dotenv (~> 3.1)
       jwt (~> 3.1)
       psych (~> 5.2)
-      thor (~> 1.2)
+      thor (~> 1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       dotenv (~> 3.1)
       jwt (~> 3.1)
       psych (~> 5.2)
-      thor (~> 1.4)
+      thor (~> 1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv",   "~> 3.1"
   spec.add_dependency "jwt",      "~> 3.1"
   spec.add_dependency "psych",    "~> 5.2"
-  spec.add_dependency "thor",     "~> 1.4"
+  spec.add_dependency "thor",     "~> 1.2"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |file|
     file.match(%r{^(coverage|pkg|spec|tmp)/})

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv",   "~> 3.1"
   spec.add_dependency "jwt",      "~> 3.1"
   spec.add_dependency "psych",    "~> 5.2"
-  spec.add_dependency "thor",     "~> 1.2"
+  spec.add_dependency "thor",     "~> 1.3"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |file|
     file.match(%r{^(coverage|pkg|spec|tmp)/})


### PR DESCRIPTION
## Summary

- Relaxes the `thor` runtime constraint in `cpflow.gemspec` from `~> 1.4` to `~> 1.3`.
- Adds a `### Fixed` entry under `[Unreleased]` in the CHANGELOG explaining the resolved-version math.
- Regenerates `Gemfile.lock` to reflect the relaxed constraint (`thor` itself still resolves to 1.5.0 locally).

## Why

`solid_queue` 1.1.0 — the version Rails 8.0.x ships by default — pins `thor ~> 1.3.1` (≥ 1.3.1, < 1.4). cpflow 5.0.0.rc.1's `thor ~> 1.4` (≥ 1.4, < 2.0) has **zero overlap** with that pin, so bundling cpflow into a fresh Rails 8 app fails outright and the only workaround is `gem install cpflow` globally. Newer `solid_queue` 1.4.0 uses `thor >= 1.3.1`, which is also satisfied by the relaxed range, so this change is forward-compatible.

`thor` is highly backwards-compatible across minor versions and cpflow only uses the stable CLI surface (`Thor::Group`, option parsing), so widening the floor to 1.2 doesn't change runtime behavior.

## Verification

- `bundle install` resolves the local repo to thor 1.5.0 as before.
- `CPLN_ORG=test-org bundle exec rspec spec/core` → 134 examples, 0 failures.
- `bundle exec rubocop cpflow.gemspec` → 1 file, no offenses.
- Simulated a Rails 8 + solid_queue 1.1.0 bundle pointing at this branch — resolves cleanly to thor 1.3.2 (the previous gemspec would have failed dependency resolution here).

## Test plan

- [ ] CI green on this branch.
- [ ] Reviewer spot-checks a clean `bundle install` against a Rails 8.0.x sample app with this branch.

Fixes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to widening the `thor` version constraint and updating lockfile/changelog, with no runtime code changes beyond dependency resolution.
> 
> **Overview**
> Improves bundler compatibility with Rails 8 apps (notably those using `solid_queue` 1.1.x) by relaxing cpflow’s runtime dependency on `thor` from `~> 1.4` to `~> 1.3`.
> 
> Updates `Gemfile.lock` to reflect the new constraint and adds an `[Unreleased]` changelog entry documenting the fix and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36775e7bed417471ca5f347ad5a74ae838ebb4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundling compatibility with Rails 8 by adjusting the runtime dependency constraint for the Thor library to align with other ecosystem gems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
