### PR TITLE
[codex] Document bulk log downloads

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -544,7 +544,7 @@ cpflow terraform import
 Regenerates the generated cpflow GitHub Actions wrappers and helper files
 from the currently installed cpflow gem. Use this after updating the
 cpflow gem so checked-in workflow wrappers move to the matching upstream
-release tag, for example `v5.0.3`.
+release tag, for example `v5.0.4`.
 
 If the existing generated staging workflow uses a custom single staging
 branch, the command preserves it. Pass `--staging-branch BRANCH` to set or

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -5,16 +5,17 @@
 3. [Remote IP](#remote-ip)
 4. [Secrets and ENV Values](/docs/secrets-and-env-values.md)
 5. [CI](#ci)
-6. [Memcached](#memcached)
-7. [Sidekiq](#sidekiq)
+6. [Logs](#logs)
+7. [Memcached](#memcached)
+8. [Sidekiq](#sidekiq)
    - [Quieting Non-Critical Workers During Deployments](#quieting-non-critical-workers-during-deployments)
    - [Setting Up a Pre Stop Hook](#setting-up-a-pre-stop-hook)
    - [Setting Up a Liveness Probe](#setting-up-a-liveness-probe)
-8. [Minimizing Review App Costs](#minimizing-review-app-costs)
+9. [Minimizing Review App Costs](#minimizing-review-app-costs)
    - [Scale the Web Workload to Zero](#scale-the-web-workload-to-zero)
    - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
    - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
-9. [Useful Links](#useful-links)
+10. [Useful Links](#useful-links)
 
 ## GVCs vs. Orgs
 
@@ -90,6 +91,38 @@ Also, log in to the Control Plane Docker repository if building and pushing an i
 
 ```sh
 cpln image docker-login
+```
+
+## Logs
+
+`cpflow logs` is a lightweight live-tail command. When you hit `cpln`/`cpflow` line-count or response-size limits, use
+Grafana Loki's [`logcli`](https://grafana.com/docs/loki/latest/query/logcli/) directly against the Control Plane logs
+endpoint for larger historical exports.
+
+Install `logcli`:
+
+```sh
+brew install logcli
+```
+
+Configure it with your Control Plane org and current profile token:
+
+```sh
+export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
+export LOKI_BEARER_TOKEN=$(cpln profile token)
+```
+
+Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
+labels as needed:
+
+```sh
+logcli query '{gvc="my-app", workload="rails"}' --since 1h --limit 10000
+```
+
+For cleaner bulk exports, omit labels and redirect the output:
+
+```sh
+logcli query '{gvc="my-app", workload="rails"}' --since 24h --limit 50000 --no-labels > rails.log
 ```
 
 ## Memcached

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -99,14 +99,22 @@ cpln image docker-login
 Grafana Loki's [`logcli`](https://grafana.com/docs/loki/latest/query/logcli/) directly against the Control Plane logs
 endpoint for larger historical exports.
 
-Install `logcli`:
+Install `logcli` with Homebrew when available:
 
 ```sh
 brew install logcli
 ```
 
+If Homebrew reports that the formula is unavailable, use Grafana's tap:
+
+```sh
+brew tap grafana/grafana
+brew install grafana/grafana/logcli
+```
+
 For Linux, CI, or other environments without Homebrew, see the [`logcli` installation
-docs](https://grafana.com/docs/loki/latest/query/logcli/#installation).
+docs](https://grafana.com/docs/loki/latest/query/logcli/getting-started/#install-logcli) for binary downloads or source
+builds.
 
 Configure it with your Control Plane org and current profile token:
 
@@ -115,8 +123,8 @@ export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
 export LOKI_BEARER_TOKEN=$(cpln profile token)
 ```
 
-`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Keep it out of logs and rerun the token export if `logcli`
-returns an authentication error.
+`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Keep it out of logs; because it is exported, child processes can
+read it from their environment. Rerun the token export if `logcli` returns a 401 or another authentication error.
 
 Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
 labels as needed:
@@ -129,6 +137,16 @@ For cleaner bulk exports, strip label metadata from each output line and redirec
 
 ```sh
 logcli query '{gvc="my-app", workload="rails"}' --since 24h --limit 50000 --no-labels > rails.log
+```
+
+For historical incidents, use absolute UTC timestamps instead of a relative `--since` window:
+
+```sh
+logcli query '{gvc="my-app"}' \
+  --from="2026-05-27T00:00:00Z" \
+  --to="2026-05-27T06:00:00Z" \
+  --limit 50000 \
+  --no-labels > incident.log
 ```
 
 ## Memcached

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -123,8 +123,8 @@ export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
 export LOKI_BEARER_TOKEN=$(cpln profile token)
 ```
 
-`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Keep it out of logs; because it is exported, child processes can
-read it from their environment. Rerun the token export if `logcli` returns a 401 or another authentication error.
+`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Avoid echoing it, committing it to scripts, or letting it
+appear in shell history or CI logs. Rerun the token export if `logcli` returns a 401 or another authentication error.
 
 Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
 labels as needed:
@@ -148,6 +148,10 @@ logcli query '{gvc="my-app"}' \
   --limit 50000 \
   --no-labels > incident.log
 ```
+
+`logcli` silently truncates results once `--limit` is reached, so a partial export looks the same as a complete one. If
+the output appears cut off, narrow the time window or raise `--limit` (the maximum may depend on your Control Plane
+plan).
 
 ## Memcached
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -119,14 +119,14 @@ builds.
 Configure it with your Control Plane org and current profile token:
 
 ```sh
-export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
+export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG  # run `cpln org get` to find your org name
 export LOKI_BEARER_TOKEN=$(cpln profile token)
 ```
 
-`LOKI_BEARER_TOKEN` is a short-lived bearer credential. The `$(cpln profile token)` capture above keeps the literal
-token out of shell history, but any later command that prints it (`echo $LOKI_BEARER_TOKEN`, `env | grep LOKI`) will
-expose it; avoid those, don't commit the value to scripts, and watch for it in CI logs. Rerun the token export if
-`logcli` returns a 401 or another authentication error.
+`LOKI_BEARER_TOKEN` is a short-lived bearer credential (it typically expires after roughly 15–60 minutes). The
+`$(cpln profile token)` capture above keeps the literal token out of shell history, but any later command that prints
+it (`echo $LOKI_BEARER_TOKEN`, `env | grep LOKI`) will expose it; avoid those, don't commit the value to scripts, and
+watch for it in CI logs. Rerun the token export if `logcli` returns a 401 or another authentication error.
 
 Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
 labels as needed. The `--forward` flag returns results oldest-first (chronological), which is almost always what you

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -123,20 +123,23 @@ export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
 export LOKI_BEARER_TOKEN=$(cpln profile token)
 ```
 
-`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Avoid echoing it, committing it to scripts, or letting it
-appear in shell history or CI logs. Rerun the token export if `logcli` returns a 401 or another authentication error.
+`LOKI_BEARER_TOKEN` is a short-lived bearer credential. The `$(cpln profile token)` capture above keeps the literal
+token out of shell history, but any later command that prints it (`echo $LOKI_BEARER_TOKEN`, `env | grep LOKI`) will
+expose it; avoid those, don't commit the value to scripts, and watch for it in CI logs. Rerun the token export if
+`logcli` returns a 401 or another authentication error.
 
 Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
-labels as needed:
+labels as needed. The `--forward` flag returns results oldest-first (chronological), which is almost always what you
+want for incident investigation or sequential reading; omit it to get the `logcli` default of newest-first:
 
 ```sh
-logcli query '{gvc="my-app", workload="rails"}' --since 1h --limit 10000
+logcli query '{gvc="my-app", workload="rails"}' --since 1h --limit 10000 --forward
 ```
 
 For cleaner bulk exports, strip label metadata from each output line and redirect the output:
 
 ```sh
-logcli query '{gvc="my-app", workload="rails"}' --since 24h --limit 50000 --no-labels > rails.log
+logcli query '{gvc="my-app", workload="rails"}' --since 24h --limit 50000 --no-labels --forward > rails.log
 ```
 
 For historical incidents, use absolute UTC timestamps instead of a relative `--since` window:
@@ -146,12 +149,14 @@ logcli query '{gvc="my-app"}' \
   --from="2026-05-27T00:00:00Z" \
   --to="2026-05-27T06:00:00Z" \
   --limit 50000 \
-  --no-labels > incident.log
+  --no-labels \
+  --forward > incident.log
 ```
 
-`logcli` silently truncates results once `--limit` is reached, so a partial export looks the same as a complete one. If
-the output appears cut off, narrow the time window or raise `--limit` (the maximum may depend on your Control Plane
-plan).
+`logcli` silently truncates results once `--limit` is reached, so a partial export looks the same as a complete one.
+To check for truncation, compare line count to the limit: `wc -l < incident.log` near `--limit` means the export was
+likely cut off. Prefer narrowing the time window (and concatenating the sub-ranges) over raising `--limit`, since the
+server-side cap may be lower than the flag value.
 
 ## Memcached
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -105,12 +105,18 @@ Install `logcli`:
 brew install logcli
 ```
 
+For Linux, CI, or other environments without Homebrew, see the [`logcli` installation
+docs](https://grafana.com/docs/loki/latest/query/logcli/#installation).
+
 Configure it with your Control Plane org and current profile token:
 
 ```sh
 export LOKI_ADDR=https://logs.cpln.io/logs/org/YOUR_ORG
 export LOKI_BEARER_TOKEN=$(cpln profile token)
 ```
+
+`LOKI_BEARER_TOKEN` is a short-lived bearer credential. Keep it out of logs and rerun the token export if `logcli`
+returns an authentication error.
 
 Then query logs by label. A Control Plane app is a GVC, so set `gvc` to the app name and narrow by workload or other
 labels as needed:
@@ -119,7 +125,7 @@ labels as needed:
 logcli query '{gvc="my-app", workload="rails"}' --since 1h --limit 10000
 ```
 
-For cleaner bulk exports, omit labels and redirect the output:
+For cleaner bulk exports, strip label metadata from each output line and redirect the output:
 
 ```sh
 logcli query '{gvc="my-app", workload="rails"}' --since 24h --limit 50000 --no-labels > rails.log


### PR DESCRIPTION
## Summary
Adds a Logs tip documenting how to use Grafana logcli for bulk Control Plane log exports when cpflow/cpln live-tail limits are too small.
Includes LOKI_ADDR, LOKI_BEARER_TOKEN, sample workload label queries, --limit, --no-labels, and redirection.
Closes #56.

## Validation
- git diff --check
- ./script/check_cpln_links docs/tips.md
- curl -fsI https://grafana.com/docs/loki/latest/query/logcli/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or application code impact.
> 
> **Overview**
> Adds a **Logs** tip for when **`cpflow logs`** live-tail limits are too small: use Grafana **`logcli`** against the Control Plane Loki endpoint for larger historical pulls.
> 
> The new section covers **`logcli`** install (Homebrew and alternatives), **`LOKI_ADDR`** / **`LOKI_BEARER_TOKEN`** setup from **`cpln profile token`**, token hygiene and refresh, label queries with **`gvc`** and **`workload`**, **`--forward`**, **`--no-labels`**, redirects, absolute **`--from`/`--to`** windows, and how to spot silent **`--limit`** truncation.
> 
> The tips table of contents is renumbered for the new section. **`docs/commands.md`** only updates the **`update-github-actions`** example release tag (**`v5.0.3`** → **`v5.0.4`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ac9005eaf9652033d635c4b84a93e83209b4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->