### PR TITLE
Handle non-zero exit from cpln workload exec gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero exit or signal from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of printing a generic "Command exited with non-zero status" error, cpflow now prints an actionable hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. The non-zero exit status is preserved so scripted callers can still detect genuine failures (auth, network, replica gone). Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
+- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero exit or signal from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of printing a generic "Command exited with non-zero status" error, cpflow now prints an actionable hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. A non-zero exit (`ExitCode::ERROR_DEFAULT`, 64) is still returned so scripted callers can detect genuine failures (auth, network, replica gone). Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
 
 ## [5.0.0.rc.2] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero exit or signal from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of printing a generic "Command exited with non-zero status" error, cpflow now prints an actionable hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. A non-zero exit (`ExitCode::ERROR_DEFAULT`, 64) is still returned so scripted callers can detect genuine failures (auth, network, replica gone). Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
+- Fixed `cpflow run` interactive sessions printing a confusing "Command exited with non-zero status" error when `cpln workload exec` exits non-zero or is signal-killed on session close. cpflow now prints an actionable `cpflow ps:stop` hint instead; exit code 64 is returned for non-zero exits and 130 for signal termination so scripted callers can still detect failure. Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). [PR 301](https://github.com/shakacode/control-plane-flow/pull/301) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.0.0.rc.2] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero status from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of compounding the upstream message with a generic "Command exited with non-zero status" error and exit code 64, cpflow now treats the upstream exit as informational and prints a hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
+- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero exit or signal from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of printing a generic "Command exited with non-zero status" error, cpflow now prints an actionable hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. The non-zero exit status is preserved so scripted callers can still detect genuine failures (auth, network, replica gone). Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
 
 ## [5.0.0.rc.2] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed broken UX when `cpflow run` interactive bash session ends with a non-zero status from the upstream `cpln workload exec` (e.g. "Failed to create terminal session"). Instead of compounding the upstream message with a generic "Command exited with non-zero status" error and exit code 64, cpflow now treats the upstream exit as informational and prints a hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active. Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). By [Justin Gordon](https://github.com/justin808).
+
 ## [5.0.0.rc.2] - 2026-05-23
 
 ### Added

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -265,17 +265,10 @@ module Command
 
     def run_interactive
       progress.puts("Connecting to replica '#{replica}'...\n\n")
-      # `workload_exec` returns true on clean exit, false on non-zero exit, or nil if the
-      # upstream process was killed by a signal / hit a SystemCallError. Only `true`
-      # counts as success — both falsy values fall through to the cleanup hint.
+      # `workload_exec` returns falsy on non-zero exit or signal (issue #199).
       success = cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
       return if success
 
-      # The upstream cpln CLI occasionally exits abnormally on session close (e.g.
-      # "Failed to create terminal session"; see issue #199). The bash session has
-      # usually ended cleanly, so replace the generic "Command exited with non-zero
-      # status" error with an actionable cleanup hint, but still propagate a non-zero
-      # exit so scripted callers can detect genuine failures.
       print_interactive_cleanup_hint
       exit(ExitCode::ERROR_DEFAULT)
     end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -265,8 +265,8 @@ module Command
 
     def run_interactive
       progress.puts("Connecting to replica '#{replica}'...\n\n")
-      # Returns false on non-zero status or nil on signal / SystemCallError; both fall
-      # through so the cleanup hint replaces the generic "non-zero status" abort.
+      # workload_exec returns false on non-zero exit, nil when signal-killed (e.g. Ctrl-C).
+      # Both fall through to the cleanup hint instead of the generic "non-zero status" abort.
       success = cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
       return if success
 
@@ -278,7 +278,7 @@ module Command
       progress.puts(Shell.color(
                       "\nThe interactive session ended with a non-zero exit or signal from the upstream CLI. " \
                       "If the runner workload is still running, stop it with:\n" \
-                      "  `cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}`",
+                      "  cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}",
                       :yellow
                     ))
     end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -265,7 +265,23 @@ module Command
 
     def run_interactive
       progress.puts("Connecting to replica '#{replica}'...\n\n")
-      cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
+      success = cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
+      return if success
+
+      # Upstream cpln CLI occasionally exits non-zero on session close (see issue #199).
+      # The bash session has usually exited cleanly, so guide the user on cleanup
+      # instead of aborting with a generic error.
+      print_interactive_cleanup_hint
+    end
+
+    def print_interactive_cleanup_hint
+      app_workload_replica_config = app_workload_replica_args.join(" ")
+      progress.puts(Shell.color(
+                      "\nThe interactive session ended with a non-zero status from the upstream CLI. " \
+                      "If the runner workload is still running, stop it with:\n" \
+                      "  `cpflow ps:stop #{app_workload_replica_config}`",
+                      :yellow
+                    ))
     end
 
     def run_non_interactive

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -271,15 +271,14 @@ module Command
       return if success
 
       print_interactive_cleanup_hint
-      exit(ExitCode::ERROR_DEFAULT)
+      exit(success.nil? ? ExitCode::INTERRUPT : ExitCode::ERROR_DEFAULT)
     end
 
     def print_interactive_cleanup_hint
-      app_workload_replica_config = app_workload_replica_args.join(" ")
       progress.puts(Shell.color(
                       "\nThe interactive session ended with a non-zero exit or signal from the upstream CLI. " \
                       "If the runner workload is still running, stop it with:\n" \
-                      "  `cpflow ps:stop #{app_workload_replica_config}`",
+                      "  `cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}`",
                       :yellow
                     ))
     end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -265,7 +265,8 @@ module Command
 
     def run_interactive
       progress.puts("Connecting to replica '#{replica}'...\n\n")
-      # `workload_exec` returns falsy on non-zero exit or signal (issue #199).
+      # Returns false on non-zero status or nil on signal / SystemCallError; both fall
+      # through so the cleanup hint replaces the generic "non-zero status" abort.
       success = cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
       return if success
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -265,19 +265,25 @@ module Command
 
     def run_interactive
       progress.puts("Connecting to replica '#{replica}'...\n\n")
+      # `workload_exec` returns true on clean exit, false on non-zero exit, or nil if the
+      # upstream process was killed by a signal / hit a SystemCallError. Only `true`
+      # counts as success — both falsy values fall through to the cleanup hint.
       success = cp.workload_exec(runner_workload, replica, location: location, container: container, command: command)
       return if success
 
-      # Upstream cpln CLI occasionally exits non-zero on session close (see issue #199).
-      # The bash session has usually exited cleanly, so guide the user on cleanup
-      # instead of aborting with a generic error.
+      # The upstream cpln CLI occasionally exits abnormally on session close (e.g.
+      # "Failed to create terminal session"; see issue #199). The bash session has
+      # usually ended cleanly, so replace the generic "Command exited with non-zero
+      # status" error with an actionable cleanup hint, but still propagate a non-zero
+      # exit so scripted callers can detect genuine failures.
       print_interactive_cleanup_hint
+      exit(ExitCode::ERROR_DEFAULT)
     end
 
     def print_interactive_cleanup_hint
       app_workload_replica_config = app_workload_replica_args.join(" ")
       progress.puts(Shell.color(
-                      "\nThe interactive session ended with a non-zero status from the upstream CLI. " \
+                      "\nThe interactive session ended with a non-zero exit or signal from the upstream CLI. " \
                       "If the runner workload is still running, stop it with:\n" \
                       "  `cpflow ps:stop #{app_workload_replica_config}`",
                       :yellow

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -530,7 +530,9 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     kernel_system_with_pid_handling(cmd)
   end
 
-  # NOTE: full analogue of Kernel.system which returns pids and saves it to child_pids for proper killing
+  # NOTE: full analogue of Kernel.system which returns pids and saves it to child_pids for proper killing.
+  # Returns true on zero exit, false on non-zero exit, nil when the process was signal-killed.
+  # SystemCallError (e.g. cpln binary missing) propagates — startup checks ensure this is unreachable in practice.
   def kernel_system_with_pid_handling(cmd)
     pid = Process.spawn(cmd)
     $child_pids << pid # rubocop:disable Style/GlobalVars
@@ -539,8 +541,6 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     $child_pids.delete(pid) # rubocop:disable Style/GlobalVars
 
     status.exited? ? status.success? : nil
-  rescue SystemCallError
-    nil
   end
 
   def perform!(cmd, output_mode: nil, sensitive_data_pattern: nil)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -282,7 +282,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     cmd = "cpln workload exec #{workload} #{gvc_org} --replica #{replica} --location #{location} -it"
     cmd += " --container #{container}" if container
     cmd += " -- #{command}"
-    perform!(cmd, output_mode: :all)
+    perform(cmd, output_mode: :all)
   end
 
   def start_cron_workload(workload, job_start_yaml, location:)

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Command::Run do
+  describe "#run_interactive" do
+    let(:config) { instance_double(Config, app: "test-app") }
+    let(:cp) { instance_double(Controlplane) }
+    let(:progress) { instance_double(IO, puts: nil) }
+    let(:command) { described_class.new(config) }
+
+    before do
+      allow(command).to receive_messages(cp: cp, progress: progress)
+      command.instance_variable_set(:@runner_workload, "rails-runner")
+      command.instance_variable_set(:@replica, "rails-runner-12345")
+      command.instance_variable_set(:@location, "aws-us-east-2")
+      command.instance_variable_set(:@container, "rails")
+      command.instance_variable_set(:@command, %(bash -c 'true'))
+      allow(cp).to receive(:workload_exec).and_return(exec_success)
+    end
+
+    context "when cpln workload exec exits successfully" do
+      let(:exec_success) { true }
+
+      it "does not print a cleanup hint" do
+        command.send(:run_interactive)
+
+        expect(progress).not_to have_received(:puts).with(/runner workload is still running/)
+      end
+    end
+
+    context "when cpln workload exec exits with a non-zero status" do
+      let(:exec_success) { false }
+
+      it "prints a cleanup hint instead of aborting" do
+        expect { command.send(:run_interactive) }.not_to raise_error
+
+        expect(progress).to have_received(:puts).with(include("cpflow ps:stop"))
+      end
+    end
+  end
+end

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -35,7 +35,14 @@ describe Command::Run do
           expect(error.status).to eq(ExitCode::ERROR_DEFAULT)
         end
 
-        expect(progress).to have_received(:puts).with(include("cpflow ps:stop"))
+        expect(progress).to have_received(:puts).with(
+          satisfy do |msg|
+            msg.include?("cpflow ps:stop") &&
+              msg.include?("-a test-app") &&
+              msg.include?("--workload rails-runner") &&
+              msg.include?("--replica rails-runner-12345")
+          end
+        )
       end
     end
 

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -25,14 +25,15 @@ describe Command::Run do
       it "does not print a cleanup hint" do
         command.send(:run_interactive)
 
+        expect(cp).to have_received(:workload_exec).once
         expect(progress).not_to have_received(:puts).with(/runner workload is still running/)
       end
     end
 
-    shared_examples "an aborted interactive session" do
+    shared_examples "an aborted interactive session" do |expected_exit_code|
       it "prints the cleanup hint instead of the generic error" do
         expect { command.send(:run_interactive) }.to raise_error(SystemExit) do |error|
-          expect(error.status).to eq(ExitCode::ERROR_DEFAULT)
+          expect(error.status).to eq(expected_exit_code)
         end
 
         expect(progress).to have_received(:puts).with(
@@ -40,7 +41,8 @@ describe Command::Run do
             msg.include?("cpflow ps:stop") &&
               msg.include?("-a test-app") &&
               msg.include?("--workload rails-runner") &&
-              msg.include?("--replica rails-runner-12345")
+              msg.include?("--replica rails-runner-12345") &&
+              msg.include?("--location aws-us-east-2")
           end
         )
       end
@@ -49,13 +51,13 @@ describe Command::Run do
     context "when cpln workload exec exits with a non-zero status" do
       let(:exec_success) { false }
 
-      it_behaves_like "an aborted interactive session"
+      it_behaves_like "an aborted interactive session", ExitCode::ERROR_DEFAULT
     end
 
     context "when cpln workload exec is killed by a signal" do
       let(:exec_success) { nil }
 
-      it_behaves_like "an aborted interactive session"
+      it_behaves_like "an aborted interactive session", ExitCode::INTERRUPT
     end
   end
 end

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -29,14 +29,26 @@ describe Command::Run do
       end
     end
 
-    context "when cpln workload exec exits with a non-zero status" do
-      let(:exec_success) { false }
-
-      it "prints a cleanup hint instead of aborting" do
-        expect { command.send(:run_interactive) }.not_to raise_error
+    shared_examples "an aborted interactive session" do
+      it "prints the cleanup hint instead of the generic error" do
+        expect { command.send(:run_interactive) }.to raise_error(SystemExit) do |error|
+          expect(error.status).to eq(ExitCode::ERROR_DEFAULT)
+        end
 
         expect(progress).to have_received(:puts).with(include("cpflow ps:stop"))
       end
+    end
+
+    context "when cpln workload exec exits with a non-zero status" do
+      let(:exec_success) { false }
+
+      it_behaves_like "an aborted interactive session"
+    end
+
+    context "when cpln workload exec is killed by a signal" do
+      let(:exec_success) { nil }
+
+      it_behaves_like "an aborted interactive session"
     end
   end
 end


### PR DESCRIPTION
## Summary

- `cpflow run` interactive mode previously surfaced a confusing `ERROR: Command exited with non-zero status.` and exited with code 64 whenever the upstream `cpln workload exec` exited non-zero on session close (e.g. `Failed to create terminal session: command terminated with exit code 1`). The bash session itself has usually exited cleanly, so the extra error and non-zero exit are misleading.
- `Controlplane#workload_exec` now uses `perform` (instead of `perform!`) and returns the success status; `Command::Run#run_interactive` swallows the non-zero exit and prints a yellow hint with the exact `cpflow ps:stop` command to clean up the runner workload if it is still active.
- Added a unit spec (`spec/command/run_unit_spec.rb`) that exercises both branches of the new behavior.

Fixes #199.

## Test plan

- [x] `bundle exec rubocop lib/command/run.rb lib/core/controlplane.rb spec/command/run_unit_spec.rb` passes.
- [x] `bundle exec rspec spec/command/run_unit_spec.rb spec/core/controlplane_spec.rb` passes (12 examples, 0 failures).
- [ ] Manual smoke-test on a real workload: `cpflow run -a <app>` → `exit` → verify no spurious `ERROR: Command exited with non-zero status.` is printed even if the upstream CLI returns non-zero, and that the cleanup hint appears when applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes interactive `cpflow run` exit/abort behavior and the return semantics of `Controlplane#workload_exec`, which could affect scripting expectations around non-zero exits and signal handling.
> 
> **Overview**
> Improves `cpflow run` *interactive* mode to avoid the generic "Command exited with non-zero status" abort when the underlying `cpln workload exec` exits non-zero or is signal-terminated; instead it prints a yellow, actionable `cpflow ps:stop ...` hint and exits with `64` (error) or `130` (interrupt).
> 
> `Controlplane#workload_exec` now uses non-bang execution (`perform`) so callers can inspect success (`true`), failure (`false`), or signal termination (`nil`), and a new unit spec covers the success and both failure branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8e840a72f501c231b579a8da77a39b9a952eaf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->