### PR TITLE
[codex] Fix 5.0.0 changelog PR link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- Fixed packaged `cpflow` gems failing to boot without the development-only `debug` gem installed. The hidden `cpflow test` command no longer requires `debug` while loading the CLI, and coverage now exercises loading `cpflow` with `require "debug"` blocked.
+- **Fixed packaged `cpflow` gems failing to boot without the development-only `debug` gem installed.** [PR 314](https://github.com/shakacode/control-plane-flow/pull/314) by [Justin Gordon](https://github.com/justin808). The hidden `cpflow test` command no longer requires `debug` while loading the CLI, and coverage now exercises loading `cpflow` with `require "debug"` blocked.
 
 ## [5.0.0.rc.3] - 2026-05-23
 


### PR DESCRIPTION
## Summary
- Formats the final 5.0.0 runtime-load fix entry with the required bold summary and PR/author links.
- Keeps the existing 5.0.0 release header and compare links intact.

## Validation
- `git diff --check`
- Ruby changelog verification for the 5.0.0 header, PR 314 link, compare links, and trailing newline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating a single changelog entry; no runtime or behavior changes.
> 
> **Overview**
> Updates the `5.0.0` changelog *Fixed* entry for the `debug`-gem boot issue to match release-note formatting by adding a bolded summary plus links to **PR 314** and the author.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9eb0b88ed400c6c9b63bda98a38206141bb66fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->