### PR TITLE
Fix update-github-actions edge cases from PR 328 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 - Added `cpflow update-github-actions`, `cpflow generate-github-actions --force`, RubyGems install guidance, and release-task follow-up output so downstream repositories remember to update checked-in generated GitHub Actions wrappers when the `cpflow` gem version changes.
 
+### Fixed
+
+- Fixed `cpflow update-github-actions` so a manually-reordered `branches: ["master", "main"]` staging workflow is still treated as the default (no spurious "multiple custom push branches" warning, no silent drop of the staging branch), and an empty or non-hash staging workflow no longer crashes the command. The command now aborts with a clear message instead of silently bootstrapping wrappers when run in a repository that has never run `generate-github-actions`. Clarified the RubyGems post-install message so first-time installers see the `generate-github-actions` path.
+
 ## [5.0.2] - 2026-05-25
 
 ### Fixed

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.post_install_message = <<~MESSAGE
     cpflow #{Cpflow::VERSION} installed.
 
-    If this repository uses generated cpflow GitHub Actions, update the checked-in
-    wrappers so GitHub loads the matching control-plane-flow release tag:
+    If this repository already uses generated cpflow GitHub Actions, update the
+    checked-in wrappers so GitHub loads the matching control-plane-flow release tag:
 
       cpflow update-github-actions
       bin/test-cpflow-github-flow
@@ -25,6 +25,9 @@ Gem::Specification.new do |spec|
 
       bundle exec cpflow update-github-actions
       bin/test-cpflow-github-flow bundle exec cpflow
+
+    New repository? Run `cpflow generate-github-actions` first to create the
+    wrappers (and the `bin/test-cpflow-github-flow` script referenced above).
   MESSAGE
 
   spec.required_ruby_version = ">= 3.0.0"

--- a/lib/command/generate_github_actions.rb
+++ b/lib/command/generate_github_actions.rb
@@ -4,6 +4,7 @@ require "json"
 require "pathname"
 
 require_relative "generator_helpers"
+require_relative "staging_branch_validation"
 
 module Command
   class GithubActionsGenerator < Thor::Group
@@ -80,6 +81,8 @@ module Command
   end
 
   class GenerateGithubActions < Base
+    include StagingBranchValidation
+
     NAME = "generate-github-actions"
     OPTIONS = [staging_branch_option, force_option].freeze
     DESCRIPTION = "Creates GitHub Actions templates for review apps, staging deploys, and production promotion"
@@ -154,40 +157,6 @@ module Command
 
     def force?
       config.options[:force]
-    end
-
-    def staging_branch
-      branch = config.options[:staging_branch].to_s.strip
-      return nil if branch.empty?
-
-      unless valid_staging_branch?(branch)
-        Shell.abort(
-          "Invalid --staging-branch value: #{branch.inspect}. " \
-          "Use a valid git branch name containing only alphanumerics, dots, slashes, underscores, hyphens, and @."
-        )
-      end
-
-      branch
-    end
-
-    def valid_staging_branch?(branch)
-      return false unless branch.match?(%r{\A[a-zA-Z0-9._/@-]+\z})
-
-      valid_git_branch_shape?(branch) && valid_git_branch_components?(branch)
-    end
-
-    def valid_git_branch_shape?(branch)
-      return false if branch.start_with?("-", "/", ".")
-      return false if branch.end_with?("/", ".")
-      return false if branch.include?("@{")
-
-      !branch.include?("..")
-    end
-
-    def valid_git_branch_components?(branch)
-      branch.split("/").none? do |component|
-        component.empty? || component.start_with?(".") || component.end_with?(".lock")
-      end
     end
   end
 end

--- a/lib/command/staging_branch_validation.rb
+++ b/lib/command/staging_branch_validation.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Command
+  module StagingBranchValidation
+    private
+
+    def staging_branch
+      branch = config.options[:staging_branch].to_s.strip
+      return nil if branch.empty?
+
+      unless valid_staging_branch?(branch)
+        Shell.abort(
+          "Invalid --staging-branch value: #{branch.inspect}. " \
+          "Use a valid git branch name containing only alphanumerics, dots, slashes, underscores, hyphens, and @."
+        )
+      end
+
+      branch
+    end
+
+    def valid_staging_branch?(branch)
+      return false unless branch.match?(%r{\A[a-zA-Z0-9._/@-]+\z})
+
+      valid_git_branch_shape?(branch) && valid_git_branch_components?(branch)
+    end
+
+    def valid_git_branch_shape?(branch)
+      return false if branch.start_with?("-", "/", ".")
+      return false if branch.end_with?("/", ".")
+      return false if branch.include?("@{")
+
+      !branch.include?("..")
+    end
+
+    def valid_git_branch_components?(branch)
+      branch.split("/").none? do |component|
+        component.empty? || component.start_with?(".") || component.end_with?(".lock")
+      end
+    end
+  end
+end

--- a/lib/command/update_github_actions.rb
+++ b/lib/command/update_github_actions.rb
@@ -2,8 +2,12 @@
 
 require "yaml"
 
