### PR TITLE
Add --mode=stop to cleanup-stale-apps (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Added
+
+- **Added `--mode=stop` to `cleanup-stale-apps` for reversible idle-app handling.** Suspends all workloads via `cpflow ps:stop` instead of deleting; restore with `cpflow ps:start`. Default `--mode=delete` preserves existing behavior. [Issue 295](https://github.com/shakacode/control-plane-flow/issues/295).
+
 ### Fixed
 
 - Fixed `cpflow run` interactive sessions printing a confusing "Command exited with non-zero status" error when `cpln workload exec` exits non-zero or is signal-killed on session close. cpflow now prints an actionable `cpflow ps:stop` hint instead; exit code 64 is returned for non-zero exits and 130 for signal termination so scripted callers can still detect failure. Fixes [issue 199](https://github.com/shakacode/control-plane-flow/issues/199). [PR 301](https://github.com/shakacode/control-plane-flow/pull/301) by [Justin Gordon](https://github.com/justin808).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,9 @@ cpflow cleanup-images -a $APP_NAME
 
 - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
 - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently. The command returns once each workload is marked suspended and does not wait for it to reach a not-ready state
+- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` — no GVC, volumeset, or image is removed; resume with `cpflow ps:start`
+- `--mode=stop` only suspends workloads listed in `app_workloads` + `additional_workloads`; workloads present in the live GVC but missing from the config are skipped silently
+- `--mode=stop` returns once each workload is marked suspended; it does not wait for the workload to reach a not-ready state
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
 - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
 - Will ask for explicit user confirmation

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,15 +78,19 @@ cpflow cleanup-images -a $APP_NAME
 
 ### `cleanup-stale-apps`
 
-- Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps
-- Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
-- Stale apps are identified based on the creation date of the latest image, or the GVC if no images exist
+- Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
+- With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
+- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
-- If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will delete all stale apps that start with the name
+- If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
 - Will ask for explicit user confirmation
 
 ```sh
+# Deletes stale apps (default).
 cpflow cleanup-stale-apps -a $APP_NAME
+
+# Stops stale apps instead of deleting them; resume with `cpflow ps:start`.
+cpflow cleanup-stale-apps -a $APP_NAME --mode=stop
 ```
 
 ### `config`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,7 @@ cpflow cleanup-images -a $APP_NAME
 
 - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
 - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently
+- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently. The command returns once each workload is marked suspended and does not wait for it to reach a not-ready state
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
 - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
 - Will ask for explicit user confirmation

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,7 @@ cpflow cleanup-images -a $APP_NAME
 
 - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
 - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed
+- With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
 - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
 - Will ask for explicit user confirmation

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -503,6 +503,8 @@ module Command
       }
     end
 
+    # Defined on Base (not CleanupStaleApps) so Cpflow::Cli.validate_options!
+    # can find it via Base.all_options, which greps `methods` for `_option$`.
     def self.cleanup_mode_option(required: false)
       {
         name: :mode,
@@ -512,7 +514,7 @@ module Command
           type: :string,
           required: required,
           default: "delete",
-          valid_regex: /^(delete|stop)$/
+          valid_regex: /\A(delete|stop)\z/
         }
       }
     end

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -518,7 +518,7 @@ module Command
           type: :string,
           required: required,
           default: "delete",
-          valid_regex: /\A(delete|stop)\z/
+          valid_regex: /^(delete|stop)$/
         }
       }
     end

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -502,6 +502,20 @@ module Command
         }
       }
     end
+
+    def self.cleanup_mode_option(required: false)
+      {
+        name: :mode,
+        params: {
+          banner: "MODE",
+          desc: "Action to take on stale apps: `delete` (default) or `stop`",
+          type: :string,
+          required: required,
+          default: "delete",
+          valid_regex: /^(delete|stop)$/
+        }
+      }
+    end
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -505,6 +505,10 @@ module Command
 
     # Defined on Base (not CleanupStaleApps) so Cpflow::Cli.validate_options!
     # can find it via Base.all_options, which greps `methods` for `_option$`.
+    # TODO: the `--mode` key is owned by this option; if another command ever
+    # needs its own `--mode` with different semantics, rename one of them
+    # before adding a second `*_mode_option` (they would collide in
+    # `all_options_by_key_name`).
     def self.cleanup_mode_option(required: false)
       {
         name: :mode,

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -503,25 +503,6 @@ module Command
       }
     end
 
-    # Defined on Base (not CleanupStaleApps) so Cpflow::Cli.validate_options!
-    # can find it via Base.all_options, which greps `methods` for `_option$`.
-    # TODO: the `--mode` key is owned by this option; if another command ever
-    # needs its own `--mode` with different semantics, rename one of them
-    # before adding a second `*_mode_option` (they would collide in
-    # `all_options_by_key_name`).
-    def self.cleanup_mode_option(required: false)
-      {
-        name: :mode,
-        params: {
-          banner: "MODE",
-          desc: "Action to take on stale apps: `delete` (default) or `stop`",
-          type: :string,
-          required: required,
-          default: "delete",
-          valid_regex: /^(delete|stop)$/
-        }
-      }
-    end
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -12,7 +12,9 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
       - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently. The command returns once each workload is marked suspended and does not wait for it to reach a not-ready state
+      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` — no GVC, volumeset, or image is removed; resume with `cpflow ps:start`
+      - `--mode=stop` only suspends workloads listed in `app_workloads` + `additional_workloads`; workloads present in the live GVC but missing from the config are skipped silently
+      - `--mode=stop` returns once each workload is marked suspended; it does not wait for the workload to reach a not-ready state
       - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
       - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
       - Will ask for explicit user confirmation
@@ -86,6 +88,7 @@ module Command
 
     def process_app(app)
       if mode == "stop"
+        progress.puts("Stopping app '#{app}'")
         run_cpflow_command("ps:stop", "-a", app)
       else
         run_cpflow_command("delete", "-a", app, "--yes")

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -81,8 +81,7 @@ module Command
     def confirm_action
       return true if config.options[:yes]
 
-      verb = mode == "stop" ? "stop" : "delete"
-      Shell.confirm("\nAre you sure you want to #{verb} these #{stale_apps.length} apps?")
+      Shell.confirm("\nAre you sure you want to #{mode} these #{stale_apps.length} apps?")
     end
 
     def process_app(app)
@@ -94,7 +93,7 @@ module Command
     end
 
     def mode
-      config.options[:mode] || "delete"
+      config.options[:mode]
     end
   end
 end

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -2,11 +2,23 @@
 
 module Command
   class CleanupStaleApps < Base
+    CLEANUP_MODE_OPTION = {
+      name: :mode,
+      params: {
+        banner: "MODE",
+        desc: "Action to take on stale apps: `delete` (default) or `stop`",
+        type: :string,
+        required: false,
+        default: "delete",
+        valid_regex: /^(delete|stop)$/
+      }
+    }.freeze
+
     NAME = "cleanup-stale-apps"
     OPTIONS = [
       app_option(required: true),
       skip_confirm_option,
-      cleanup_mode_option
+      CLEANUP_MODE_OPTION
     ].freeze
     DESCRIPTION = "Deletes or stops stale apps based on the latest image's creation date"
     LONG_DESCRIPTION = <<~DESC
@@ -83,7 +95,7 @@ module Command
     def confirm_action
       return true if config.options[:yes]
 
-      Shell.confirm("\nAre you sure you want to #{mode} these #{stale_apps.length} apps?")
+      Shell.confirm("\nAre you sure you want to #{action_description} these #{stale_apps.length} apps?")
     end
 
     def process_app(app)
@@ -95,8 +107,12 @@ module Command
       end
     end
 
+    def action_description
+      mode == "stop" ? "suspend all workloads in" : "delete"
+    end
+
     def mode
-      config.options[:mode]
+      @mode ||= config.options[:mode]
     end
   end
 end

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -12,7 +12,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
       - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently
+      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently. The command returns once each workload is marked suspended and does not wait for it to reach a not-ready state
       - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
       - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
       - Will ask for explicit user confirmation

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -5,17 +5,27 @@ module Command
     NAME = "cleanup-stale-apps"
     OPTIONS = [
       app_option(required: true),
-      skip_confirm_option
+      skip_confirm_option,
+      cleanup_mode_option
     ].freeze
-    DESCRIPTION = "Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps"
+    DESCRIPTION = "Deletes or stops stale apps based on the latest image's creation date"
     LONG_DESCRIPTION = <<~DESC
-      - Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps
-      - Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
-      - Stale apps are identified based on the creation date of the latest image, or the GVC if no images exist
+      - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
+      - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
+      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed
       - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
-      - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will delete all stale apps that start with the name
+      - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
       - Will ask for explicit user confirmation
     DESC
+    EXAMPLES = <<~EX
+      ```sh
+      # Deletes stale apps (default).
+      cpflow cleanup-stale-apps -a $APP_NAME
+
+      # Stops stale apps instead of deleting them; resume with `cpflow ps:start`.
+      cpflow cleanup-stale-apps -a $APP_NAME --mode=stop
+      ```
+    EX
 
     def call # rubocop:disable Metrics/MethodLength
       return progress.puts("No stale apps found.") if stale_apps.empty?
@@ -25,11 +35,11 @@ module Command
         progress.puts("  - #{app[:name]} (#{Shell.color(app[:date].to_s, :red)})")
       end
 
-      return unless confirm_delete
+      return unless confirm_action
 
       progress.puts
       stale_apps.each do |app|
-        delete_app(app[:name])
+        process_app(app[:name])
         progress.puts
       end
     end
@@ -68,14 +78,23 @@ module Command
         end
     end
 
-    def confirm_delete
+    def confirm_action
       return true if config.options[:yes]
 
-      Shell.confirm("\nAre you sure you want to delete these #{stale_apps.length} apps?")
+      verb = mode == "stop" ? "stop" : "delete"
+      Shell.confirm("\nAre you sure you want to #{verb} these #{stale_apps.length} apps?")
     end
 
-    def delete_app(app)
-      run_cpflow_command("delete", "-a", app, "--yes")
+    def process_app(app)
+      if mode == "stop"
+        run_cpflow_command("ps:stop", "-a", app)
+      else
+        run_cpflow_command("delete", "-a", app, "--yes")
+      end
+    end
+
+    def mode
+      config.options[:mode] || "delete"
     end
   end
 end

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -12,7 +12,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Acts on stale apps based on the creation date of the latest image, or the GVC if no images exist
       - With `--mode=delete` (default): deletes the whole app (GVC with all workloads, all volumesets and all images), and unbinds the app from the secrets policy as long as both the identity and the policy exist (and are bound)
-      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed
+      - With `--mode=stop`: suspends all workloads via `cpflow ps:stop` so the app can be resumed later with `cpflow ps:start` — no GVC, volumeset, or image is removed. Only workloads listed in `app_workloads` + `additional_workloads` in `.controlplane/controlplane.yml` are suspended; workloads present in the live GVC but missing from the config are skipped silently
       - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
       - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will act on all stale apps that start with the name
       - Will ask for explicit user confirmation

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -277,8 +277,8 @@ module Command
     def print_interactive_cleanup_hint
       progress.puts(Shell.color(
                       "\nThe interactive session ended with a non-zero exit or signal from the upstream CLI. " \
-                      "If the runner workload is still running, stop it with:\n" \
-                      "  cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}",
+                      "If the runner workload is still running, stop it with:\n  " \
+                      "cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}",
                       :yellow
                     ))
     end

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -307,7 +307,7 @@ module Cpflow
         end
 
         begin
-          Cpflow::Cli.validate_options!(options)
+          Cpflow::Cli.validate_options!(options, command_options: command_options)
 
           config = Config.new(args, options, required_options)
 
@@ -333,25 +333,39 @@ module Cpflow
     check_unknown_options!(except: @commands_with_extra_options)
     stop_on_unknown_option!
 
-    def self.validate_options!(options) # rubocop:disable Metrics/MethodLength
+    def self.validate_options!(options, command_options: ::Command::Base.all_options)
+      option_definitions = option_definitions_for(command_options)
+
       options.each do |name, value|
         normalized_name = ::Helpers.normalize_option_name(name)
         raise "No value provided for option #{normalized_name}." if value.to_s.strip.empty?
 
-        option = ::Command::Base.all_options.find { |current_option| current_option[:name].to_s == name }
-        if option[:new_name]
-          normalized_new_name = ::Helpers.normalize_option_name(option[:new_name])
-          ::Shell.warn_deprecated("Option #{normalized_name} is deprecated, " \
-                                  "please use #{normalized_new_name} instead.")
-          $stderr.puts
-        end
-
-        params = option[:params]
-        next unless params[:valid_regex]
-
-        raise "Invalid value provided for option #{normalized_name}." unless value.match?(params[:valid_regex])
+        option = option_definitions.find { |current_option| current_option[:name].to_s == name }
+        validate_option!(option, normalized_name, value) if option
       end
     end
+
+    def self.option_definitions_for(command_options)
+      (::Command::Base.common_options + command_options).uniq { |option| option[:name] }
+    end
+    private_class_method :option_definitions_for
+
+    def self.validate_option!(option, normalized_name, value)
+      warn_deprecated_option(option, normalized_name) if option[:new_name]
+
+      params = option[:params]
+      return unless params[:valid_regex]
+
+      raise "Invalid value provided for option #{normalized_name}." unless value.match?(params[:valid_regex])
+    end
+    private_class_method :validate_option!
+
+    def self.warn_deprecated_option(option, normalized_name)
+      normalized_new_name = ::Helpers.normalize_option_name(option[:new_name])
+      ::Shell.warn_deprecated("Option #{normalized_name} is deprecated, please use #{normalized_new_name} instead.")
+      $stderr.puts
+    end
+    private_class_method :warn_deprecated_option
 
     def self.show_info_header(config) # rubocop:disable Metrics/MethodLength
       return if @showed_info_header

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -62,7 +62,7 @@ describe Command::CleanupStaleApps do
     end
   end
 
-  context "when there are no stale apps to delete" do
+  context "when there are no stale apps to act on" do
     let!(:app) { dummy_test_app }
 
     it "displays message" do

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -128,7 +128,9 @@ describe Command::CleanupStaleApps do
       # the stale-apps listing and that the stop step ran twice (once per app).
       expect(result[:stderr]).to include("- #{app1}")
       expect(result[:stderr]).to include("- #{app2}")
-      expect(result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/).length).to eq(2)
+      stop_lines = result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/)
+      expect(stop_lines.length).to eq(2),
+                                   "expected exactly 2 'Stopping workload postgres' lines; got: #{result[:stderr]}"
     end
 
     it "asks for confirmation and deletes stale apps", :slow do
@@ -179,7 +181,9 @@ describe Command::CleanupStaleApps do
       # the stale-apps listing and that the stop step ran twice (once per app).
       expect(result[:stderr]).to include("- #{app1}")
       expect(result[:stderr]).to include("- #{app2}")
-      expect(result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/).length).to eq(2)
+      stop_lines = result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/)
+      expect(stop_lines.length).to eq(2),
+                                   "expected exactly 2 'Stopping workload postgres' lines; got: #{result[:stderr]}"
     end
   end
 

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -160,6 +160,19 @@ describe Command::CleanupStaleApps do
       expect(result[:stderr]).to match(/Deleting app '#{app2}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting image '#{app2}:1' from app '#{app2}'[.]+? done!/)
     end
+
+    it "skips confirmation and stops stale apps when --mode=stop --yes", :slow do
+      allow(Shell).to receive(:confirm).and_return(false)
+
+      travel_to_days_later(30)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--mode=stop", "--yes")
+      travel_back
+
+      expect(Shell).not_to have_received(:confirm)
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).not_to include("Deleting app")
+      expect(result[:stderr]).to match(/Stopping workload 'postgres'[.]+? done!/)
+    end
   end
 
   context "with multiple apps" do

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -51,6 +51,17 @@ describe Command::CleanupStaleApps do
     end
   end
 
