### PR TITLE
Keep RC changelog sections separate until stable release

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -166,11 +166,14 @@ This repo does **not** have an `update_changelog` rake task — the slash comman
      ```
 
      Note: this repo uses `...HEAD`, not `...main`. Match the existing convention.
-   - Add a new compare link for the stamped version, comparing the previous tag to the new one:
+   - Add a new compare link for the stamped version:
 
      ```markdown
      [4.3.0]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v4.3.0
      ```
+
+     - **For stable releases**, skip prerelease tags — compare from the previous **stable** tag. A stable release that coalesces prior RCs (e.g., `v5.0.0.rc.0`, `v5.0.0.rc.1`) still uses the last stable tag as the left side (e.g., `v4.2.0...v5.0.0`), not the latest RC tag.
+     - **For prereleases**, compare from the immediately previous tag (which may be a prior RC/beta or the last stable tag).
 
 3. **For `rc`/`beta` modes**: Insert the new RC/beta section above any prior prereleases — do NOT collapse them. Each RC/beta is a separately-tagged release that users install, and they need to see what changed between, say, `rc.0` and `rc.1`. See "For Prerelease Versions" below. Coalescing happens only at the stable release.
 
@@ -269,7 +272,9 @@ If the user passed `release`, `rc`, `beta`, or an explicit version string as an 
 
 5. **For `rc`/`beta`**: Do NOT collapse prior prerelease sections — each RC/beta gets its own section so users can see what changed between prereleases. Just insert the new section above the prior ones and add a new compare link. See "For Prerelease Versions" below.
 
-6. **Verify** the stamped header and diff links match the requested version. If anything looks off, fix it before continuing.
+6. **For stable `release` (or explicit stable version) when prior `rc`/`beta` sections exist for the same base version**: Do NOT just stamp `## [5.0.0]` above the prior RC sections. Instead, follow the "For Prerelease to Stable Version Release" process below — it replaces steps 3–4 here with the coalesce + curate flow (combine all RC sections into the new stable section, move any matching `[Unreleased]` entries in, drop prerelease-only noise, and use the previous **stable** tag in the compare link).
+
+7. **Verify** the stamped header and diff links match the requested version. If anything looks off, fix it before continuing.
 
 If no argument was passed, skip this step -- entries stay in `## [Unreleased]`.
 
@@ -310,7 +315,7 @@ When the user passes `rc` or `beta` as an argument:
 
 2. **Auto-compute the next prerelease version** using the process in "Auto-Computing the Next Version" above. Use RubyGems format (`5.0.0.rc.0`), not `5.0.0-rc.0`.
 
-3. **Do NOT collapse prior prereleases.** Each RC/beta is a separately-tagged release that users install — they need to see what changed between, for example, `rc.0` and `rc.1` (especially when diagnosing a regression in a specific RC). The rake task reads each `## [VERSION]` section independently, so each RC's GitHub release gets its own focused notes. Instead:
+3. **Do NOT collapse prior prereleases.** Each RC/beta is a separately-tagged release that users install — they need to see what changed between, for example, `rc.0` and `rc.1` (especially when diagnosing a regression in a specific RC). Each successive `bundle exec rake release` reads only the top-most `## [VERSION]` section (the RC you just stamped — see the "Version Stamping" section above), so as long as each RC has its own section the corresponding GitHub release gets its own focused notes. Instead:
 
    - Insert the new prerelease version section immediately after `## [Unreleased]`, **above** any prior prerelease sections (preserves newest-first ordering)
    - Move any entries from `## [Unreleased]` that belong to this prerelease into the new section
@@ -318,6 +323,35 @@ When the user passes `rc` or `beta` as an argument:
    - Add any new user-visible changes from commits since the last prerelease tag to the new section only
    - Add a new compare link at the bottom comparing the previous prerelease tag (or the last stable tag if this is the first RC) to the new prerelease tag
    - Update the `[Unreleased]` compare link to point from the new prerelease tag to `HEAD`
+
+**Resulting structure** after stamping `5.0.0.rc.1` (with `5.0.0.rc.0` already shipped on top of stable `4.2.0`):
+
+```markdown
+## [Unreleased]
+
+## [5.0.0.rc.1] - 2026-05-25
+
+### Fixed
+
+- **Fix regression introduced in rc.0**. [PR 320](https://github.com/shakacode/control-plane-flow/pull/320) by [Justin Gordon](https://github.com/justin808).
+
+## [5.0.0.rc.0] - 2026-05-10
+
+### Added
+
+- **New feature**. [PR 315](https://github.com/shakacode/control-plane-flow/pull/315) by [Justin Gordon](https://github.com/justin808).
+
+## [4.2.0] - 2026-04-01
+
+...
+
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.1...HEAD
+[5.0.0.rc.1]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.0...v5.0.0.rc.1
+[5.0.0.rc.0]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v5.0.0.rc.0
+[4.2.0]: https://github.com/shakacode/control-plane-flow/compare/v4.1.1...v4.2.0
+```
+
+Both RC sections remain intact with their own compare links until the stable release coalesces them.
 
 **Coalescing happens only at the stable release** — see "For Prerelease to Stable Version Release" below.
 
