### PR TITLE
Preserve Node package manager shims in generated Dockerfile

### DIFF
--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -197,7 +197,7 @@ module Command
       spec = nil
 
       step("Checking if runner workload '#{runner_workload}' needs to be updated") do # rubocop:disable Metrics/BlockLength
-        _, original_container_spec = base_workload_specs(original_workload)
+        original_spec, original_container_spec = base_workload_specs(original_workload)
         spec, container_spec = base_workload_specs(runner_workload)
 
         # Keep ENV synced between original and runner workloads
@@ -205,6 +205,16 @@ module Command
         env_str = container_spec["env"]&.sort_by { |env| env["name"] }.to_s
         if original_env_str != env_str
           container_spec["env"] = original_container_spec["env"] || []
+          should_update = true
+        end
+
+        # Keep the app identity in sync so runner jobs can resolve GVC-level secrets.
+        if spec["identityLink"] != original_spec["identityLink"]
+          if original_spec["identityLink"]
+            spec["identityLink"] = original_spec["identityLink"]
+          else
+            spec.delete("identityLink")
+          end
           should_update = true
         end
 

--- a/lib/generator_templates/Dockerfile
+++ b/lib/generator_templates/Dockerfile
@@ -17,11 +17,16 @@ WORKDIR /app
 # rely on ExecJS in production. Narrowed to just what the node stage actually
 # ships under /usr/local so we don't drag in unused Debian libs from that image.
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=node /usr/local/include/node /usr/local/include/node
+
+RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    ln -sf ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
+    chmod +x /usr/local/lib/node_modules/npm/bin/npm-cli.js \
+             /usr/local/lib/node_modules/npm/bin/npx-cli.js \
+             /usr/local/lib/node_modules/corepack/dist/corepack.js && \
+    node --version && npm --version && corepack --version
 
 # Expose Corepack-managed shims so later build steps can call yarn/pnpm
 # directly during asset precompilation hooks.

--- a/lib/generator_templates/templates/app.yml
+++ b/lib/generator_templates/templates/app.yml
@@ -1,6 +1,6 @@
 # Template setup of the GVC, roughly corresponding to a Heroku app
 kind: gvc
-name: {{APP_NAME}}
+name: "{{APP_NAME}}"
 spec:
   env:
     - name: DATABASE_URL
@@ -12,7 +12,7 @@ spec:
     - name: RAILS_SERVE_STATIC_FILES
       value: "true"
     - name: SECRET_KEY_BASE
-      value: cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE
+      value: "cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE"
   staticPlacement:
     locationLinks:
-      - {{APP_LOCATION_LINK}}
+      - "{{APP_LOCATION_LINK}}"

--- a/lib/generator_templates/templates/postgres.yml
+++ b/lib/generator_templates/templates/postgres.yml
@@ -2,8 +2,8 @@
 # https://github.com/controlplane-com/examples/blob/main/examples/postgres/manifest.yaml
 
 kind: volumeset
-name: postgres-poc-vs
-description: postgres-poc-vs
+name: "{{APP_NAME}}-pg-vs"
+description: "{{APP_NAME}}-pg-vs"
 spec:
   autoscaling:
     maxCapacity: 1000
@@ -18,7 +18,7 @@ spec:
 
 ---
 kind: secret
-name: postgres-poc-credentials
+name: "{{APP_NAME}}-pg"
 description: ''
 type: dictionary
 data:
@@ -27,7 +27,7 @@ data:
 
 ---
 kind: secret
-name: postgres-poc-entrypoint-script
+name: "{{APP_NAME}}-pg-script"
 type: opaque
 data:
   encoding: base64
@@ -92,13 +92,13 @@ data:
 
 ---
 kind: identity
-name: postgres-poc-identity
-description: postgres-poc-identity
+name: "{{APP_NAME}}-pg-identity"
+description: "{{APP_NAME}}-pg-identity"
 
 ---
 kind: policy
-name: postgres-poc-access
-description: postgres-poc-access
+name: "{{APP_NAME}}-pg-access"
+description: "{{APP_NAME}}-pg-access"
 bindings:
   - permissions:
       - reveal