+  context "when --mode value is invalid" do
+    let!(:app) { dummy_test_app }
+
+    it "rejects the command" do
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app, "--mode=pause")
+
+      expect(result[:status]).not_to eq(0)
+      expect(result[:stderr]).to include("Invalid value provided for option --mode.")
+    end
+  end
+
   context "when there are no stale apps to delete" do
     let!(:app) { dummy_test_app }
 
@@ -79,7 +90,7 @@ describe Command::CleanupStaleApps do
     end
 
     it "asks for confirmation and does nothing", :slow do
-      allow(Shell).to receive(:confirm).with(include("2 apps")).and_return(false)
+      allow(Shell).to receive(:confirm).with(include("delete these 2 apps")).and_return(false)
 
       travel_to_days_later(30)
       result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)
@@ -88,6 +99,19 @@ describe Command::CleanupStaleApps do
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Deleting app")
+    end
+
+    it "uses stop wording when --mode=stop and does nothing on declined confirmation", :slow do
+      allow(Shell).to receive(:confirm).with(include("stop these 2 apps")).and_return(false)
+
+      travel_to_days_later(30)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--mode=stop")
+      travel_back
+
+      expect(Shell).to have_received(:confirm).once
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).not_to include("Deleting app")
+      expect(result[:stderr]).not_to include("Stopping workload")
     end
 
     it "asks for confirmation and deletes stale apps", :slow do

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -171,7 +171,11 @@ describe Command::CleanupStaleApps do
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Deleting app")
-      expect(result[:stderr]).to match(/Stopping workload 'postgres'[.]+? done!/)
+      # ps:stop output does not echo the app name, so assert both apps appear in
+      # the stale-apps listing and that the stop step ran twice (once per app).
+      expect(result[:stderr]).to include("- #{app1}")
+      expect(result[:stderr]).to include("- #{app2}")
+      expect(result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/).length).to eq(2)
     end
   end
 

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -124,7 +124,11 @@ describe Command::CleanupStaleApps do
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Deleting app")
-      expect(result[:stderr]).to match(/Stopping workload 'postgres'[.]+? done!/)
+      # ps:stop output does not echo the app name, so assert both apps appear in
+      # the stale-apps listing and that the stop step ran twice (once per app).
+      expect(result[:stderr]).to include("- #{app1}")
+      expect(result[:stderr]).to include("- #{app2}")
+      expect(result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/).length).to eq(2)
     end
 
     it "asks for confirmation and deletes stale apps", :slow do

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -73,7 +73,7 @@ describe Command::CleanupStaleApps do
     end
   end
 