@@ -330,15 +364,16 @@ When releasing from prerelease to a stable version (e.g., `v5.0.0.rc.2` -> `v5.0
 #### Step 1: Coalesce all prerelease sections into one stable section
 
 - Replace `## [5.0.0.rc.0]`, `## [5.0.0.rc.1]`, `## [5.0.0.beta.1]`, etc. with a single `## [5.0.0] - YYYY-MM-DD` section
-- Combine entries from all prerelease sections, consolidating duplicate category headings (e.g., merge multiple `### Fixed` sections into one under the preferred order from "Category Organization")
+- **Move any remaining entries from `## [Unreleased]` into the new stable section** — anything still under `[Unreleased]` at stable-release time is shipping in this stable version. Leave `## [Unreleased]` with only its header (no entries).
+- Combine entries from all prerelease sections and the moved `[Unreleased]` entries, consolidating duplicate category headings (e.g., merge multiple `### Fixed` sections into one under the preferred order from "Category Organization")
 - Remove the orphaned compare links at the bottom of the file for the coalesced prerelease versions
-- Add the `[5.0.0]` compare link pointing from the previous stable tag (e.g., `v4.2.0`) to `v5.0.0`
+- Add the `[5.0.0]` compare link pointing from the previous stable tag (e.g., `v4.2.0`) to `v5.0.0` — **not** from the latest RC tag
 - Update the `[Unreleased]` compare link to point from `v5.0.0` to `HEAD`
 
 #### Step 2: Curate the entries — REMOVE these
 
 1. **Prerelease-only fixes** — bugs introduced during the prerelease cycle and fixed in a later RC. If the bug never shipped in a stable release, the fix is noise to stable users.
-   - Investigate when a bug was introduced: `git log --oneline v<last_stable>..v<current_prerelease> -- <file>`
+   - Investigate when a bug was introduced: `git log --oneline v<last_stable>..v<rc_that_fixed_the_bug>` — if this commit range doesn't contain the bug's introduction (i.e., the introducing commit predates the RC cycle), the bug was already in the last stable release and the fix belongs in the stable section. If the introduction *is* in this range, the bug never shipped in stable, so drop the fix.
    - Check the PR description for what was broken and when
 
 2. **Refinements to prerelease-only features** — if a new feature was introduced in `rc.0` and then iterated in `rc.1`/`rc.2`, keep only the final description and drop the iteration history

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -172,7 +172,7 @@ This repo does **not** have an `update_changelog` rake task — the slash comman
      [4.3.0]: https://github.com/shakacode/control-plane-flow/compare/v4.2.0...v4.3.0
      ```
 
-3. **For `rc`/`beta` modes**: collapse prior prerelease sections of the same base version into a single section (see "For Prerelease Versions" below). Remove the orphaned compare links for the collapsed prerelease versions.
+3. **For `rc`/`beta` modes**: Insert the new RC/beta section above any prior prereleases — do NOT collapse them. Each RC/beta is a separately-tagged release that users install, and they need to see what changed between, say, `rc.0` and `rc.1`. See "For Prerelease Versions" below. Coalescing happens only at the stable release.
 
 The `rake release` task reads the first `## [VERSION]` header (skipping `Unreleased`) and uses it as the target version when newer than the current gem version. So once the changelog PR merges, `bundle exec rake release` (no args) will pick up the version automatically.
 
@@ -267,7 +267,7 @@ If the user passed `release`, `rc`, `beta`, or an explicit version string as an 
    - Update `[Unreleased]` to compare from the new tag to `HEAD`
    - Add a new compare link for the stamped version
 
-5. **For `rc`/`beta`**: collapse prior prerelease sections of the same base version (see below) and remove their orphaned compare links.
+5. **For `rc`/`beta`**: Do NOT collapse prior prerelease sections — each RC/beta gets its own section so users can see what changed between prereleases. Just insert the new section above the prior ones and add a new compare link. See "For Prerelease Versions" below.
 
 6. **Verify** the stamped header and diff links match the requested version. If anything looks off, fix it before continuing.
 
@@ -310,32 +310,62 @@ When the user passes `rc` or `beta` as an argument:
 
 2. **Auto-compute the next prerelease version** using the process in "Auto-Computing the Next Version" above. Use RubyGems format (`5.0.0.rc.0`), not `5.0.0-rc.0`.
 
-3. **Always collapse prior prereleases into the current prerelease** (this is the default behavior):
-   - Combine all prior prerelease changelog entries into the new prerelease version section
-   - Remove previous prerelease version sections (e.g., remove `## [5.0.0.rc.0]` when creating `## [5.0.0.rc.1]`)
-   - When collapsing, **consolidate duplicate category headings** — if both the Unreleased section and a prior prerelease section have `### Fixed`, merge all entries under a single `### Fixed` heading
-   - **Remove orphaned version diff links** at the bottom of the file for collapsed prerelease sections
-   - Add any new user-visible changes from commits since the last prerelease
-   - Update version diff links to point from the last stable version to the new prerelease
-   - This keeps the changelog clean with a single prerelease section that accumulates all changes since the last stable release
+3. **Do NOT collapse prior prereleases.** Each RC/beta is a separately-tagged release that users install — they need to see what changed between, for example, `rc.0` and `rc.1` (especially when diagnosing a regression in a specific RC). The rake task reads each `## [VERSION]` section independently, so each RC's GitHub release gets its own focused notes. Instead:
 
-**Note**: The new version header must be inserted **immediately after `## [Unreleased]`** (see Step 4). This ensures correct ordering of version headers.
+   - Insert the new prerelease version section immediately after `## [Unreleased]`, **above** any prior prerelease sections (preserves newest-first ordering)
+   - Move any entries from `## [Unreleased]` that belong to this prerelease into the new section
+   - Leave prior prerelease sections (e.g., `## [5.0.0.rc.0]`) untouched — keep their entries and their compare links at the bottom of the file
+   - Add any new user-visible changes from commits since the last prerelease tag to the new section only
+   - Add a new compare link at the bottom comparing the previous prerelease tag (or the last stable tag if this is the first RC) to the new prerelease tag
+   - Update the `[Unreleased]` compare link to point from the new prerelease tag to `HEAD`
+
+**Coalescing happens only at the stable release** — see "For Prerelease to Stable Version Release" below.
+
+**Note**: The new version header must be inserted **immediately after `## [Unreleased]`** (see Step 4). This ensures correct newest-first ordering of version headers.
 
 ### For Prerelease to Stable Version Release
 
-When releasing from prerelease to a stable version (e.g., `v5.0.0.rc.1` -> `v5.0.0`):
+When releasing from prerelease to a stable version (e.g., `v5.0.0.rc.2` -> `v5.0.0`), this is where the accumulated prerelease sections get coalesced into one stable section. **Curate carefully** — users landing on the stable version don't care about intermediate prerelease state, and noise here makes the upgrade story harder to read.
 
-1. **Remove all prerelease version labels** from the changelog:
-   - Change `## [5.0.0.rc.0]`, `## [5.0.0.rc.1]`, etc. to a single `## [5.0.0]` section
-   - Also handle beta versions: `## [5.0.0.beta.1]` etc.
-   - Combine all prerelease entries into the stable release section
+#### Step 1: Coalesce all prerelease sections into one stable section
 
-2. **Consolidate duplicate entries**:
-   - If bug fixes or changes were made to features introduced in earlier prereleases, keep only the final state
-   - Remove redundant changelog entries for fixes to prerelease features
-   - Keep the most recent/accurate description of each change
+- Replace `## [5.0.0.rc.0]`, `## [5.0.0.rc.1]`, `## [5.0.0.beta.1]`, etc. with a single `## [5.0.0] - YYYY-MM-DD` section
+- Combine entries from all prerelease sections, consolidating duplicate category headings (e.g., merge multiple `### Fixed` sections into one under the preferred order from "Category Organization")
+- Remove the orphaned compare links at the bottom of the file for the coalesced prerelease versions
+- Add the `[5.0.0]` compare link pointing from the previous stable tag (e.g., `v4.2.0`) to `v5.0.0`
+- Update the `[Unreleased]` compare link to point from `v5.0.0` to `HEAD`
 
-3. **Update version diff links** at the bottom to point to the stable version (and remove the orphaned prerelease compare links)
+#### Step 2: Curate the entries — REMOVE these
+
+1. **Prerelease-only fixes** — bugs introduced during the prerelease cycle and fixed in a later RC. If the bug never shipped in a stable release, the fix is noise to stable users.
+   - Investigate when a bug was introduced: `git log --oneline v<last_stable>..v<current_prerelease> -- <file>`
+   - Check the PR description for what was broken and when
+
+2. **Refinements to prerelease-only features** — if a new feature was introduced in `rc.0` and then iterated in `rc.1`/`rc.2`, keep only the final description and drop the iteration history
+
+3. **Internal/contributor-only tooling** — CI tweaks, build script changes, generator handling of prerelease version formats, local-dev tooling fixes. These don't belong in a user-facing changelog.
+
+#### Step 3: Curate the entries — KEEP these
+
+1. **User-facing fixes for bugs that existed in the previous stable** — if `rc.2` fixes a bug that was in `4.2.0`, that fix matters to stable users upgrading
+
+2. **Compatibility fixes** — Ruby/Rails version support, dependency relaxations, etc.
+
+3. **All breaking changes** — API/CLI changes, removed methods, configuration changes, exit code changes, generator output changes. Even if a breaking change was introduced and refined across multiple prereleases, the final breaking change description belongs in stable.
+
+4. **Performance/security improvements affecting all users**
+
+#### Step 4: Investigation process for each entry
+
+For each entry from a prerelease section, ask:
+
+- Was this bug present in the last stable release? If no, drop.
+- Was this feature introduced in an earlier prerelease and then superseded? If yes, keep only the final state.
+- Does this matter to someone upgrading from the last stable to this stable? If no, drop.
+
+#### Step 5: Final read-through
+
+Read the resulting stable section as if you're a user upgrading from the previous stable. Every entry should be something you'd want to know about. If an entry only makes sense to someone who tracked the RC cycle, drop it.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Flip `/update-changelog rc` and `/update-changelog beta` from always-collapse to never-collapse. Each RC/beta gets its own changelog section so users on a prior RC can see what changed between, say, `rc.0` and `rc.1`.
- Coalescing now happens only at the stable release (`/update-changelog release`), where accumulated RC sections collapse into one stable section.
- Ports a Prerelease Changelog Curation section from the react_on_rails `update-changelog` command, with explicit REMOVE/KEEP rules, an investigation process, and a final read-through check applied at stable-release coalesce time.

## Why

Each RC is a separately-tagged release that users install. Collapsing prior RCs on every new RC threw away the per-RC history, which is exactly what a user on `rc.0` needs to read when deciding whether to upgrade to `rc.1` or when diagnosing a regression.

The rake task in `rakelib/create_release.rake` already reads each `## [VERSION]` section independently via `extract_changelog_section`, so non-coalesced RCs produce focused per-RC GitHub release notes with **no rake task changes required**.

## Curation rules added (applied at stable release)

**REMOVE** at stable coalesce:
- Prerelease-only fixes (bug never shipped in stable)
- Refinements to prerelease-only features (keep only the final state)
- Internal/contributor-only tooling

**KEEP** at stable coalesce:
- User-facing fixes for bugs that existed in the previous stable
- Compatibility fixes (Ruby/Rails support, dependency relaxations)
- All breaking changes (final description only)
- Performance/security improvements affecting all users

## Note on existing CHANGELOG.md

The current `CHANGELOG.md` already has `5.0.0` (stable) with partially coalesced RC history above it. The new policy applies going forward — no retroactive split needed.

## Test plan

- [ ] Next time `/update-changelog rc` runs, verify the prior RC section stays in place and the new RC section is inserted above it.
- [ ] Next time `/update-changelog release` runs (stable), verify all RC sections coalesce into one and the curation steps are applied.
- [ ] Verify `bundle exec rake "sync_github_release[5.x.x.rc.N]"` still produces correct per-RC release notes from a non-coalesced section.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the update-changelog slash command; no runtime or release rake behavior is modified.
> 
> **Overview**
> Updates the **`/update-changelog`** Claude command docs so **RC/beta** runs **stop merging** prior prerelease sections into one block. Each new RC/beta section sits **below `[Unreleased]` and above older RCs**, with **per-RC compare links** (previous RC or last stable → new RC).
> 
> **Stable `release`** is now the only time RC/beta history is **coalesced** into one version: move leftover `[Unreleased]` items in, merge categories, fix links from the **last stable tag** (not the latest RC), and apply a **curation playbook** (drop prerelease-only fixes/iteration noise/internal tooling; keep stable-relevant fixes, compatibility, breaking changes, perf/security).
> 
> Step 4/5 in the main process and the **Version Stamping** section are aligned with that split so stable releases must use the dedicated prerelease→stable flow instead of stamping `## [X.Y.Z]` on top of RC sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bdb061c31a7382282314ac3da8033a93313465. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified changelog rules: new RC/beta prerelease sections are inserted above prior prereleases and do not collapse earlier sections.
  * Added compare-link rules: link new prerelease to previous prerelease (or last stable) and updated [Unreleased] compare direction.
  * Expanded prerelease→stable coalescing guidance with a stepwise curation checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->