### PR TITLE
Mark cpflow 5.0.0 as breaking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [5.0.0] - 2026-05-23
 
+### Breaking Changes
+
+- Promotes the 5.x release-candidate line to stable. The breaking changes introduced during the 5.0.0 prerelease cycle are documented in `5.0.0.rc.1`, including the Ruby 3.0 minimum, `cpflow exists` not-found exit code change, and generated Dockerfile production-group behavior.
+
 ### Changed
 
 - Promoted the 5.0.0 release-candidate line to stable. This release includes the generated GitHub Actions flow, upstream reusable workflow model, Node 24 action updates, richer review-app command feedback, generated downstream pin/validation helpers, and cleanup/run/deploy fixes documented in `5.0.0.rc.3`.


### PR DESCRIPTION
## Summary
- add a Breaking Changes heading to the final 5.0.0 changelog section
- document that the stable release promotes the 5.x release-candidate breaking changes
- unblock the release task's version-policy validation for 4.2.0 -> 5.0.0

## Validation
- git diff --check

## Notes
- The release dry run reached version-policy validation and correctly rejected the previous changelog section as a patch-level release. This PR fixes that policy signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change; risk is limited to release tooling behavior that keys off the `### Breaking Changes` heading to enforce a major version bump.
> 
> **Overview**
> Adds a `### Breaking Changes` section to the `5.0.0` changelog entry, explicitly carrying forward the breaking changes introduced during the `5.0.0` release-candidate cycle.
> 
> This updates the changelog heading structure so release/version-policy validation recognizes `5.0.0` as a **major** (breaking) release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de188dd63561f610fe8b49fe83921e1ad6105398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->