-  context "when there are stale apps to delete" do
+  context "when there are stale apps" do
     let!(:app1) { dummy_test_app("stale-app") }
     let!(:app2) { dummy_test_app("stale-app") }
 
@@ -114,8 +114,21 @@ describe Command::CleanupStaleApps do
       expect(result[:stderr]).not_to include("Stopping workload")
     end
 
+    it "asks for confirmation and stops stale apps when --mode=stop", :slow do
+      allow(Shell).to receive(:confirm).with(include("stop these 2 apps")).and_return(true)
+
+      travel_to_days_later(30)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--mode=stop")
+      travel_back
+
+      expect(Shell).to have_received(:confirm).once
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).not_to include("Deleting app")
+      expect(result[:stderr]).to match(/Stopping workload 'postgres'[.]+? done!/)
+    end
+
     it "asks for confirmation and deletes stale apps", :slow do
-      allow(Shell).to receive(:confirm).with(include("2 apps")).and_return(true)
+      allow(Shell).to receive(:confirm).with(include("delete these 2 apps")).and_return(true)
 
       travel_to_days_later(30)
       result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -124,10 +124,9 @@ describe Command::CleanupStaleApps do
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Deleting app")
-      # ps:stop output does not echo the app name, so assert both apps appear in
-      # the stale-apps listing and that the stop step ran twice (once per app).
-      expect(result[:stderr]).to include("- #{app1}")
-      expect(result[:stderr]).to include("- #{app2}")
+      # Per-app header gives the workload-stop output app-name context in CI logs.
+      expect(result[:stderr]).to include("Stopping app '#{app1}'")
+      expect(result[:stderr]).to include("Stopping app '#{app2}'")
       stop_lines = result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/)
       expect(stop_lines.length).to eq(2),
                                    "expected exactly 2 'Stopping workload postgres' lines; got: #{result[:stderr]}"
