### PR TITLE
Fallback Ruby setup when no version file exists

### DIFF
--- a/.github/actions/cpflow-setup-environment/action.yml
+++ b/.github/actions/cpflow-setup-environment/action.yml
@@ -10,12 +10,13 @@ inputs:
     required: true
   ruby_version:
     description: >-
-      Ruby version used for cpflow. When empty (the default), ruby/setup-ruby auto-detects
-      from .ruby-version, .tool-versions, or the Gemfile.
+      Ruby version used for cpflow. When empty (the default), ruby/setup-ruby
+      auto-detects from .ruby-version, .tool-versions, mise.toml, or a Gemfile
+      ruby directive, then falls back to the action's pinned default.
     required: false
     default: ""
   working_directory:
-    description: Directory where ruby/setup-ruby should detect .ruby-version, .tool-versions, or the Gemfile.
+    description: Directory where ruby/setup-ruby should detect Ruby version files.
     required: false
     default: "."
   # GitHub parses double-brace expression snippets inside action metadata (including
@@ -42,12 +43,41 @@ runs:
   # ruby/setup-ruby tracks Ruby/toolcache updates on a major tag. The privileged
   # reusable workflows pin GitHub-owned actions to immutable SHAs.
   steps:
+    - name: Resolve Ruby setup version
+      id: ruby-version
+      shell: bash
+      env:
+        INPUT_RUBY_VERSION: ${{ inputs.ruby_version }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working_directory }}
+      run: |
+        set -euo pipefail
+
+        ruby_version="${INPUT_RUBY_VERSION}"
+        working_directory="${INPUT_WORKING_DIRECTORY:-.}"
+        # Bump when the project's minimum-supported Ruby advances.
+        default_ruby_version="3.2"
+
+        if [[ -z "${ruby_version}" ]]; then
+          if [[ -f "${working_directory}/.ruby-version" ]] ||
+             { [[ -f "${working_directory}/.tool-versions" ]] && grep -Eq "^[[:space:]]*ruby[[:space:]]+" "${working_directory}/.tool-versions"; } ||
+             { [[ -f "${working_directory}/mise.toml" ]] && grep -Eq "^[[:space:]]*ruby[[:space:]]*=" "${working_directory}/mise.toml"; } ||
+             { [[ -f "${working_directory}/.mise.toml" ]] && grep -Eq "^[[:space:]]*ruby[[:space:]]*=" "${working_directory}/.mise.toml"; }; then
+            : # keep empty; ruby/setup-ruby will auto-detect
+          elif [[ -f "${working_directory}/Gemfile" ]] && grep -Eq "^[[:space:]]*ruby[[:space:]]*(\(|file:|['\"])" "${working_directory}/Gemfile"; then
+            : # keep empty; ruby/setup-ruby will read Gemfile
+          else
+            ruby_version="${default_ruby_version}"
+          fi
+        fi
+
+        echo "ruby_version=${ruby_version}" >> "$GITHUB_OUTPUT"
+
     - name: Set up Ruby
       # ruby/setup-ruby intentionally tracks the v1 tag so Ruby/toolcache updates
       # roll out automatically; Dependabot/Renovate can manage this non-GitHub action.
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ inputs.ruby_version }}
+        ruby-version: ${{ steps.ruby-version.outputs.ruby_version }}
         working-directory: ${{ inputs.working_directory }}
 
     - name: Install Control Plane CLI and cpflow gem

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -207,6 +207,12 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("CPLN_CLI_VERSION: ${{ inputs.cpln_cli_version }}")
       expect(contents).to include("CPFLOW_VERSION: ${{ inputs.cpflow_version }}")
       expect(contents).to include("ruby/setup-ruby intentionally tracks the v1 tag")
+      expect(contents).to include('default_ruby_version="3.2"')
+      expect(contents).to include("minimum-supported Ruby advances")
+      expect(contents).to include("ruby-version: ${{ steps.ruby-version.outputs.ruby_version }}")
+      expect(contents).to include("${working_directory}/mise.toml")
+      expect(contents).to include("${working_directory}/.mise.toml")
+      expect(contents).to include('grep -Eq "^[[:space:]]*ruby[[:space:]]+" "${working_directory}/.tool-versions"')
       expect(contents).to include('npm_global_prefix="${HOME}/.npm-global"')
       expect(contents).to include('echo "${npm_global_prefix}/bin" >> "$GITHUB_PATH"')
       expect(contents).to include(
@@ -300,6 +306,9 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       )
       expect(setup_action_path.read).to include(
         "working-directory: ${{ inputs.working_directory }}"
+      )
+      expect(setup_action_path.read).to include(
+        'grep -Eq "^[[:space:]]*ruby[[:space:]]*(\(|file:|[\'\"])" "${working_directory}/Gemfile"'
       )
     end
 


### PR DESCRIPTION
## Summary
- resolve a fallback Ruby version inside cpflow-setup-environment before ruby/setup-ruby runs
- keep auto-detection for caller apps that provide .ruby-version, .tool-versions, or a Gemfile ruby directive
- fix downstream staging deploys that run setup from the .cpflow checkout

## Verification
- CPLN_ORG=dummy-test-org bundle exec rspec spec/command/generate_github_actions_spec.rb
- RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop spec/command/generate_github_actions_spec.rb
- ruby -e 'require "yaml"; Dir[".github/actions/cpflow-*/*.yml", ".github/workflows/cpflow-*.yml"].sort.each { |p| YAML.load_file(p, aliases: true) }; puts "YAML OK"'
- actionlint -ignore 'SC2129' .github/workflows/cpflow-*.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Ruby version resolution in the shared `cpflow-setup-environment` GitHub Action, which can alter CI runtime and dependency compatibility for downstream workflows when no version files are present.
> 
> **Overview**
> Ensures the `cpflow-setup-environment` composite action always provides a Ruby version to `ruby/setup-ruby` by adding a pre-step that **auto-detects** from `.ruby-version`, `.tool-versions`, `mise.toml`/`.mise.toml`, or a `Gemfile` ruby directive, and otherwise **falls back to Ruby 3.2**.
> 
> Updates the setup action to pass the resolved version via step outputs (instead of `inputs.ruby_version` directly) and expands specs to assert the new fallback/detection behavior and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd42ea343944c3ec3697fa08463f9a44cf3c2205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Ruby version auto-detection to include mise.toml/.mise.toml plus existing common files; detection runs in the configured working directory.
  * Default Ruby version now set to 3.2 when unspecified.

* **Documentation**
  * Clarified input descriptions for ruby_version and working_directory in the action.

* **Tests**
  * Updated tests to verify auto-detection sources and default/pinning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->