+require_relative "staging_branch_validation"
+
 module Command
   class UpdateGithubActions < Base
+    include StagingBranchValidation
+
     NAME = "update-github-actions"
     OPTIONS = [staging_branch_option].freeze
     DESCRIPTION = "Regenerates generated GitHub Actions wrappers for the installed cpflow version"
@@ -38,35 +42,36 @@ module Command
 
     def call
       GenerateGithubActions.ensure_template_root!
+      abort_if_no_generated_files!
 
       branch = staging_branch || inferred_staging_branch
       GithubActionsGenerator.start([branch].compact)
 
+      print_post_update_message
+    end
+
+    private
+
+    def abort_if_no_generated_files!
+      return if GenerateGithubActions.generated_files.any? { |path| File.exist?(path) }
+
+      Shell.abort(
+        "No generated cpflow GitHub Actions files found in this repository. " \
+        "Run `cpflow generate-github-actions` first to create the wrappers, " \
+        "then use `cpflow update-github-actions` after future gem upgrades."
+      )
+    end
+
+    def print_post_update_message
       Shell.info("")
       Shell.info("Updated cpflow GitHub Actions wrappers for cpflow #{Cpflow::VERSION}.")
       Shell.info("Next: review the diff and run `bin/test-cpflow-github-flow`.")
       Shell.info("If you run cpflow through Bundler, use `bin/test-cpflow-github-flow bundle exec cpflow`.")
     end
 
-    private
-
-    def staging_branch
-      branch = config.options[:staging_branch].to_s.strip
-      return nil if branch.empty?
-
-      unless valid_staging_branch?(branch)
-        Shell.abort(
-          "Invalid --staging-branch value: #{branch.inspect}. " \
-          "Use a valid git branch name containing only alphanumerics, dots, slashes, underscores, hyphens, and @."
-        )
-      end
-
-      branch
-    end
-
     def inferred_staging_branch
       branches = existing_staging_branches
-      return if branches.empty? || branches == DEFAULT_STAGING_BRANCHES
+      return if branches.empty? || branches.sort == DEFAULT_STAGING_BRANCHES.sort
       return branches.first if branches.length == 1
 
       Shell.warn(
@@ -78,37 +83,27 @@ module Command
     end
 
     def existing_staging_branches
-      return [] unless STAGING_WORKFLOW_PATH.file?
+      Array(parsed_staging_workflow_on.dig("push", "branches")).map(&:to_s)
+    end
+
+    def parsed_staging_workflow_on
+      return {} unless STAGING_WORKFLOW_PATH.file?
 
       workflow = YAML.load_file(STAGING_WORKFLOW_PATH, aliases: true)
-      workflow_on = workflow["on"] || workflow[true] || {}
-      Array(workflow_on.dig("push", "branches")).map(&:to_s)
+      return {} unless workflow.is_a?(Hash)
+
+      workflow_on = workflow["on"] || workflow[true]
+      workflow_on.is_a?(Hash) ? workflow_on : {}
     rescue Psych::SyntaxError => e
+      warn_unparseable_staging_workflow(e)
+      {}
+    end
+
+    def warn_unparseable_staging_workflow(error)
       Shell.warn(
-        "Could not parse #{STAGING_WORKFLOW_PATH}: #{e.message}. " \
+        "Could not parse #{STAGING_WORKFLOW_PATH}: #{error.message}. " \
         "Run with --staging-branch BRANCH if staging should use a custom branch."
       )
-      []
-    end
-
-    def valid_staging_branch?(branch)
-      return false unless branch.match?(%r{\A[a-zA-Z0-9._/@-]+\z})
-
-      valid_git_branch_shape?(branch) && valid_git_branch_components?(branch)
-    end
-
-    def valid_git_branch_shape?(branch)
-      return false if branch.start_with?("-", "/", ".")
-      return false if branch.end_with?("/", ".")
-      return false if branch.include?("@{")
-
-      !branch.include?("..")
-    end
-
-    def valid_git_branch_components?(branch)
-      branch.split("/").none? do |component|
-        component.empty? || component.start_with?(".") || component.end_with?(".lock")
-      end
     end
   end
 end

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -244,6 +244,34 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(staging_workflow_path.read).to include('staging_app_branch_default: "develop"')
     end
 
+    it "treats a reversed default branch list as the default during update" do
+      staging_workflow_path.write(
+        staging_workflow_path.read.gsub('branches: ["main", "master"]', 'branches: ["master", "main"]')
+      )
+
+      inside_dir(playground) do
+        result = run_cpflow_command("update-github-actions")
+
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).not_to include("multiple custom push branches")
+      end
+
+      expect(staging_workflow_path.read).to include('branches: ["main", "master"]')
+      expect(staging_workflow_path.read).to include('staging_app_branch_default: ""')
+    end
+
+    it "regenerates wrappers without crashing when the staging workflow is empty" do
+      staging_workflow_path.write("")
+
+      inside_dir(playground) do
+        result = run_cpflow_command("update-github-actions")
+
+        expect(result[:status]).to eq(0)
+      end
+
+      expect(staging_workflow_path.read).to include('branches: ["main", "master"]')
+    end
+
     it "generates local helpers for pinning and validating cpflow workflow refs" do
       expect(pin_cpflow_ref_path.read).to include("Use a full 40-character commit SHA")
       expect(pin_cpflow_ref_path.read).to include("Pathname.new(path).relative_path_from(root).to_s")