@@ -177,10 +176,9 @@ describe Command::CleanupStaleApps do
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Deleting app")
-      # ps:stop output does not echo the app name, so assert both apps appear in
-      # the stale-apps listing and that the stop step ran twice (once per app).
-      expect(result[:stderr]).to include("- #{app1}")
-      expect(result[:stderr]).to include("- #{app2}")
+      # Per-app header gives the workload-stop output app-name context in CI logs.
+      expect(result[:stderr]).to include("Stopping app '#{app1}'")
+      expect(result[:stderr]).to include("Stopping app '#{app2}'")
       stop_lines = result[:stderr].scan(/Stopping workload 'postgres'[.]+? done!/)
       expect(stop_lines.length).to eq(2),
                                    "expected exactly 2 'Stopping workload postgres' lines; got: #{result[:stderr]}"

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -6,6 +6,43 @@ require "spec_helper"
 describe Command::CleanupStaleApps do
   let!(:app_prefix) { dummy_test_app_prefix("stale-app") }
 
+  describe ".OPTIONS" do
+    it "keeps the cleanup mode option scoped to cleanup-stale-apps" do
+      expect(described_class::OPTIONS.map { |option| option[:name] }).to include(:mode)
+      expect(Command::Base.all_options.map { |option| option[:name] }).not_to include(:mode)
+    end
+  end
+
+  describe "#confirm_action" do
+    let(:config) { instance_double(Config, options: { mode: mode, yes: false }) }
+    let(:command) { described_class.new(config) }
+
+    before do
+      allow(command).to receive(:stale_apps).and_return([{ name: "app-1" }, { name: "app-2" }])
+      allow(Shell).to receive(:confirm).and_return(false)
+    end
+
+    context "with delete mode" do
+      let(:mode) { "delete" }
+
+      it "confirms app deletion" do
+        command.send(:confirm_action)
+
+        expect(Shell).to have_received(:confirm).with(include("delete these 2 apps"))
+      end
+    end
+
+    context "with stop mode" do
+      let(:mode) { "stop" }
+
+      it "confirms workload suspension" do
+        command.send(:confirm_action)
+
+        expect(Shell).to have_received(:confirm).with(include("suspend all workloads in these 2 apps"))
+      end
+    end
+  end
+
   describe "#stale_apps" do
     let(:config) { instance_double(Config, app: "dummy-test") }
     let(:cp) { instance_double(Controlplane) }
