### PR TITLE
Document Thruster HTTP/2 proxy configuration for Rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Additionally, the documentation includes numerous examples and practical tips fo
 14. [Migrating Postgres Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/postgres/)
 15. [Migrating Redis Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/redis/)
 16. [Tips](https://www.shakacode.com/control-plane-flow/docs/tips/)
+17. [Thruster HTTP/2 Proxy on Control Plane](https://www.shakacode.com/control-plane-flow/docs/thruster/)
 
 ## Key Features
 

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -1,0 +1,107 @@
+# Thruster HTTP/2 Proxy on Control Plane
+
+[Thruster](https://github.com/basecamp/thruster) is Basecamp's zero-config HTTP/2 proxy for
+Ruby web applications. It provides HTTP/2 support, asset caching, compression, and early
+hints. Running it on Control Plane requires settings that differ from a standalone (e.g.,
+VPS) deployment, and getting them wrong produces a confusing `502 Bad Gateway` with a
+"protocol error" message.
+
+This page documents the configuration that works.
+
+## TL;DR
+
+- Workload port: `protocol: http` (not `http2`).
+- Dockerfile `CMD` runs Thruster: `CMD ["bundle", "exec", "thrust", "bin/rails", "server"]`.
+- End users still get HTTP/2; Control Plane's load balancer terminates it.
+
+## Why `protocol: http` and not `http2`
+
+### Standalone Thruster (e.g., VPS)
+
+```
+User → HTTPS/HTTP2 → Thruster → HTTP/1.1 → Rails
+      (Thruster handles TLS + HTTP/2)
+```
+
+### Control Plane + Thruster
+
+```
+User → HTTPS/HTTP2 → Control Plane LB → HTTP/1.1 → Thruster → HTTP/1.1 → Rails
+                      (LB handles TLS)    (protocol: http)  (HTTP/2 features)
+```
+
+Thruster speaks HTTP/2 on the *frontend* (the TLS-terminated connection from the browser)
+and talks to upstream services over HTTP/1.1. On Control Plane the load balancer
+terminates TLS, so it is the load balancer — not Thruster — that talks HTTP/2 to the
+browser. Setting `protocol: http2` on the workload port tells the load balancer to expect
+HTTP/2 from the container, which Thruster does not provide on that hop, and protocol
+negotiation fails with `502 Bad Gateway`.
+
+Even with `protocol: http`, end users still get:
+
+- HTTP/2 to the browser (via the Control Plane load balancer)
+- Asset caching and compression
+- Efficient static file serving
+- Early hints support
+- HTTP/2 multiplexing
+
+## Workload template
+
+In `.controlplane/templates/rails.yml`:
+
+```yaml
+ports:
+  - number: 3000
+    protocol: http  # Required when fronting Rails with Thruster. Do not use http2.
+```
+
+## Dockerfile
+
+The container's `CMD` must launch Thruster. On Control Plane/Kubernetes the Dockerfile
+`CMD` determines container startup — the `Procfile` is not used (unlike Heroku).
+
+```dockerfile
+# .controlplane/Dockerfile
+CMD ["bundle", "exec", "thrust", "bin/rails", "server"]
+```
+
+## Troubleshooting
+
+### `502 Bad Gateway` with "protocol error"
+
+The workload port is set to `protocol: http2`. Change it to `protocol: http` and redeploy.
+
+### Verify Thruster is the process running as PID 1
+
+```sh
+cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
+  -- cat /proc/1/cmdline
+```
+
+You should see `thrust` in the output. If you see `rails` or `puma` directly, the
+Dockerfile `CMD` is not invoking Thruster.
+
+### Test internal connectivity to Rails
+
+```sh
+cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
+  -- curl -s localhost:3000
+```
+
+### Inspect the workload port configuration
+
+```sh
+cpln workload get <workload> --gvc <gvc> --org <org> -o json | grep -A 3 "ports"
+```
+
+## Reference implementation
+
+A working setup lives in the
+[react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial)
+repository — see
+[PR #687](https://github.com/shakacode/react-webpack-rails-tutorial/pull/687).
+
+## Further reading
+
+- Thruster: https://github.com/basecamp/thruster
+- DHH on Rails 8 with Thruster: https://world.hey.com/dhh/rails-8-with-thruster-by-default-c953f5e3

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -27,7 +27,7 @@ User → HTTPS/HTTP2 → Thruster → HTTP/1.1 → Rails
 
 ```
 User → HTTPS/HTTP2 → Control Plane LB → HTTP/1.1 → Thruster → HTTP/1.1 → Rails
-                      (LB handles TLS)    (protocol: http)  (HTTP/2 features)
+                      (LB handles TLS)    (protocol: http)  (caching, compression)
 ```
 
 Thruster speaks HTTP/2 on the *frontend* (the TLS-terminated connection from the browser)
@@ -39,11 +39,11 @@ negotiation fails with `502 Bad Gateway`.
 
 Even with `protocol: http`, end users still get:
 
-- HTTP/2 to the browser (via the Control Plane load balancer)
-- Asset caching and compression
-- Efficient static file serving
-- Early hints support
-- HTTP/2 multiplexing
+- HTTP/2 to the browser (from the Control Plane load balancer)
+- HTTP/2 multiplexing (from the Control Plane load balancer)
+- Asset caching and compression (from Thruster)
+- Efficient static file serving (from Thruster)
+- Early hints support (from Thruster)
 
 ## Workload template
 
@@ -73,9 +73,12 @@ The workload port is set to `protocol: http2`. Change it to `protocol: http` and
 
 ### Verify Thruster is the process running as PID 1
 
+`/proc/1/cmdline` stores arguments NUL-separated with no trailing newline, so pipe it
+through `tr` to make the output readable:
+
 ```sh
 cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
-  -- cat /proc/1/cmdline
+  -- sh -c "tr '\0' ' ' < /proc/1/cmdline && echo"
 ```
 
 You should see `thrust` in the output. If you see `rails` or `puma` directly, the
@@ -103,5 +106,5 @@ repository — see
 
 ## Further reading
 
-- Thruster: https://github.com/basecamp/thruster
-- DHH on Rails 8 with Thruster: https://world.hey.com/dhh/rails-8-with-thruster-by-default-c953f5e3
+- [Thruster on GitHub](https://github.com/basecamp/thruster)
+- [DHH on Rails 8 with Thruster](https://world.hey.com/dhh/rails-8-with-thruster-by-default-c953f5e3)

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -74,15 +74,32 @@ CMD ["bundle", "exec", "thrust", "bin/rails", "server"]
 ### `502 Bad Gateway` with "protocol error"
 
 The workload port is set to `protocol: http2`. Change it to `protocol: http` in
-`rails.yml`, then apply the template so the workload spec is updated:
+`rails.yml`, then push the workload spec.
+
+`cpflow apply-template` rewrites the workload from the template. If you have tuned
+CPU, memory, autoscaling, firewall, or other workload fields directly in the
+Control Plane UI (or via `cpln`) without mirroring those changes back into
+`rails.yml`, those edits will be reset. Either reconcile `rails.yml` with the live
+spec first, or change the port field in place:
 
 ```sh
-cpflow apply-template rails -a <app>   # pushes the protocol change to the workload
-# Run `cpflow deploy-image -a <app>` only if you also want to update the container image.
+# Option A — apply the full template (resets any drift between rails.yml and the live spec):
+cpflow apply-template rails -a <app>
+
+# Option B — edit only the port protocol in place (preserves UI-tuned fields):
+cpln workload edit <workload> --gvc <gvc> --org <org>
+# change spec.containers[].ports[].protocol from http2 to http
+```
+
+Inspect the current spec before choosing if you're unsure what would change:
+
+```sh
+cpln workload get <workload> --gvc <gvc> --org <org> -o yaml
 ```
 
 Note: `cpflow deploy-image` alone is not sufficient — it only updates the container
-image reference and does not modify the workload's port configuration.
+image reference and does not modify the workload's port configuration. Run it
+*after* the protocol change has been applied if you also want to ship a new image.
 
 The remaining troubleshooting commands use the raw Control Plane CLI (`cpln`) rather
 than `cpflow`; see
@@ -102,7 +119,10 @@ cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
 You should see `thrust` in the output. If you see `rails` or `puma` directly, the
 Dockerfile `CMD` is not invoking Thruster.
 
-### Test internal connectivity to Rails
+### Test HTTP connectivity through Thruster
+
+This hits Thruster on port 3000 — not Rails directly. A `200 OK` confirms the
+container-internal LB → Thruster → Rails path is healthy.
 
 ```sh
 cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
@@ -120,7 +140,8 @@ cpln workload get <workload> --gvc <gvc> --org <org> -o json | jq '.spec.contain
 A working setup lives in the
 [react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial)
 repository — see
-[PR #687](https://github.com/shakacode/react-webpack-rails-tutorial/pull/687).
+[`.controlplane/templates/rails.yml`](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/rails.yml)
+on the `master` branch.
 
 ## Further reading
 

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -30,7 +30,7 @@ User → HTTPS/HTTP2 → Control Plane LB → HTTP/1.1 → Thruster → HTTP/1.1
                       (LB handles TLS)    (protocol: http)  (caching, compression)
 ```
 
-Thruster speaks HTTP/2 on the *frontend* (the TLS-terminated connection from the browser)
+Thruster terminates TLS and speaks HTTP/2 on the *frontend* (the browser-facing side),
 and talks to upstream services over HTTP/1.1. On Control Plane the load balancer
 terminates TLS, so it is the load balancer — not Thruster — that talks HTTP/2 to the
 browser. Setting `protocol: http2` on the workload port tells the load balancer to expect
@@ -69,7 +69,8 @@ CMD ["bundle", "exec", "thrust", "bin/rails", "server"]
 
 ### `502 Bad Gateway` with "protocol error"
 
-The workload port is set to `protocol: http2`. Change it to `protocol: http` and redeploy.
+The workload port is set to `protocol: http2`. Change it to `protocol: http` in
+`rails.yml`, then redeploy (`cpflow deploy-image -a <app>`) for the change to take effect.
 
 ### Verify Thruster is the process running as PID 1
 
@@ -94,7 +95,7 @@ cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \
 ### Inspect the workload port configuration
 
 ```sh
-cpln workload get <workload> --gvc <gvc> --org <org> -o json | grep -A 3 "ports"
+cpln workload get <workload> --gvc <gvc> --org <org> -o json | jq '.spec.containers[].ports'
 ```
 
 ## Reference implementation

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -12,7 +12,7 @@ This page documents the configuration that works.
 
 - Workload port: `protocol: http` (not `http2`).
 - Dockerfile `CMD` runs Thruster: `CMD ["bundle", "exec", "thrust", "bin/rails", "server"]`.
-- End users still get HTTP/2; Control Plane's load balancer terminates it.
+- End users still get HTTP/2; Control Plane's load balancer handles TLS termination.
 
 ## Why `protocol: http` and not `http2`
 
@@ -32,14 +32,14 @@ User → HTTPS/HTTP2 → Control Plane LB → HTTP/1.1 → Thruster → HTTP/1.1
 
 In the diagram above, `protocol: http` is the workload port setting that governs the
 LB→Thruster hop; `caching, compression` describes what Thruster contributes in this
-path (regardless of which arrow the label lands under in your Markdown renderer).
+path.
 
-Thruster terminates TLS and speaks HTTP/2 on the *frontend* (the browser-facing side),
-and talks to upstream services over HTTP/1.1. On Control Plane the load balancer
-terminates TLS, so it is the load balancer — not Thruster — that talks HTTP/2 to the
-browser. Setting `protocol: http2` on the workload port tells the load balancer to expect
-HTTP/2 from the container, which Thruster does not provide on that hop, and protocol
-negotiation fails with `502 Bad Gateway`.
+On Control Plane, the load balancer terminates TLS and speaks HTTP/2 to the browser —
+so Thruster never sees TLS or HTTP/2 on its incoming side. This is the opposite of a
+standalone (VPS) deployment, where Thruster itself handles TLS and HTTP/2. Setting
+`protocol: http2` on the workload port tells the load balancer to expect HTTP/2 from
+the container, which Thruster does not emit on that hop, and protocol negotiation fails
+with `502 Bad Gateway`.
 
 Even with `protocol: http`, end users still get:
 
@@ -78,11 +78,16 @@ The workload port is set to `protocol: http2`. Change it to `protocol: http` in
 
 ```sh
 cpflow apply-template rails -a <app>   # pushes the protocol change to the workload
-cpflow deploy-image -a <app>           # optional: re-pins the latest image
+# Run `cpflow deploy-image -a <app>` only if you also want to update the container image.
 ```
 
 Note: `cpflow deploy-image` alone is not sufficient — it only updates the container
 image reference and does not modify the workload's port configuration.
+
+The remaining troubleshooting commands use the raw Control Plane CLI (`cpln`) rather
+than `cpflow`; see
+[the Control Plane CLI quickstart](https://shakadocs.controlplane.com/quickstart/quick-start-3-cli#getting-started-with-the-cli)
+if you don't already have it installed.
 
 ### Verify Thruster is the process running as PID 1
 

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -122,7 +122,7 @@ Dockerfile `CMD` is not invoking Thruster.
 ### Test HTTP connectivity through Thruster
 
 This hits Thruster on port 3000 — not Rails directly. A `200 OK` confirms the
-container-internal LB → Thruster → Rails path is healthy.
+Thruster → Rails path within the container is healthy.
 
 ```sh
 cpln workload exec <workload> --gvc <gvc> --org <org> --location <location> \

--- a/docs/thruster.md
+++ b/docs/thruster.md
@@ -30,6 +30,10 @@ User → HTTPS/HTTP2 → Control Plane LB → HTTP/1.1 → Thruster → HTTP/1.1
                       (LB handles TLS)    (protocol: http)  (caching, compression)
 ```
 
+In the diagram above, `protocol: http` is the workload port setting that governs the
+LB→Thruster hop; `caching, compression` describes what Thruster contributes in this
+path (regardless of which arrow the label lands under in your Markdown renderer).
+
 Thruster terminates TLS and speaks HTTP/2 on the *frontend* (the browser-facing side),
 and talks to upstream services over HTTP/1.1. On Control Plane the load balancer
 terminates TLS, so it is the load balancer — not Thruster — that talks HTTP/2 to the
@@ -43,7 +47,7 @@ Even with `protocol: http`, end users still get:
 - HTTP/2 multiplexing (from the Control Plane load balancer)
 - Asset caching and compression (from Thruster)
 - Efficient static file serving (from Thruster)
-- Early hints support (from Thruster)
+- Early Hints (103) from Thruster (reaches the browser only if the load balancer forwards 103 responses)
 
 ## Workload template
 
@@ -70,7 +74,15 @@ CMD ["bundle", "exec", "thrust", "bin/rails", "server"]
 ### `502 Bad Gateway` with "protocol error"
 
 The workload port is set to `protocol: http2`. Change it to `protocol: http` in
-`rails.yml`, then redeploy (`cpflow deploy-image -a <app>`) for the change to take effect.
+`rails.yml`, then apply the template so the workload spec is updated:
+
+```sh
+cpflow apply-template rails -a <app>   # pushes the protocol change to the workload
+cpflow deploy-image -a <app>           # optional: re-pins the latest image
+```
+
+Note: `cpflow deploy-image` alone is not sufficient — it only updates the container
+image reference and does not modify the workload's port configuration.
 
 ### Verify Thruster is the process running as PID 1
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,3 +4,7 @@
 ## App Web Page Shows `upstream request timeout`
 
 If you get a blank screen showing the message `upstream request timeout` on your app after running `cpflow open -a my-app-name`, check out the application logs. Your image has been promoted and your app crashing when starting.
+
+## `502 Bad Gateway` with "protocol error" (Rails + Thruster)
+
+If a Rails app fronted by [Thruster](https://github.com/basecamp/thruster) returns `502 Bad Gateway` with a "protocol error" message, the workload port is likely set to `protocol: http2`. Thruster speaks HTTP/1.1 to upstreams, so the workload port must be `protocol: http` — Control Plane's load balancer still serves HTTP/2 to end users. See [Thruster HTTP/2 Proxy on Control Plane](./thruster.md) for the full configuration and debugging commands.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,4 +7,8 @@ If you get a blank screen showing the message `upstream request timeout` on your
 
 ## `502 Bad Gateway` with "protocol error" (Rails + Thruster)
 
-If a Rails app fronted by [Thruster](https://github.com/basecamp/thruster) returns `502 Bad Gateway` with a "protocol error" message, the workload port is likely set to `protocol: http2`. Thruster speaks HTTP/1.1 to upstreams, so the workload port must be `protocol: http` — Control Plane's load balancer still serves HTTP/2 to end users. See [Thruster HTTP/2 Proxy on Control Plane](./thruster.md) for the full configuration and debugging commands.
+If a Rails app fronted by [Thruster](https://github.com/basecamp/thruster) returns `502 Bad Gateway` with a "protocol error" message, the workload port is likely set to `protocol: http2`.
+
+Thruster speaks HTTP/1.1 to upstreams, so the workload port must be `protocol: http`. Control Plane's load balancer still serves HTTP/2 to end users.
+
+See [Thruster HTTP/2 Proxy on Control Plane](./thruster.md) for the full configuration and debugging commands.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,6 @@ If you get a blank screen showing the message `upstream request timeout` on your
 
 If a Rails app fronted by [Thruster](https://github.com/basecamp/thruster) returns `502 Bad Gateway` with a "protocol error" message, the workload port is likely set to `protocol: http2`.
 
-Thruster speaks HTTP/1.1 to upstreams, so the workload port must be `protocol: http`. Control Plane's load balancer still serves HTTP/2 to end users.
+Thruster accepts HTTP/1.1 connections from the load balancer, so the workload port must be `protocol: http`. Control Plane's load balancer still serves HTTP/2 to end users.
 
 See [Thruster HTTP/2 Proxy on Control Plane](./thruster.md) for the full configuration and debugging commands.

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -14,7 +14,7 @@ spec:
         - number: 3000
           # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
           # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
-          # `502 Bad Gateway` with "protocol error". See docs/thruster.md for details.
+          # `502 Bad Gateway` with "protocol error". See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
           protocol: http
   defaultOptions:
     autoscaling:

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -12,6 +12,9 @@ spec:
       memory: 512Mi
       ports:
         - number: 3000
+          # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
+          # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
+          # `502 Bad Gateway` with "protocol error". See docs/thruster.md for details.
           protocol: http
   defaultOptions:
     autoscaling:

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -14,7 +14,8 @@ spec:
         - number: 3000
           # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
           # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
-          # `502 Bad Gateway` with "protocol error". See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
+          # `502 Bad Gateway` with "protocol error".
+          # See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
           protocol: http
   defaultOptions:
     autoscaling:

--- a/lib/generator_templates_sqlite/templates/rails.yml
+++ b/lib/generator_templates_sqlite/templates/rails.yml
@@ -12,7 +12,7 @@ spec:
         - number: 3000
           # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
           # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
-          # `502 Bad Gateway` with "protocol error". See docs/thruster.md for details.
+          # `502 Bad Gateway` with "protocol error". See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
           protocol: http
       volumes:
         - path: /app/db

--- a/lib/generator_templates_sqlite/templates/rails.yml
+++ b/lib/generator_templates_sqlite/templates/rails.yml
@@ -10,6 +10,9 @@ spec:
       memory: 512Mi
       ports:
         - number: 3000
+          # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
+          # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
+          # `502 Bad Gateway` with "protocol error". See docs/thruster.md for details.
           protocol: http
       volumes:
         - path: /app/db

--- a/lib/generator_templates_sqlite/templates/rails.yml
+++ b/lib/generator_templates_sqlite/templates/rails.yml
@@ -12,7 +12,8 @@ spec:
         - number: 3000
           # Keep this as `http` even when fronting Rails with Thruster — the Control Plane
           # load balancer still serves HTTP/2 to end users. Setting `http2` here causes
-          # `502 Bad Gateway` with "protocol error". See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
+          # `502 Bad Gateway` with "protocol error".
+          # See https://www.shakacode.com/control-plane-flow/docs/thruster/ for details.
           protocol: http
       volumes:
         - path: /app/db


### PR DESCRIPTION
## Summary

- Adds `docs/thruster.md` documenting how to run Rails with [Thruster](https://github.com/basecamp/thruster) on Control Plane: why workload ports must use `protocol: http` (not `http2`), the required Dockerfile `CMD`, architecture details, and troubleshooting commands for the common 502 "protocol error" failure mode.
- Links the new doc from `README.md` and `docs/troubleshooting.md` (with a dedicated 502 entry).
- Adds an inline comment on both generator `rails.yml` templates (postgres + sqlite variants) so newly generated projects carry the hint forward.

Fixes #257

## Test plan

- [x] `CPLN_ORG=test-org bundle exec rspec spec/command/generate_spec.rb` — 18 examples, 0 failures
- [x] `bundle exec rubocop` — 191 files, no offenses
- [x] `./script/check_cpln_links docs/thruster.md docs/troubleshooting.md README.md` — exit 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies troubleshooting guidance without affecting runtime behavior.
> 
> **Overview**
> Clarifies the Thruster troubleshooting doc to state that the `curl localhost:3000` check validates the **Thruster → Rails path within the container**, removing the earlier implication of a container-internal load balancer hop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c40c1973cfdc068db966241acf03bbc06a156a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive guide for running Thruster HTTP/2 proxy with Control Plane, including configuration requirements and operational checks
* Added troubleshooting subsections for upstream request timeout and HTTP protocol error scenarios  
* Updated Rails workload templates with clarified protocol configuration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->