@@ -847,6 +875,19 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
                      .sort
 
       expect(generated).to eq(expected)
+    end
+  end
+
+  context "when update-github-actions runs in a fresh repository" do
+    it "aborts with a clear message instead of silently bootstrapping wrappers" do
+      inside_dir(playground) do
+        result = run_cpflow_command("update-github-actions")
+
+        expect(result[:status]).to eq(ExitCode::ERROR_DEFAULT)
+        expect(result[:stderr]).to include("No generated cpflow GitHub Actions files")
+        expect(result[:stderr]).to include("cpflow generate-github-actions")
+        expect(playground.join(".github")).not_to exist
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Follow-up to #328 addressing review-bot feedback. Four small fixes plus a duplication cleanup, all scoped to the `update-github-actions` command.

- **Order-sensitive default-branch comparison** — a manually-edited staging workflow with `branches: ["master", "main"]` (reversed from generated default) used to fall through to the "multiple custom push branches" warning and silently drop the staging branch from regenerated wrappers. Fixed to compare sorted arrays.
- **Non-hash staging YAML crash** — an empty `cpflow-deploy-staging.yml` (or one that parses to `nil`/`false`) used to raise `NoMethodError` on `workflow["on"]`. Now returns an empty branch list and the command proceeds with defaults.
- **Silent file creation in fresh repos** — `update-github-actions` ran the generator unconditionally with `force: true`, so a repo that had never run `generate-github-actions` got the full wrapper set bootstrapped without warning. Now aborts with a message pointing at `generate-github-actions`.
- **Confusing `post_install_message`** — first-time gem installers saw `bin/test-cpflow-github-flow` referenced but the script doesn't exist yet. Added an explicit "New repository?" pointer to `generate-github-actions`.
- **Duplicated branch validation** — both `generate-github-actions` and `update-github-actions` had identical `staging_branch` / `valid_staging_branch?` / `valid_git_branch_*?` helpers. Extracted to a shared `Command::StagingBranchValidation` module.

Bots that flagged these: claude (#328), greptile, chatgpt-codex. The trivial nits we skipped (spurious `.freeze`, hardcoded `v5.0.0` in a test) are noted in the original review thread and don't materially affect behavior.

## Verification

- `env CPLN_ORG=dummy-test-org bundle exec rspec spec/command/generate_github_actions_spec.rb spec/command/ai_github_flow_prompt_spec.rb spec/cpflow_spec.rb spec/rakelib/create_release_spec.rb` — 103 examples, 0 failures
- `env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop-cache bundle exec rubocop cpflow.gemspec lib/command/base.rb lib/command/generate_github_actions.rb lib/command/update_github_actions.rb lib/command/staging_branch_validation.rb lib/command/ai_github_flow_prompt.rb rakelib/create_release.rake spec/cpflow_spec.rb spec/command/generate_github_actions_spec.rb spec/command/ai_github_flow_prompt_spec.rb` — 10 files, no offenses
- `bundle exec rake check_command_docs` — passes
- `git diff --check` — clean

## Test plan

- [x] New spec: reversed `[master, main]` is treated as the default (no warning, default branches regenerated)
- [x] New spec: empty staging workflow YAML doesn't crash and falls back to defaults
- [x] New spec: `update-github-actions` in a fresh repo aborts with `No generated cpflow GitHub Actions files` and creates no files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only changes to GitHub Actions generator/update commands with added specs; no auth, deploy, or runtime platform behavior changes.
> 
> **Overview**
> Hardens **`cpflow update-github-actions`** and related install/docs after PR #328 review feedback.
> 
> **`update-github-actions` behavior:** Default staging push branches (`main` / `master`) are recognized regardless of YAML list order (sorted comparison), so a reversed `["master", "main"]` no longer triggers a false “multiple custom branches” warning or drops the default staging branch on regenerate. Empty or non-hash staging workflow YAML no longer crashes; parsing falls back to defaults. Repos with no generated cpflow GitHub Actions files abort with a clear message pointing to **`generate-github-actions`** instead of silently creating wrappers.
> 
> **Refactor:** Shared **`Command::StagingBranchValidation`** replaces duplicated `--staging-branch` validation in generate and update commands.
> 
> **Docs / packaging:** Unreleased changelog entry, gemspec **`post_install_message`** clarifies “already uses” vs new repos (`generate-github-actions` first), plus specs for the new edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00feaa601b7b03885290463ada26c758c9ce8b88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->