### PR TITLE
Prepare cpflow 5.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-05-23
+
+### Changed
+
+- Promoted the 5.0.0 release-candidate line to stable. This release includes the generated GitHub Actions flow, upstream reusable workflow model, Node 24 action updates, richer review-app command feedback, generated downstream pin/validation helpers, and cleanup/run/deploy fixes documented in `5.0.0.rc.3`.
+
 ### Fixed
 
 - Fixed packaged `cpflow` gems failing to boot without the development-only `debug` gem installed. The hidden `cpflow test` command no longer requires `debug` while loading the CLI, and coverage now exercises loading `cpflow` with `require "debug"` blocked.
@@ -343,7 +349,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.3...HEAD
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.3...v5.0.0
 [5.0.0.rc.3]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.1...v5.0.0.rc.3
 [5.0.0.rc.1]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v5.0.0.rc.1
 [4.2.0]: https://github.com/shakacode/control-plane-flow/compare/v4.1.1...v4.2.0


### PR DESCRIPTION
## Summary
- add a final 5.0.0 changelog section for the stable release
- move the rc3 runtime boot fix into the final release notes
- update compare links so Unreleased starts after v5.0.0

## Validation
- git diff --check

## Release note
Merge this before running bundle exec rake "release[5.0.0]" so the release task can create GitHub release notes for v5.0.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating release notes and compare links; no runtime code paths are modified.
> 
> **Overview**
> Adds a new `5.0.0` section to `CHANGELOG.md`, promoting the RC line to a stable release entry and carrying forward the `cpflow` boot-without-`debug` fix into the final notes.
> 
> Updates the changelog compare links so `[Unreleased]` now compares from `v5.0.0`, and adds the `v5.0.0.rc.3...v5.0.0` diff link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df2dbce59ad0c7caffc36616211bc1a76e9d3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog to document the stable release of version 5.0.0, finalizing the promotion of the 5.0.0 release-candidate line.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->