### PR TITLE
Prepare 5.0.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+## [5.0.2] - 2026-05-25
+
+### Fixed
+
+- **Fixed generated Dockerfiles so Node package-manager shims (`npm`, `npx`, and `corepack`) remain working symlinks in the final Ruby image instead of broken dereferenced files.** [PR 322](https://github.com/shakacode/control-plane-flow/pull/322) by [Justin Gordon](https://github.com/justin808). Generated Dockerfiles now fail fast if the Node shim paths are no longer valid.
+- **Fixed generated Control Plane templates so app workloads receive app identity links, templated YAML scalars are parseable, and generated Postgres resources/secrets are app-scoped.** [PR 322](https://github.com/shakacode/control-plane-flow/pull/322) by [Justin Gordon](https://github.com/justin808). This lets review apps resolve `cpln://secret/...` values reliably from Rails, worker, renderer, and release jobs.
+- **Fixed `cpflow run` so existing runner workloads stay in sync with the source workload `identityLink`.** [PR 322](https://github.com/shakacode/control-plane-flow/pull/322) by [Justin Gordon](https://github.com/justin808). Existing runner jobs now gain or drop the app identity as the source workload changes.
+
 ## [5.0.1] - 2026-05-24
 
 ### Breaking Changes
@@ -374,7 +382,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.1...HEAD
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.2...HEAD
+[5.0.2]: https://github.com/shakacode/control-plane-flow/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.3...v5.0.0
 [5.0.0.rc.3]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.1...v5.0.0.rc.3


### PR DESCRIPTION
Prepares the changelog for a 5.0.2 patch release containing the post-5.0.1 review-app fixes from PR #322.\n\nValidation:\n- git diff --check\n- release dry run intentionally waits until this changelog PR is merged because stable releases must run from main

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and link updates with no runtime or generated artifact changes in this diff.
> 
> **Overview**
> Documents **5.0.2** (2026-05-25) as a patch release after 5.0.1, moving three **Fixed** entries from **Unreleased** into the new version (all attributed to PR #322): Node shim handling in generated Dockerfiles, Control Plane template/identity/Postgres scoping for review apps, and `cpflow run` runner `identityLink` sync.
> 
> Clears **Unreleased** for the next cycle and updates compare links so **[Unreleased]** is `v5.0.2...HEAD` and **[5.0.2]** is `v5.0.1...v5.0.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f40595099c207dbc71d7617f41e4c07eae6d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 5.0.2 documenting three bug fixes: Node package manager shims in generated Dockerfiles, app identity links and Postgres resources in Control Plane templates, and runner workload synchronization with `cpflow run` command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->