### PR TITLE
Update docs dispatch actions to Node 24 versions (#327)

### DIFF
--- a/.github/workflows/trigger-docs-site.yml
+++ b/.github/workflows/trigger-docs-site.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Generate GitHub App token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
           app-id: ${{ secrets.DOCS_DISPATCH_APP_ID }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Dispatch docs-updated event
         id: dispatch
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           repository: shakacode/controlplaneflow-com


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token` from v1.12.0 → v3.2.0 (now runs on `node24`).
- Bump `peter-evans/repository-dispatch` from v3.0.0 → v4.0.1 (now runs on `node24`).
- Eliminates the `Node.js 20 actions are deprecated` warning on the `Trigger docs site rebuild` run.

## Compatibility notes
- `actions/create-github-app-token` v2.0.0 dropped deprecated inputs (`app_id`, `private_key`, `skip_token_revoke`). The current workflow already uses the supported `app-id` / `private-key` form, so no input change is needed.
- `actions/create-github-app-token` v3.0.0 removed custom proxy handling and now requires `NODE_USE_ENV_PROXY=1` for proxies. This workflow sets no proxy env vars, so it is unaffected.
- Both v3.2.0 / v4.0.1 require Actions Runner v2.327.1+ for `node24`; `ubuntu-latest` already satisfies that.

## Test plan
- [ ] CI on this PR is green.
- [ ] After merge, run `Trigger docs site rebuild` manually via `workflow_dispatch` and confirm:
  - [ ] No `Node.js 20 actions are deprecated` warning appears.
  - [ ] `shakacode/controlplaneflow-com` `Site Build and Deploy` workflow starts from `repository_dispatch` and passes.

Fixes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only pin updates in a single CI workflow; no application or auth logic changes.
> 
> **Overview**
> Updates the **Trigger docs site rebuild** workflow to pin newer GitHub Actions that run on **Node 24**, removing the deprecated Node 20 runtime warning.
> 
> `actions/create-github-app-token` moves from **v1.12.0** to **v3.2.0** and `peter-evans/repository-dispatch` from **v3.0.0** to **v4.0.1**; step inputs and the docs `repository_dispatch` payload are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5fdcfe11a5304ce625fca6eef4d549072607e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow versions to latest releases for improved stability and security in the documentation site deployment pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->