### PR TITLE
[codex] Fix run command RuboCop offense

### DIFF
--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -277,8 +277,8 @@ module Command
     def print_interactive_cleanup_hint
       progress.puts(Shell.color(
                       "\nThe interactive session ended with a non-zero exit or signal from the upstream CLI. " \
-                      "If the runner workload is still running, stop it with:\n" \
-                      "  cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}",
+                      "If the runner workload is still running, stop it with:\n  " \
+                      "cpflow ps:stop #{app_workload_replica_args.join(' ')} --location #{location}",
                       :yellow
                     ))
     end


### PR DESCRIPTION
## Summary
Fixes a RuboCop Layout/LineContinuationLeadingSpace offense in the run command cleanup hint.
The visible cleanup hint output is unchanged; only the string continuation split moved the two leading command spaces to the previous literal.

## Validation
- bundle exec rubocop --config .rubocop.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: formatting-only change to a user-facing hint string; no behavior, control flow, or external interactions are modified.
> 
> **Overview**
> Adjusts the `run` command’s interactive cleanup hint string concatenation to satisfy RuboCop’s `Layout/LineContinuationLeadingSpace` rule by moving the leading indentation spaces to the prior literal. Output text is intended to remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5abf6004d1c0054b176b09b60afdee3a2dfd23a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->