@@ -101,8 +138,8 @@ describe Command::CleanupStaleApps do
       expect(result[:stderr]).not_to include("Deleting app")
     end
 
-    it "uses stop wording when --mode=stop and does nothing on declined confirmation", :slow do
-      allow(Shell).to receive(:confirm).with(include("stop these 2 apps")).and_return(false)
+    it "uses workload-suspension wording when --mode=stop and does nothing on declined confirmation", :slow do
+      allow(Shell).to receive(:confirm).with(include("suspend all workloads in these 2 apps")).and_return(false)
 
       travel_to_days_later(30)
       result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--mode=stop")
@@ -115,7 +152,7 @@ describe Command::CleanupStaleApps do
     end
 
     it "asks for confirmation and stops stale apps when --mode=stop", :slow do
-      allow(Shell).to receive(:confirm).with(include("stop these 2 apps")).and_return(true)
+      allow(Shell).to receive(:confirm).with(include("suspend all workloads in these 2 apps")).and_return(true)
 
       travel_to_days_later(30)
       result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--mode=stop")

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -20,6 +20,23 @@ describe Cpflow do
     end
   end
 
+  describe ".validate_options!" do
+    it "validates regexes against the current command options only" do
+      command_options = [
+        {
+          name: :mode,
+          params: {
+            valid_regex: /^(preview|apply)$/
+          }
+        }
+      ]
+
+      expect do
+        Cpflow::Cli.validate_options!({ "mode" => "preview" }, command_options: command_options)
+      end.not_to raise_error
+    end
+  end
+
   it "handles subcommands correctly" do
     result = run_cpflow_command("--help")
 