@@ -106,11 +106,14 @@ bindings:
 #      - use
 #      - view
     principalLinks:
-      - //gvc/{{APP_NAME}}/identity/postgres-poc-identity
+      - "//gvc/{{APP_NAME}}/identity/{{APP_NAME}}-pg-identity"
+      # cpflow apply-template replaces {{APP_IDENTITY_LINK}} with the full app workload identity link.
+      # Example: //gvc/{{APP_NAME}}/identity/{{APP_NAME}}-identity.
+      - "{{APP_IDENTITY_LINK}}"
 targetKind: secret
 targetLinks:
-  - //secret/postgres-poc-credentials
-  - //secret/postgres-poc-entrypoint-script
+  - "//secret/{{APP_NAME}}-pg"
+  - "//secret/{{APP_NAME}}-pg-script"
 
 ---
 kind: workload
@@ -130,9 +133,9 @@ spec:
         - name: PGDATA #The location postgres stores the db. This can be anything other than /var/lib/postgresql/data, but it must be inside the mount point for the volume set
           value: "/var/lib/postgresql/data/pg_data"
         - name: POSTGRES_PASSWORD #The password for the default user
-          value: cpln://secret/postgres-poc-credentials.password
+          value: "cpln://secret/{{APP_NAME}}-pg.password"
         - name: POSTGRES_USER #The name of the default user
-          value: cpln://secret/postgres-poc-credentials.username
+          value: "cpln://secret/{{APP_NAME}}-pg.username"
       name: postgres
       image: postgres:15
       command: /bin/bash
@@ -146,10 +149,10 @@ spec:
         - number: 5432
           protocol: tcp
       volumes:
-        - uri: cpln://volumeset/postgres-poc-vs
+        - uri: "cpln://volumeset/{{APP_NAME}}-pg-vs"
           path: "/var/lib/postgresql/data"
         # Make the ENV value for the entry script a file
-        - uri: cpln://secret/postgres-poc-entrypoint-script
+        - uri: "cpln://secret/{{APP_NAME}}-pg-script"
           path: "/usr/local/bin/cpln-entrypoint.sh"
       inheritEnv: false
       livenessProbe:
@@ -160,7 +163,7 @@ spec:
         tcpSocket:
           port: 5432
         failureThreshold: 1
-  identityLink: //identity/postgres-poc-identity
+  identityLink: "//identity/{{APP_NAME}}-pg-identity"
   defaultOptions:
     capacityAI: false
     autoscaling:

--- a/lib/generator_templates/templates/rails.yml
+++ b/lib/generator_templates/templates/rails.yml
@@ -8,7 +8,7 @@ spec:
     - name: rails
       cpu: 300m
       inheritEnv: true
-      image: {{APP_IMAGE_LINK}}
+      image: "{{APP_IMAGE_LINK}}"
       memory: 512Mi
       ports:
         - number: 3000
@@ -29,3 +29,5 @@ spec:
         - 0.0.0.0/0
       outboundAllowCIDR:
         - 0.0.0.0/0
+  # cpflow apply-template replaces {{APP_IDENTITY_LINK}} with the app workload identity link.
+  identityLink: "{{APP_IDENTITY_LINK}}"

--- a/lib/generator_templates_sqlite/templates/app.yml
+++ b/lib/generator_templates_sqlite/templates/app.yml
@@ -1,5 +1,5 @@
 kind: gvc
-name: {{APP_NAME}}
+name: "{{APP_NAME}}"
 spec:
   env:
     - name: RAILS_ENV
@@ -9,7 +9,7 @@ spec:
     - name: RAILS_SERVE_STATIC_FILES
       value: "true"
     - name: SECRET_KEY_BASE
-      value: cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE
+      value: "cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE"
   staticPlacement:
     locationLinks:
-      - {{APP_LOCATION_LINK}}
+      - "{{APP_LOCATION_LINK}}"

