### PR TITLE
Use Node 24 GitHub action versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Changed
+
+- **Updated generated GitHub Actions workflow templates to Node 24-compatible action versions** by using `actions/checkout@v6` and `actions/github-script@v8`. [PR 303](https://github.com/shakacode/control-plane-flow/pull/303) by [Justin Gordon](https://github.com/justin808).
+
 ### Fixed
 
 - **Relaxed `thor` runtime dependency from `~> 1.4` to `~> 1.3`** so cpflow can be bundled into Rails 8 apps that pull in `solid_queue` 1.1.0 (Rails 8.0.x default), which pins `thor ~> 1.3.1`. The previous `~> 1.4` constraint had zero overlap with that pin and forced users to install cpflow globally instead of adding it to the Gemfile. [Issue 264](https://github.com/shakacode/control-plane-flow/issues/264) / [PR 291](https://github.com/shakacode/control-plane-flow/pull/291) by [Justin Gordon](https://github.com/justin808).

--- a/lib/github_flow_templates/.github/workflows/cpflow-cleanup-stale-review-apps.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-cleanup-stale-review-apps.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
@@ -49,7 +49,7 @@ jobs:
       # the trust boundary. All local composite actions below are therefore loaded from
       # trusted base-branch code; keep them that way when changing this workflow.
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Delete only invokes `cpln`/`cpflow`; no git push happens, so drop the
           # GITHUB_TOKEN credential helper to keep the token out of .git/config under
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set workflow links
         if: steps.config.outputs.ready == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -94,7 +94,7 @@ jobs:
       - name: Create initial PR comment
         if: steps.config.outputs.ready == 'true'
         id: create-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const comment = await github.rest.issues.createComment({
@@ -117,7 +117,7 @@ jobs:
       # created the initial PR comment and workflow link env vars it updates.
       - name: Finalize delete status
         if: always() && steps.config.outputs.ready == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
           JOB_STATUS: ${{ job.status }}

--- a/lib/github_flow_templates/.github/workflows/cpflow-deploy-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-deploy-review-app.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout trusted workflow sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Keep generated composite actions on the trusted base branch. The PR
           # application code is checked out separately under ./app after source
@@ -164,7 +164,7 @@ jobs:
 
       - name: Checkout PR commit
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.PR_SHA }}
           path: app
@@ -251,7 +251,7 @@ jobs:
       - name: Create initial PR comment
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         id: create-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const result = await github.rest.issues.createComment({
@@ -264,7 +264,7 @@ jobs:
 
       - name: Set deployment links
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const workflowUrl = `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
@@ -277,7 +277,7 @@ jobs:
       - name: Initialize GitHub deployment
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         id: init-deployment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const deployment = await github.rest.repos.createDeployment({
@@ -302,7 +302,7 @@ jobs:
 
       - name: Update PR comment with build status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
@@ -343,7 +343,7 @@ jobs:
 
       - name: Update PR comment with deploy status
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
         with:
@@ -399,7 +399,7 @@ jobs:
 
       - name: Finalize deployment status
         if: always() && steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
           DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}

--- a/lib/github_flow_templates/.github/workflows/cpflow-deploy-staging.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-deploy-staging.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.check-branch.outputs.is_deployable == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -108,7 +108,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/lib/github_flow_templates/.github/workflows/cpflow-help-command.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-help-command.yml
@@ -33,14 +33,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Help only reads `.github/cpflow-help.md`; no git push happens, so drop the
           # GITHUB_TOKEN credential helper to keep the token out of .git/config.
           persist-credentials: false
 
       - name: Post help message
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require("fs");

--- a/lib/github_flow_templates/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/lib/github_flow_templates/.github/workflows/cpflow-review-app-help.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-review-app-help.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Post quick reference
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = [

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -95,6 +95,16 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(staging_workflow_path.read).to include("cpflow_version: ${{ vars.CPFLOW_VERSION }}")
     end
 
+    it "uses Node 24 action versions in generated workflows" do
+      contents = generated_yaml_paths.map { |path| File.read(path) }.join("\n")
+
+      expect(contents).to include("actions/checkout@v6")
+      expect(contents).to include("actions/github-script@v8")
+      expect(contents).not_to include("actions/checkout@v4")
+      expect(contents).not_to include("actions/checkout@v5")
+      expect(contents).not_to include("actions/github-script@v7")
+    end
+
     it "passes setup action versions through env before using them in shell commands" do
       contents = setup_action_path.read
 


### PR DESCRIPTION
## Summary
- update generated cpflow GitHub workflow templates from actions/checkout@v4 to @v6
- update generated cpflow GitHub workflow templates from actions/github-script@v7 to @v8
- add a generator spec guard so Node 20 action versions do not come back

## Verification
- env CPLN_ORG=dummy-test-org bundle exec rspec spec/command/generate_github_actions_spec.rb
- env XDG_CACHE_HOME=/private/tmp/rubocop-cache RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop spec/command/generate_github_actions_spec.rb
- ruby -e 'require "yaml"; Dir["lib/github_flow_templates/.github/workflows/*.yml"].sort.each { |path| YAML.load_file(path, aliases: true); puts path }'
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: template-only GitHub Actions version bumps plus a spec guard; behavior should be unchanged aside from using newer action releases.
> 
> **Overview**
> Updates the generated cpflow GitHub Actions workflow templates to use **Node 24-compatible** action versions, bumping `actions/checkout` to `v6` and `actions/github-script` to `v8` across review-app, staging, cleanup, help, and promotion workflows.
> 
> Adds a generator spec assertion to pin these versions and fail if older `checkout@v4/v5` or `github-script@v7` reappear, and records the change in `CHANGELOG.md` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc0fb2c751ebfd1921fb754f263893e91868b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions used by generated workflows to Node‑24–compatible releases (checkout → v6; github‑script → v8).
* **Tests**
  * Added automated spec to verify generated workflows pin the new action versions and reject older pins.
* **Documentation**
  * Noted these workflow version updates in the Unreleased changelog entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->