### PR DESCRIPTION
## Summary

- Adds a `--mode` flag to `cpflow cleanup-stale-apps` with two values: `delete` (default; current behavior) and `stop` (new).
- `--mode=stop` runs `cpflow ps:stop -a <app>` for each stale app — suspends every workload via `defaultOptions.suspend: true`, leaves the GVC, volumesets, and images alone, and is reversible with `cpflow ps:start`.
- Staleness detection (`stale_app_image_deployed_days` config + latest-image creation date) is unchanged.
- Confirmation prompt is mode-aware: "Are you sure you want to stop these N apps?" vs "Are you sure you want to delete these N apps?".

## Design decisions (from the issue's open questions)

- **Single threshold.** Kept the existing `stale_app_image_deployed_days` as the only staleness config. Teams wanting two-stage cleanup (stop at 7d, delete at 30d) can run the command twice in CI with different configs / prefixes — no new config keys needed for this PR.
- **No "already suspended" skip.** Mirrors `ps:stop` behavior — re-setting `suspend: true` on an already-suspended workload is effectively a no-op. Detecting that would require an extra fetch per workload for no real win.
- **Mode-aware confirmation wording.** Verified by spec.

## Files changed

- `lib/command/cleanup_stale_apps.rb` — wires `--mode`, refactors `confirm_delete`/`delete_app` into `confirm_action`/`process_app`, updates `DESCRIPTION`/`LONG_DESCRIPTION`, adds `EXAMPLES`.
- `lib/command/base.rb` — adds `cleanup_mode_option` (validated via `valid_regex: /^(delete|stop)$/`, default `delete`). Defined on `Base` so `Cpflow::Cli.validate_options!` can look it up.
- `spec/command/cleanup_stale_apps_spec.rb` — adds an offline spec rejecting `--mode=pause`, and a slow spec verifying the "stop these N apps" prompt wording when `--mode=stop` is supplied. Tightens the existing default-mode confirm test to assert "delete these 2 apps".
- `docs/commands.md` — documents the flag and adds a `--mode=stop` example.
- `CHANGELOG.md` — `Unreleased` → `Added` entry.

