### PR TITLE
Add regression test for #293: forbid literal GitHub expressions in composite action descriptions

### DIFF
--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -232,15 +232,15 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
       violations = action_paths.flat_map do |path|
         metadata = YAML.load_file(path, aliases: true)
-        described = []
-        described << ["description", metadata["description"]]
+        field_pairs = []
+        field_pairs << ["description", metadata["description"]]
         (metadata["inputs"] || {}).each do |name, spec|
-          described << ["inputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
+          field_pairs << ["inputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
         end
         (metadata["outputs"] || {}).each do |name, spec|
-          described << ["outputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
+          field_pairs << ["outputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
         end
-        described
+        field_pairs
           .select { |_key, value| value.is_a?(String) && value.include?("${{") }
           .map { |key, value| "#{path}: #{key} contains #{value.inspect}" }
       end

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -223,6 +223,33 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(test_cpflow_flow_path.read).to include("cpflow workflow wrappers use multiple upstream refs")
     end
 
+    # Issue #293: GitHub parses ${{ ... }} inside composite action `description:` fields
+    # while loading the manifest, where `vars` is unavailable. Any literal expression
+    # syntax there makes the entire action fail to load before workflow steps run.
+    it "keeps GitHub expression syntax out of composite action metadata descriptions" do
+      action_paths = Dir.glob(playground.join(".github/actions/*/action.yml").to_s).sort
+      expect(action_paths).not_to be_empty
+
+      violations = action_paths.flat_map do |path|
+        metadata = YAML.load_file(path, aliases: true)
+        described = []
+        described << ["description", metadata["description"]]
+        (metadata["inputs"] || {}).each do |name, spec|
+          described << ["inputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
+        end
+        (metadata["outputs"] || {}).each do |name, spec|
+          described << ["outputs.#{name}.description", spec.is_a?(Hash) ? spec["description"] : nil]
+        end
+        described
+          .select { |_key, value| value.is_a?(String) && value.include?("${{") }
+          .map { |key, value| "#{path}: #{key} contains #{value.inspect}" }
+      end
+
+      expect(violations).to be_empty,
+                            "Composite action descriptions must not embed GitHub expression syntax " \
+                            "(see issue #293):\n#{violations.join("\n")}"
+    end
+
     it "passes setup action versions through env before using them in shell commands" do
       contents = setup_action_path.read
 


### PR DESCRIPTION
## Summary

Test-only follow-up to #293. The runtime fix — rewriting the `cpflow-setup-environment` composite action's input descriptions in plain prose and adding a guardrail YAML comment — already shipped in 8e9c0c5 ("Move generated GitHub Actions logic upstream"). This PR adds the regression spec that issue #293's checklist asked for, so the literal-expression pattern can't quietly come back.

The new spec walks every generated composite action manifest and fails if any top-level, input, or output `description` contains `${{`, with a diagnostic that points at the offending key and file path.

Fixes #293.

## Test plan
- [x] `CPLN_ORG=dummy-test-org bundle exec rspec spec/command/generate_github_actions_spec.rb` — 45 examples, 0 failures
- [x] New test confirmed to fail when the pre-fix description text is reintroduced locally (reverted, ran, restored)
- [x] `bundle exec rubocop spec/command/generate_github_actions_spec.rb` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