--- a/lib/generator_templates_sqlite/templates/rails.yml
+++ b/lib/generator_templates_sqlite/templates/rails.yml
@@ -6,7 +6,7 @@ spec:
     - name: rails
       cpu: 300m
       inheritEnv: true
-      image: {{APP_IMAGE_LINK}}
+      image: "{{APP_IMAGE_LINK}}"
       memory: 512Mi
       ports:
         - number: 3000
@@ -34,3 +34,5 @@ spec:
         - 0.0.0.0/0
       outboundAllowCIDR:
         - 0.0.0.0/0
+  # cpflow apply-template replaces {{APP_IDENTITY_LINK}} with the app workload identity link.
+  identityLink: "{{APP_IDENTITY_LINK}}"

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -76,6 +76,7 @@ describe Command::Generate, :enable_validations, :without_config_file do
         dockerfile_content = dockerfile_path.read
         app_template_content = app_template_path.read
         rails_template_content = rails_template_path.read
+        postgres_template_content = postgres_template_path.read
 
         expect(controlplane_content).to include("sample-project-staging")
         expect(controlplane_content).to include("sample-project-review")
@@ -88,6 +89,24 @@ describe Command::Generate, :enable_validations, :without_config_file do
         expect(generated_ruby_arg).to eq("ARG RUBY_VERSION=3.3\n")
         expect(dockerfile_content).to include("FROM docker.io/library/node:22-bookworm-slim AS node")
         expect(dockerfile_content).to include("COPY --from=node /usr/local/bin/node /usr/local/bin/node")
+        expect(dockerfile_content).not_to include("COPY --from=node /usr/local/bin/npm")
+        expect(dockerfile_content).not_to include("COPY --from=node /usr/local/bin/npx")
+        expect(dockerfile_content).not_to include("COPY --from=node /usr/local/bin/corepack")
+        expect(dockerfile_content).to include(
+          "ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm"
+        )
+        expect(dockerfile_content).to include(
+          "ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx"
+        )
+        expect(dockerfile_content).to include(
+          "ln -sf ../lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack"
+        )
+        expect(dockerfile_content).to match(
+          %r{chmod[ ]\+x[ ]/usr/local/lib/node_modules/npm/bin/npm-cli\.js[ ]\\\n\s+
+             /usr/local/lib/node_modules/npm/bin/npx-cli\.js[ ]\\\n\s+
+             /usr/local/lib/node_modules/corepack/dist/corepack\.js[ ]&&[ ]\\\n\s+
+             node[ ]--version[ ]&&[ ]npm[ ]--version[ ]&&[ ]corepack[ ]--version}x
+        )
         expect(dockerfile_content).not_to include("RUN apt-get update")
         expect(dockerfile_content).to include("bundle config set with 'production'")
         expect(dockerfile_content).not_to include("bundle config set with 'staging production'")
@@ -106,10 +125,21 @@ describe Command::Generate, :enable_validations, :without_config_file do
         expect(dockerfile_content).to include("corepack pnpm install --frozen-lockfile")
         expect(dockerfile_content).to include("npm ci")
         expect(dockerfile_content).not_to include("react_on_rails:generate_packs")
+        expect(app_template_content).to include('name: "{{APP_NAME}}"')
+        expect(app_template_content).to include('"{{APP_LOCATION_LINK}}"')
         expect(app_template_content).to include("RAILS_LOG_TO_STDOUT")
         expect(app_template_content).to include("SECRET_KEY_BASE")
+        expect(rails_template_content).to include('image: "{{APP_IMAGE_LINK}}"')
+        expect(rails_template_content).to include('identityLink: "{{APP_IDENTITY_LINK}}"')
         expect(rails_template_content).to include("minScale: 1")
         expect(rails_template_content).to include("timeoutSeconds: 60")