## Test plan

- [x] `bundle exec rubocop lib/command/cleanup_stale_apps.rb lib/command/base.rb spec/command/cleanup_stale_apps_spec.rb` — clean.
- [x] `bundle exec rspec spec/command/cleanup_stale_apps_spec.rb:12 spec/command/cleanup_stale_apps_spec.rb:23` (offline specs) — pass.
- [x] `ruby bin/cpflow help cleanup-stale-apps` — `--mode=MODE` shows in Options with `Default: delete`, both modes documented in Description.
- [ ] Slow specs (require `CPLN_ORG` + token): the two pre-existing `:slow` specs that build images, plus the new `:slow` spec for `--mode=stop` confirmation wording. Will run in CI.

## Out of scope (per issue #295)

- No new config keys (`stale_app_stop_days` etc.).
- No CPLN scale-to-zero auto-detection (#188 covers that, closed in favor of this narrower change).
- No auto-restart of stopped apps — manual `cpflow ps:start` is sufficient.

Fixes #295

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution path that invokes `ps:stop` instead of deletion and adjusts CLI option validation; risk is moderate due to potentially impacting automation that relies on cleanup semantics and option parsing.
> 
> **Overview**
> `cpflow cleanup-stale-apps` now supports `--mode=stop` (default remains `delete`) to *suspend workloads instead of deleting apps*, making stale-app cleanup reversible via `cpflow ps:start`.
> 
> To support command-specific flags, option validation is updated to validate `valid_regex` against the current command’s option set (plus common options), and docs/changelog/tests are updated to cover the new mode, confirmation wording, and invalid `--mode` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ca40bdabe181a9bca28e6e17c85a2cf3a77afd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `cleanup-stale-apps` gains a `--mode` option: `--mode=delete` (default) removes stale apps; `--mode=stop` suspends workloads to preserve apps for later resume (`cpflow ps:stop` / `cpflow ps:start`).

* **Documentation**
  * Command docs and changelog updated to explain `--mode` behaviors and show examples for both delete and stop flows.

* **Tests**
  * Tests added for invalid mode values and for confirmed/declined flows (delete and stop), including a skip-confirmation stop scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->