### PR TITLE
[codex] Fix stale app cleanup for image-less GVCs

### DIFF
--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   rspec:
     runs-on: ${{ inputs.os_version }}
+    concurrency:
+      group: cpln-shared-org-${{ vars.CPLN_ORG }}
+      cancel-in-progress: false
     env:
       RAILS_ENV: test
       # We have to add "_CI" to the end, otherwise it messes with tests where we switch profiles,

--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -20,7 +20,7 @@ jobs:
   rspec:
     runs-on: ${{ inputs.os_version }}
     concurrency:
-      group: cpln-shared-org-${{ vars.CPLN_ORG }}
+      group: cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}
       cancel-in-progress: false
     env:
       RAILS_ENV: test

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ aliases:
     # If not specified, defaults to 21600 (6 hours).
     runner_job_timeout: 1000
 
-    # Apps with a deployed image created before this amount of days will be listed for deletion
-    # when running the command `cpflow cleanup-stale-apps`.
+    # Apps with a deployed image, or an image-less GVC, created before this amount of days
+    # will be listed for deletion when running the command `cpflow cleanup-stale-apps`.
     stale_app_image_deployed_days: 5
 
     # Images that exceed this quantity will be listed for deletion

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -80,7 +80,7 @@ cpflow cleanup-images -a $APP_NAME
 
 - Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps
 - Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
-- Stale apps are identified based on the creation date of the latest image
+- Stale apps are identified based on the creation date of the latest image, or the GVC if no images exist
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
 - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will delete all stale apps that start with the name
 - Will ask for explicit user confirmation

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -11,7 +11,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps
       - Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
-      - Stale apps are identified based on the creation date of the latest image
+      - Stale apps are identified based on the creation date of the latest image, or the GVC if no images exist
       - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
       - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will delete all stale apps that start with the name
       - Will ask for explicit user confirmation
@@ -50,9 +50,11 @@ module Command
 
             images = cp.query_images(app_name)["items"].select { |item| item["name"].start_with?("#{app_name}:") }
             image = cp.latest_image_from(images, app_name: app_name, name_only: false)
-            next unless image
 
-            created_date = DateTime.parse(image["created"])
+            created_at = image ? image["created"] : gvc["created"]
+            next unless created_at
+
+            created_date = DateTime.parse(created_at)
             diff_in_days = (now - created_date).to_i
             next unless diff_in_days >= stale_app_image_deployed_days
 

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -6,6 +6,32 @@ require "spec_helper"
 describe Command::CleanupStaleApps do
   let!(:app_prefix) { dummy_test_app_prefix("stale-app") }
 
+  describe "#stale_apps" do
+    let(:config) { instance_double(Config, app: "dummy-test", options: { yes: true }) }
+    let(:cp) { instance_double(Controlplane) }
+    let(:command) { described_class.new(config) }
+    let(:gvc) { { "name" => "dummy-test-image-less", "created" => "2000-01-01T00:00:00Z" } }
+
+    before do
+      allow(config).to receive(:[]).with(:stale_app_image_deployed_days).and_return(5)
+      allow(command).to receive(:cp).and_return(cp)
+      allow(cp).to receive(:gvc_query).with("dummy-test").and_return({ "items" => [gvc] })
+      allow(cp).to receive(:query_images).with(gvc.fetch("name")).and_return({ "items" => [] })
+      allow(cp).to receive(:latest_image_from)
+        .with([], app_name: gvc.fetch("name"), name_only: false)
+        .and_return(nil)
+    end
+
+    it "uses the GVC creation date when the app has no images" do
+      expect(command.send(:stale_apps)).to eq([
+                                                {
+                                                  name: gvc.fetch("name"),
+                                                  date: DateTime.parse(gvc.fetch("created"))
+                                                }
+                                              ])
+    end
+  end
+
   context "when 'stale_app_image_deployed_days' is not defined" do
     let!(:app) { dummy_test_app("nothing") }
 

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -7,7 +7,7 @@ describe Command::CleanupStaleApps do
   let!(:app_prefix) { dummy_test_app_prefix("stale-app") }
 
   describe "#stale_apps" do