+        expect(postgres_template_content).to include('name: "{{APP_NAME}}-pg"')
+        expect(postgres_template_content).to include('name: "{{APP_NAME}}-pg-vs"')
+        expect(postgres_template_content).to include('name: "{{APP_NAME}}-pg-identity"')
+        expect(postgres_template_content).to include('"cpln://volumeset/{{APP_NAME}}-pg-vs"')
+        expect(postgres_template_content).to include('"cpln://secret/{{APP_NAME}}-pg.password"')
+        expect(postgres_template_content).to include('"//identity/{{APP_NAME}}-pg-identity"')
+        expect(postgres_template_content).to include('- "{{APP_IDENTITY_LINK}}"')
         entrypoint_content = entrypoint_path.read
         expect(entrypoint_content).to include("set -e")
         expect(dockerfile_content).to include("RUN chmod +x /app/entrypoint.sh")
@@ -232,6 +262,11 @@ describe Command::Generate, :enable_validations, :without_config_file do
         expect(db_template_path).to exist
         expect(storage_template_path).to exist
         expect(app_template_path.read).not_to include("DATABASE_URL")
+        expect(app_template_path.read).to include('name: "{{APP_NAME}}"')
+        expect(app_template_path.read).to include('"{{APP_LOCATION_LINK}}"')
+        expect(app_template_path.read).to include('"cpln://secret/{{APP_SECRETS}}.SECRET_KEY_BASE"')
+        expect(rails_template_path.read).to include('image: "{{APP_IMAGE_LINK}}"')
+        expect(rails_template_path.read).to include('identityLink: "{{APP_IDENTITY_LINK}}"')
         expect(rails_template_path.read).to include("uri: cpln://volumeset/app-db")
         expect(rails_template_path.read).to include("uri: cpln://volumeset/app-storage")
         expect(release_script_path.read).to include("mkdir -p db storage")

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -3,6 +3,98 @@
 require "spec_helper"
 
 describe Command::Run do
+  describe "#update_runner_workload" do
+    let(:config) { instance_double(Config) }
+    let(:cp) { instance_double(Controlplane) }
+    let(:command) { described_class.new(config) }
+    let(:workload_identities) { { original: "//identity/test-app-identity", runner: nil } }
+    let(:workload_specs) do
+      original_spec = {}
+      original_spec["identityLink"] = workload_identities[:original] if workload_identities[:original]
+      original_container_spec = {
+        "env" => [{ "name" => "SECRET_KEY_BASE", "value" => "cpln://secret/app.SECRET_KEY_BASE" }]
+      }
+      runner_container_spec = {
+        "env" => original_container_spec["env"],
+        "image" => "test-app:#{Controlplane::NO_IMAGE_AVAILABLE}",
+        "cpu" => described_class::DEFAULT_JOB_CPU,
+        "memory" => described_class::DEFAULT_JOB_MEMORY
+      }
+      runner_spec = {
+        "containers" => [runner_container_spec],
+        "defaultOptions" => {},
+        "job" => {
+          "activeDeadlineSeconds" => described_class::DEFAULT_JOB_TIMEOUT,
+          "historyLimit" => described_class::DEFAULT_JOB_HISTORY_LIMIT
+        }
+      }
+      runner_spec["identityLink"] = workload_identities[:runner] if workload_identities[:runner]
+
+      {
+        original_spec: original_spec,
+        original_container_spec: original_container_spec,
+        runner_spec: runner_spec,
+        runner_container_spec: runner_container_spec
+      }
+    end
+
+    before do
+      allow(command).to receive(:cp).and_return(cp)
+      allow(command).to receive(:step).and_yield
+      allow(command).to receive(:base_workload_specs)
+        .with("rails")
+        .and_return([workload_specs[:original_spec], workload_specs[:original_container_spec]])
+      allow(command).to receive(:base_workload_specs)
+        .with("rails-runner")
+        .and_return([workload_specs[:runner_spec], workload_specs[:runner_container_spec]])
+      allow(cp).to receive(:apply_hash)
+
+      command.instance_variable_set(:@original_workload, "rails")
+      command.instance_variable_set(:@runner_workload, "rails-runner")
+      command.instance_variable_set(:@default_image, "test-app:#{Controlplane::NO_IMAGE_AVAILABLE}")
+      command.instance_variable_set(:@default_cpu, described_class::DEFAULT_JOB_CPU)
+      command.instance_variable_set(:@default_memory, described_class::DEFAULT_JOB_MEMORY)
+      command.instance_variable_set(:@job_timeout, described_class::DEFAULT_JOB_TIMEOUT)
+      command.instance_variable_set(:@job_history_limit, described_class::DEFAULT_JOB_HISTORY_LIMIT)
+    end
+
+    it "syncs the original workload identity link to the runner workload" do
+      command.send(:update_runner_workload)
+
+      expect(cp).to have_received(:apply_hash).with(
+        { "kind" => "workload", "name" => "rails-runner", "spec" => workload_specs[:runner_spec] },
+        wait: true
+      )
+      expect(workload_specs[:runner_spec]["identityLink"]).to eq("//identity/test-app-identity")
+    end
+
+    context "when the original workload has no identity link" do
+      let(:workload_identities) { { original: nil, runner: "//identity/stale-app-identity" } }
+
+      it "removes the stale identity link from the runner workload" do
+        command.send(:update_runner_workload)
+
+        expect(cp).to have_received(:apply_hash).with(
+          { "kind" => "workload", "name" => "rails-runner", "spec" => workload_specs[:runner_spec] },
+          wait: true
+        )
+        expect(workload_specs[:runner_spec]).not_to have_key("identityLink")
+      end
+    end
+
+    context "when the identity links are already in sync" do
+      let(:workload_identities) do
+        { original: "//identity/test-app-identity", runner: "//identity/test-app-identity" }
+      end
+
+      it "does not update the runner workload" do
+        command.send(:update_runner_workload)
+
+        expect(cp).not_to have_received(:apply_hash)
+      end
+    end
+  end
+
   describe "#run_interactive" do
     let(:config) { instance_double(Config, app: "test-app") }
     let(:cp) { instance_double(Controlplane) }


