### PR TITLE
Update changelog for 5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+## [5.0.3] - 2026-05-26
+
 ### Added
 
-- Added `cpflow update-github-actions`, `cpflow generate-github-actions --force`, RubyGems install guidance, and release-task follow-up output so downstream repositories remember to update checked-in generated GitHub Actions wrappers when the `cpflow` gem version changes.
+- **Added `cpflow update-github-actions`, `cpflow generate-github-actions --force`, RubyGems install guidance, and release-task follow-up output so downstream repositories remember to update checked-in generated GitHub Actions wrappers when the `cpflow` gem version changes.** [PR 328](https://github.com/shakacode/control-plane-flow/pull/328) by [Justin Gordon](https://github.com/justin808).
 
 ### Fixed
 
-- Fixed `cpflow update-github-actions` so a manually-reordered `branches: ["master", "main"]` staging workflow is still treated as the default (no spurious "multiple custom push branches" warning, no silent drop of the staging branch), and an empty or non-hash staging workflow no longer crashes the command. The command now aborts with a clear message instead of silently bootstrapping wrappers when run in a repository that has never run `generate-github-actions`. Clarified the RubyGems post-install message so first-time installers see the `generate-github-actions` path.
+- **Fixed `cpflow update-github-actions` so reordered default staging branches remain defaults, empty or non-hash staging workflow YAML no longer crashes, and fresh repos fail with a clear `generate-github-actions` instruction instead of silently creating wrappers.** [PR 331](https://github.com/shakacode/control-plane-flow/pull/331) by [Justin Gordon](https://github.com/justin808). Clarified the RubyGems post-install message so first-time installers see the `generate-github-actions` path.
 
 ## [5.0.2] - 2026-05-25
 
@@ -390,7 +392,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.2...HEAD
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.3...HEAD
+[5.0.3]: https://github.com/shakacode/control-plane-flow/compare/v5.0.2...v5.0.3
 [5.0.2]: https://github.com/shakacode/control-plane-flow/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0...v5.0.1
 [5.0.0]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0.rc.3...v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [5.0.3] - 2026-05-26
 
-### Added
+### Changed
 
-- **Added `cpflow update-github-actions`, `cpflow generate-github-actions --force`, RubyGems install guidance, and release-task follow-up output so downstream repositories remember to update checked-in generated GitHub Actions wrappers when the `cpflow` gem version changes.** [PR 328](https://github.com/shakacode/control-plane-flow/pull/328) by [Justin Gordon](https://github.com/justin808).
+- **Changed `cpflow update-github-actions`, `cpflow generate-github-actions --force`, RubyGems install guidance, and release-task follow-up output so downstream repositories remember to update checked-in generated GitHub Actions wrappers when the `cpflow` gem version changes.** [PR 328](https://github.com/shakacode/control-plane-flow/pull/328) by [Justin Gordon](https://github.com/justin808).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Stamps `CHANGELOG.md` for `5.0.3` with release notes for PR 328 and PR 331.
- Updates the `Unreleased` and `5.0.3` compare links so release automation reads the new section.

## Verification
- `git diff --check -- CHANGELOG.md`
- `bundle exec ruby -e "... CHANGELOG version/link check ..."`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and link updates with no runtime or API changes.
> 
> **Overview**
> Cuts **`CHANGELOG.md`** for release **5.0.3** (dated 2026-05-26): moves the prior **Unreleased** notes into a versioned section and leaves **Unreleased** empty.
> 
> The **5.0.3** section documents **Changed** work from [PR 328](https://github.com/shakacode/control-plane-flow/pull/328) (GitHub Actions wrapper update/generate flows and install/release messaging when the gem version changes) and **Fixed** work from [PR 331](https://github.com/shakacode/control-plane-flow/pull/331) (`update-github-actions` robustness for default staging branches, invalid YAML, and repos that have not run `generate-github-actions` yet). Compare links at the bottom now point **Unreleased** at `v5.0.3...HEAD` and add **`[5.0.3]`** vs `v5.0.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d3cef30ed4adc020541ec0200588dddc85b46a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->