-    let(:config) { instance_double(Config, app: "dummy-test", options: { yes: true }) }
+    let(:config) { instance_double(Config, app: "dummy-test") }
     let(:cp) { instance_double(Controlplane) }
     let(:command) { described_class.new(config) }
     let(:gvc) { { "name" => "dummy-test-image-less", "created" => "2000-01-01T00:00:00Z" } }
@@ -29,6 +29,14 @@ describe Command::CleanupStaleApps do
                                                   date: DateTime.parse(gvc.fetch("created"))
                                                 }
                                               ])
+    end
+
+    context "when the GVC has no creation date" do
+      let(:gvc) { { "name" => "dummy-test-image-less", "created" => nil } }
+
+      it "skips the app instead of raising" do
+        expect(command.send(:stale_apps)).to eq([])
+      end
     end
   end
 

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -138,7 +138,7 @@ describe Command::CleanupStaleApps do
     end
 
     it "lists correct stale apps", :slow do
-      allow(Shell).to receive(:confirm).with(include("2 apps")).and_return(false)
+      allow(Shell).to receive(:confirm).with(include("3 apps")).and_return(false)
 
       # We need to stub the image from app3 to have the current date,
       # as Control Plane does not allow manipulating the creation date of an image
@@ -156,6 +156,7 @@ describe Command::CleanupStaleApps do
       travel_to_days_later(30)
       # App with new image, wont't be listed
       run_cpflow_command!("build-image", "-a", app3)
+      # app4 has no image; its old GVC date is used as the fallback, so it is listed
       result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)
       travel_back
 
@@ -164,7 +165,7 @@ describe Command::CleanupStaleApps do
       expect(result[:stderr]).to include("- #{app1}")
       expect(result[:stderr]).to include("- #{app2}")
       expect(result[:stderr]).not_to include("- #{app3}")
-      expect(result[:stderr]).not_to include("- #{app4}")
+      expect(result[:stderr]).to include("- #{app4}")
     end
   end
 end

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
 
     it "queues jobs that share the CI Control Plane org" do
       expect(job.fetch("concurrency")).to eq(
-        "group" => "cpln-shared-org-${{ vars.CPLN_ORG }}",
+        "group" => "cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}",
         "cancel-in-progress" => false
       )
     end

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -4,6 +4,24 @@ require "spec_helper"
 require "yaml"
 
 RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/DescribeClass
+  describe "RSpec shared workflow" do
+    let(:workflow) do
+      YAML.safe_load_file(
+        File.expand_path("../.github/workflows/rspec-shared.yml", __dir__),
+        aliases: true
+      )
+    end
+
+    let(:job) { workflow.fetch("jobs").fetch("rspec") }
+
+    it "queues jobs that share the CI Control Plane org" do
+      expect(job.fetch("concurrency")).to eq(
+        "group" => "cpln-shared-org-${{ vars.CPLN_ORG }}",
+        "cancel-in-progress" => false
+      )
+    end
+  end
+
   describe "Delete Review App workflow" do
     let(:workflow) do
       YAML.safe_load_file(


### PR DESCRIPTION
Fixes #309.

This updates `cleanup-stale-apps` to treat image-less GVCs as stale based on the GVC `created` timestamp, so partial CI apps are no longer skipped forever. It also serializes shared RSpec workflow jobs by `vars.CPLN_ORG` to reduce concurrent CI pressure on the same Control Plane GVC quota. Added regression coverage for the cleanup fallback and workflow concurrency, and updated README/generated command docs.

Validation: `CPLN_ORG=test-org bundle exec rspec spec/command/cleanup_stale_apps_spec.rb:29 spec/github_workflows_spec.rb`, `bundle exec rubocop lib/command/cleanup_stale_apps.rb spec/command/cleanup_stale_apps_spec.rb spec/github_workflows_spec.rb`, `script/check_command_docs`, and `git diff --check origin/main...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage for edge cases without modifying production behavior.
> 
> **Overview**
> Adds specs for `Command::CleanupStaleApps#stale_apps` to ensure apps with no images fall back to the GVC `created` timestamp, and that GVCs with a missing `created` value are skipped instead of raising.
> 
> Also simplifies the `Config` test double setup by removing the unused `options: { yes: true }` stub in this spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3582d0fd2f1e1621a7f2156c2319f372b306e687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->