### PR DESCRIPTION
## Summary

- Preserve Node image `npm`, `npx`, and `corepack` as symlinks in the generated Dockerfile.
- Add a generator spec guard so `corepack` is not copied as a plain file.

## Why

Copying `/usr/local/bin/corepack` from the Node image dereferences the symlink target. In the Ruby final image, that plain copied file looks for `./lib/corepack.cjs` relative to `/usr/local/bin` and fails during generated app Docker builds.

## Test

- `CPLN_ORG=dummy bundle exec rspec spec/command/generate_spec.rb`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches deploy manifests, secret/identity wiring, and `cpflow run` workload updates; Dockerfile change affects all generated app builds but is localized to Node shim installation.
> 
> **Overview**
> The generated **Dockerfile** no longer copies `npm`, `npx`, and `corepack` from the Node stage (which turned symlinks into broken plain files). It copies `node_modules` and wires those tools via symlinks into the shipped CLI paths, with a sanity check that `node`, `npm`, and `corepack` run.
> 
> **Control Plane templates** now use quoted `{{APP_NAME}}` / `{{APP_IMAGE_LINK}}` / `{{APP_LOCATION_LINK}}` placeholders, app-scoped Postgres resource names, and `{{APP_IDENTITY_LINK}}` on Rails/SQLite workloads and Postgres secret access. **`cpflow run`** keeps the runner cron workload’s `identityLink` aligned with the base workload so one-off jobs can use the same GVC secret identity.
> 
> Specs assert the new Dockerfile and template output and cover runner identity sync (including clearing a stale link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95ae70104243faaf68e07e7737c16bf96d1996f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensured Node tooling (npm/npx/corepack) in generated images resolves reliably by including necessary Node modules/headers and using stable symlinks.
  * Parameterized Postgres resource and secret names with the application-name placeholder for reusable templates.
  * Consistently quoted templated fields and added workload identity references across Rails and SQLite generator templates; runner workload now syncs identity links from originals.

* **Tests**
  * Added/expanded tests validating Dockerfile tooling behavior, templated Postgres/SQLite/Rails values, and runner workload identity synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->