### PR TITLE
Friendly error in cpflow-detect-release-phase when controlplane.yml missing

### DIFF
--- a/.github/actions/cpflow-detect-release-phase/action.yml
+++ b/.github/actions/cpflow-detect-release-phase/action.yml
@@ -34,6 +34,13 @@ runs:
         require "yaml"
 
         app_name = ARGV.fetch(0)
+
+        unless File.file?(".controlplane/controlplane.yml")
+          warn "Error: `.controlplane/controlplane.yml` is missing. " \
+               "cpflow-detect-release-phase must be invoked from a cpflow-configured project."
+          exit 1
+        end
+
         data = YAML.safe_load(File.read(".controlplane/controlplane.yml"), aliases: true)
         apps = data["apps"] || {}
         app_config = apps[app_name]

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -630,7 +630,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       contents = detect_release_action_path.read
 
       expect(contents).to include('unless File.file?(".controlplane/controlplane.yml")')
-      expect(contents).to include(".controlplane/controlplane.yml` is missing")
+      expect(contents).to match(%r{`\.controlplane/controlplane\.yml` is missing.*?exit 1}m)
     end
 
     it "makes pull_request_target config validation skip cleanly when setup is incomplete" do

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -626,6 +626,13 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).not_to include("grep -qE")
     end
 
+    it "emits a friendly error before reading a missing controlplane.yml" do
+      contents = detect_release_action_path.read
+
+      expect(contents).to include('unless File.file?(".controlplane/controlplane.yml")')
+      expect(contents).to include(".controlplane/controlplane.yml` is missing")
+    end
+
     it "makes pull_request_target config validation skip cleanly when setup is incomplete" do
       contents = shared_action_path("cpflow-validate-config").read
 


### PR DESCRIPTION
## Summary

Closes #279 (last outstanding item — #7 in the issue).

The `cpflow-detect-release-phase` composite action embedded `File.read(".controlplane/controlplane.yml")` unconditionally, so missing config produced a raw `Errno::ENOENT` traceback. Now it guards on `File.file?` and exits with a clear "missing config" message instead.

Items #1–#6 from #279 shipped in #288.

## Test plan

- [x] `bundle exec rspec spec/command/generate_github_actions_spec.rb` — new spec asserts the guard text is generated.
- [x] Smoke-tested the embedded Ruby block both with and without `.controlplane/controlplane.yml` present (exit 1 + friendly message vs. exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple existence guard and message before reading `.controlplane/controlplane.yml`, plus a spec to lock in the generated output.
> 
> **Overview**
> `cpflow-detect-release-phase` now checks for `.controlplane/controlplane.yml` before attempting to read it, and exits with a clear, actionable error message when the file is missing (instead of raising a Ruby `ENOENT`).
> 
> The GitHub Actions generator spec suite is updated to assert that this missing-config guard and friendly error text are present in the generated composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ab1d50d9bac3a5c7d601abef6b5d7ac36bcc2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->