### PR TITLE
Replace maintenance mode sleep with domain polling

### DIFF
--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -19,6 +19,13 @@ on:
 jobs:
   rspec:
     runs-on: ${{ inputs.os_version }}
+    # Scope the live Control Plane org queue per PR (or ref) instead of globally:
+    # each run uses its own random app suffix (SecureRandom.hex(2)) on a fresh
+    # runner, so concurrent PRs don't collide on app names or CLI profiles. PRs
+    # run only the fast (~slow) suite, which doesn't switch the shared domain's
+    # route; domain-mutating specs are :slow and dispatched manually, keyed by
+    # github.ref so same-ref dispatches still serialize. cancel-in-progress is
+    # false, so queued runs wait their turn rather than being cancelled.
     concurrency:
       group: cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -20,7 +20,7 @@ jobs:
   rspec:
     runs-on: ${{ inputs.os_version }}
     concurrency:
-      group: cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}
+      group: cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: false
     env:
       RAILS_ENV: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Changed
+
+- **Changed `cpflow maintenance:on` and `cpflow maintenance:off` to confirm the domain route has switched by polling the Control Plane API (bounded retry, 30 attempts, 1 second apart) instead of sleeping a fixed 30 seconds.** [PR 337](https://github.com/shakacode/control-plane-flow/pull/337) by [Justin Gordon](https://github.com/justin808). Fixes [issue 157](https://github.com/shakacode/control-plane-flow/issues/157). If the route never updates within the poll window, the command aborts before stopping workloads so traffic stays on the current workload, and transient API errors during polling are retried rather than aborting the switch.
+
 ### Fixed
 
 - **Fixed `cpflow run` so short non-interactive runner jobs no longer hang when the Control Plane cron job finishes before a runner replica is visible.** This prevents generated deploy workflows with release-phase commands from waiting until the GitHub Actions job timeout even though the release job already completed successfully.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Changed
 
-- **Changed `cpflow maintenance:on` and `cpflow maintenance:off` to confirm the domain route has switched by polling the Control Plane API (bounded retry, 30 attempts, 1 second apart) instead of sleeping a fixed 30 seconds.** [PR 337](https://github.com/shakacode/control-plane-flow/pull/337) by [Justin Gordon](https://github.com/justin808). Fixes [issue 157](https://github.com/shakacode/control-plane-flow/issues/157). If the route never updates within the poll window, the command aborts before stopping workloads so traffic stays on the current workload, and transient API errors during polling are retried rather than aborting the switch.
+- **Changed `cpflow maintenance:on` and `cpflow maintenance:off` to confirm the domain route has switched by polling the Control Plane API (bounded retry, 30 attempts, 1 second apart) instead of sleeping a fixed 30 seconds.** [PR 337](https://github.com/shakacode/control-plane-flow/pull/337) by [Justin Gordon](https://github.com/justin808). Fixes [issue 157](https://github.com/shakacode/control-plane-flow/issues/157). If the route never updates within the poll window, the command aborts before stopping workloads so traffic stays on the current workload, and transient API errors during polling are retried rather than aborting the switch. Because the route switch and the workload stop run as separate steps, re-running the command also finishes a switch whose poll timed out after the route had already updated.
 
 ### Fixed
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -315,7 +315,7 @@ cpflow maintenance -a $APP_NAME
 ### `maintenance:off`
 
 - Disables maintenance mode for an app
-- Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already disabled stops the workloads to finish it (so it is not a pure no-op)
+- Safe to re-run: if a previous run timed out after switching the domain but before stopping the maintenance workload, re-running while maintenance mode is already disabled stops the maintenance workload to finish it (so it is not a pure no-op)
 - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
 - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443
@@ -327,7 +327,7 @@ cpflow maintenance:off -a $APP_NAME
 ### `maintenance:on`
 
 - Enables maintenance mode for an app
-- Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already enabled stops the workloads to finish it (so it is not a pure no-op)
+- Safe to re-run: if a previous run timed out after switching the domain but before stopping the app workloads, re-running while maintenance mode is already enabled stops the app workloads to finish it (so it is not a pure no-op)
 - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
 - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -315,6 +315,7 @@ cpflow maintenance -a $APP_NAME
 ### `maintenance:off`
 
 - Disables maintenance mode for an app
+- Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already disabled stops the workloads to finish it (so it is not a pure no-op)
 - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
 - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443
@@ -326,6 +327,7 @@ cpflow maintenance:off -a $APP_NAME
 ### `maintenance:on`
 
 - Enables maintenance mode for an app
+- Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already enabled stops the workloads to finish it (so it is not a pure no-op)
 - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
 - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -10,6 +10,7 @@ module Command
     DESCRIPTION = "Disables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
       - Disables maintenance mode for an app
+      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already disabled stops the workloads to finish it (so it is not a pure no-op)
       - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
       - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
       - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -10,7 +10,7 @@ module Command
     DESCRIPTION = "Disables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
       - Disables maintenance mode for an app
-      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already disabled stops the workloads to finish it (so it is not a pure no-op)
+      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the maintenance workload, re-running while maintenance mode is already disabled stops the maintenance workload to finish it (so it is not a pure no-op)
       - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
       - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
       - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -10,6 +10,7 @@ module Command
     DESCRIPTION = "Enables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
       - Enables maintenance mode for an app
+      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already enabled stops the workloads to finish it (so it is not a pure no-op)
       - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
       - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
       - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -10,7 +10,7 @@ module Command
     DESCRIPTION = "Enables maintenance mode for an app"
     LONG_DESCRIPTION = <<~DESC
       - Enables maintenance mode for an app
-      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the workloads, re-running while maintenance mode is already enabled stops the workloads to finish it (so it is not a pure no-op)
+      - Safe to re-run: if a previous run timed out after switching the domain but before stopping the app workloads, re-running while maintenance mode is already enabled stops the app workloads to finish it (so it is not a pure no-op)
       - Specify the one-off workload through `one_off_workload` in the `.controlplane/controlplane.yml` file
       - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
       - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -3,12 +3,12 @@
 class MaintenanceMode
   extend Forwardable
 
-  DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT = 30
-  DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT = 1
+  DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS = 30
+  DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS = 1
   DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
     retry_on_failure: true,
-    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT,
-    wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT
+    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1,
+    wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS
   }.freeze
 
   def_delegators :@command, :config, :progress, :cp, :step, :run_cpflow_command
@@ -93,7 +93,8 @@ class MaintenanceMode
     domain_name = domain_data["name"]
 
     step("Requesting workload switch for domain '#{domain_name}' to '#{to}'") do
-      request_domain_workload_update(to)
+      domain_data_for_update = Marshal.load(Marshal.dump(domain_data))
+      cp.set_domain_workload(domain_data_for_update, to)
     end
 
     step("Waiting for domain '#{domain_name}' workload to switch to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
@@ -102,10 +103,6 @@ class MaintenanceMode
     end
 
     progress.puts
-  end
-
-  def request_domain_workload_update(workload)
-    cp.set_domain_workload(domain_data, workload)
   end
 
   def refresh_domain_data(domain_name)

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -84,9 +84,9 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
 
   # A run that already switched the route but hit the poll timeout aborts before
   # its final workload-stop step runs. The next `enable!`/`disable!` short-circuits
-  # on the route check, so finish that stop here — a re-run completes what the
-  # timed-out run started. `ps:stop` is idempotent, so each is a no-op once the
-  # target workload is already stopped.
+  # on the route check, so do the matching stop here — once the route is on the
+  # target, this brings the workloads into the state that route implies. `ps:stop`
+  # is idempotent, so each is a no-op once the target workload is already stopped.
   #
   # The stop target differs by direction. `ps:stop -a` covers only
   # `app_workloads` + `additional_workloads`, never the maintenance workload:
@@ -128,7 +128,11 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
       # `set_domain_workload` mutates the route in place, so send a deep copy
       # (round-tripped through JSON, since the domain is plain parsed-API data
       # with string keys and JSON-native values) to keep the cached
-      # `@domain_data` intact for the polling check below.
+      # `@domain_data` reflecting the real server route. The poll re-fetches and
+      # matches on that fresh data, but if every poll times out without a routable
+      # fetch, `@domain_data` is what a re-run's `enabled?`/`disabled?` check reads
+      # — mutating it here would make that check report the requested route, not
+      # the actual one.
       domain_data_for_update = JSON.parse(JSON.generate(domain_data))
       cp.set_domain_workload(domain_data_for_update, to)
     end
@@ -168,8 +172,8 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
     # lines. Guard on `tmp_stderr` so this stays safe if ever called outside a
     # `step` block, where no tmp stderr is set up.
     message = "#{e.class}: #{e.message} (#{e.backtrace&.first})\n"
-    if message != @last_poll_error
-      Shell.write_to_tmp_stderr(message) if Shell.tmp_stderr
+    if message != @last_poll_error && Shell.tmp_stderr
+      Shell.write_to_tmp_stderr(message)
       @last_poll_error = message
     end
     false

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -108,10 +108,16 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   def switch_domain_workload(to:)
     domain_name = domain_data["name"]
 
+    # Unlike the polling step below, the switch request is intentionally not
+    # retried: if it fails, nothing has changed yet, so aborting and letting the
+    # user re-run is the safe outcome. (Retrying would not help here anyway —
+    # `with_retry` retries on a falsy return, and `set_domain_workload` raises
+    # rather than returning false.)
     step("Requesting workload switch for domain '#{domain_name}' to '#{to}'") do
       # `set_domain_workload` mutates the route in place, so send a deep copy
-      # (round-tripped through JSON, since the domain is plain API data) to keep
-      # the cached `@domain_data` intact for the polling check below.
+      # (round-tripped through JSON, since the domain is plain parsed-API data
+      # with string keys and JSON-native values) to keep the cached
+      # `@domain_data` intact for the polling check below.
       domain_data_for_update = JSON.parse(JSON.generate(domain_data))
       cp.set_domain_workload(domain_data_for_update, to)
     end
@@ -140,7 +146,7 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
     @domain_data = refreshed_domain_data if refreshed_domain_data
     refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, workload)
   rescue StandardError => e
-    Shell.write_to_tmp_stderr("#{e.class}: #{e.message}\n")
+    Shell.write_to_tmp_stderr("#{e.class}: #{e.message} (#{e.backtrace&.first})\n")
     false
   end
 

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -3,6 +3,14 @@
 class MaintenanceMode
   extend Forwardable
 
+  DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT = 30
+  DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT = 1
+  DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
+    retry_on_failure: true,
+    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT,
+    wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT
+  }.freeze
+
   def_delegators :@command, :config, :progress, :cp, :step, :run_cpflow_command
 
   def initialize(command)
@@ -82,14 +90,28 @@ class MaintenanceMode
   end
 
   def switch_domain_workload(to:)
-    step("Switching workload for domain '#{domain_data['name']}' to '#{to}'") do
-      cp.set_domain_workload(domain_data, to)
+    domain_name = domain_data["name"]
+    update_requested = false
 
-      # Give it a bit of time for the domain to update
-      Kernel.sleep(30)
+    step("Switching workload for domain '#{domain_name}' to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
+      unless update_requested
+        request_domain_workload_update(to)
+        update_requested = true
+      end
+
+      domain_workload_update_confirmed?(domain_name, to)
     end
 
     progress.puts
+  end
+
+  def request_domain_workload_update(workload)
+    cp.set_domain_workload(domain_data, workload)
+  end
+
+  def domain_workload_update_confirmed?(domain_name, workload)
+    @domain_data = cp.fetch_domain(domain_name)
+    @domain_data && cp.domain_workload_matches?(@domain_data, workload)
   end
 
   def domain_data

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -7,6 +7,9 @@ class MaintenanceMode
   DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS = 1
   DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
     retry_on_failure: true,
+    # `step`'s `max_retry_count` is inclusive of the initial attempt, so total
+    # poll attempts == max_retry_count + 1. Subtract 1 to get exactly the
+    # configured number of attempts.
     max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1,
     wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS
   }.freeze
@@ -93,10 +96,15 @@ class MaintenanceMode
     domain_name = domain_data["name"]
 
     step("Requesting workload switch for domain '#{domain_name}' to '#{to}'") do
+      # `set_domain_workload` mutates the route in place, so update a deep copy
+      # to keep the cached `@domain_data` intact for the polling check below.
       domain_data_for_update = Marshal.load(Marshal.dump(domain_data))
       cp.set_domain_workload(domain_data_for_update, to)
     end
 
+    # If the route never switches within the bounded poll window, this step aborts
+    # (abort_on_error) before any workloads are stopped, so traffic stays on the
+    # current workload. Re-run the command to retry the switch.
     step("Waiting for domain '#{domain_name}' workload to switch to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
       refreshed_domain_data = refresh_domain_data(domain_name)
       refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, to)

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -91,15 +91,14 @@ class MaintenanceMode
 
   def switch_domain_workload(to:)
     domain_name = domain_data["name"]
-    update_requested = false
 
-    step("Switching workload for domain '#{domain_name}' to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
-      unless update_requested
-        request_domain_workload_update(to)
-        update_requested = true
-      end
+    step("Requesting workload switch for domain '#{domain_name}' to '#{to}'") do
+      request_domain_workload_update(to)
+    end
 
-      domain_workload_update_confirmed?(domain_name, to)
+    step("Waiting for domain '#{domain_name}' workload to switch to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
+      refreshed_domain_data = refresh_domain_data(domain_name)
+      refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, to)
     end
 
     progress.puts
@@ -109,9 +108,10 @@ class MaintenanceMode
     cp.set_domain_workload(domain_data, workload)
   end
 
-  def domain_workload_update_confirmed?(domain_name, workload)
-    @domain_data = cp.fetch_domain(domain_name)
-    @domain_data && cp.domain_workload_matches?(@domain_data, workload)
+  def refresh_domain_data(domain_name)
+    cp.fetch_domain(domain_name).tap do |refreshed_domain_data|
+      @domain_data = refreshed_domain_data if refreshed_domain_data
+    end
   end
 
   def domain_data

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -7,9 +7,9 @@ class MaintenanceMode
   DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS = 1
   DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
     retry_on_failure: true,
-    # `step`'s `max_retry_count` is inclusive of the initial attempt, so total
-    # poll attempts == max_retry_count + 1. Subtract 1 to get exactly the
-    # configured number of attempts.
+    # `with_retry` runs the block while `retry_count <= max_retry_count`, where
+    # `retry_count` starts at 0, so total attempts == max_retry_count + 1. Pass
+    # MAX_POLL_ATTEMPTS - 1 to get exactly MAX_POLL_ATTEMPTS attempts.
     max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1,
     wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS
   }.freeze
@@ -96,27 +96,36 @@ class MaintenanceMode
     domain_name = domain_data["name"]
 
     step("Requesting workload switch for domain '#{domain_name}' to '#{to}'") do
-      # `set_domain_workload` mutates the route in place, so update a deep copy
-      # to keep the cached `@domain_data` intact for the polling check below.
-      domain_data_for_update = Marshal.load(Marshal.dump(domain_data))
+      # `set_domain_workload` mutates the route in place, so send a deep copy
+      # (round-tripped through JSON, since the domain is plain API data) to keep
+      # the cached `@domain_data` intact for the polling check below.
+      domain_data_for_update = JSON.parse(JSON.generate(domain_data))
       cp.set_domain_workload(domain_data_for_update, to)
     end
 
     # If the route never switches within the bounded poll window, this step aborts
     # (abort_on_error) before any workloads are stopped, so traffic stays on the
-    # current workload. Re-run the command to retry the switch.
-    step("Waiting for domain '#{domain_name}' workload to switch to '#{to}'", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
-      refreshed_domain_data = refresh_domain_data(domain_name)
-      refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, to)
+    # current workload. The label tells the user how to recover, since an exhausted
+    # poll has no error message of its own to print.
+    step("Waiting for domain '#{domain_name}' workload to switch to '#{to}' " \
+         "(re-run this command if it times out)", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
+      domain_workload_update_confirmed?(domain_name, to)
     end
 
     progress.puts
   end
 
-  def refresh_domain_data(domain_name)
-    cp.fetch_domain(domain_name).tap do |refreshed_domain_data|
-      @domain_data = refreshed_domain_data if refreshed_domain_data
-    end
+  # Refetches the domain, refreshes the cached `@domain_data` when the fetch
+  # returns a routable domain, and reports whether the route now points at
+  # `workload`. A transient API error (e.g. a 5xx while the route is still
+  # propagating) is treated as "not switched yet" so the bounded poll keeps
+  # retrying instead of aborting on the first blip.
+  def domain_workload_update_confirmed?(domain_name, workload)
+    refreshed_domain_data = cp.fetch_domain(domain_name)
+    @domain_data = refreshed_domain_data if refreshed_domain_data
+    refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, workload)
+  rescue RuntimeError
+    false
   end
 
   def domain_data

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -35,6 +35,7 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   def enable!
     if enabled?
       progress.puts("Maintenance mode is already enabled for app '#{config.app}'.")
+      ensure_workloads_stopped
     else
       enable_maintenance_mode
     end
@@ -43,6 +44,7 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   def disable!
     if disabled?
       progress.puts("Maintenance mode is already disabled for app '#{config.app}'.")
+      ensure_workloads_stopped
     else
       disable_maintenance_mode
     end
@@ -80,6 +82,15 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
 
   def validate_maintenance_workload_exists!
     cp.fetch_workload!(maintenance_workload)
+  end
+
+  # A run that already switched the route but hit the poll timeout aborts before
+  # `start_or_stop_all_workloads(:stop)` runs, leaving the app workloads up. The
+  # next `enable!`/`disable!` short-circuits on the route check, so stop the
+  # workloads here too — that lets a re-run finish what the timed-out run started.
+  # `ps:stop` is idempotent, so it is a no-op once the workloads are stopped.
+  def ensure_workloads_stopped
+    start_or_stop_all_workloads(:stop)
   end
 
   def start_or_stop_all_workloads(action)

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -5,12 +5,14 @@ class MaintenanceMode
 
   DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS = 30
   DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS = 1
+  # `with_retry` runs the block while `retry_count <= max_retry_count`, where
+  # `retry_count` starts at 0, so total attempts == max_retry_count + 1. Subtract
+  # 1 here so the bounded poll runs exactly MAX_POLL_ATTEMPTS times. Naming the
+  # value keeps that off-by-one explicit if `with_retry`'s loop ever changes.
+  DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT = DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1
   DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
     retry_on_failure: true,
-    # `with_retry` runs the block while `retry_count <= max_retry_count`, where
-    # `retry_count` starts at 0, so total attempts == max_retry_count + 1. Pass
-    # MAX_POLL_ATTEMPTS - 1 to get exactly MAX_POLL_ATTEMPTS attempts.
-    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1,
+    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT,
     wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS
   }.freeze
 
@@ -117,14 +119,15 @@ class MaintenanceMode
 
   # Refetches the domain, refreshes the cached `@domain_data` when the fetch
   # returns a routable domain, and reports whether the route now points at
-  # `workload`. A transient API error (e.g. a 5xx while the route is still
-  # propagating) is treated as "not switched yet" so the bounded poll keeps
+  # `workload`. Any API error (a 5xx while the route is still propagating, or a
+  # transient 403 — `ControlplaneApiDirect::ForbiddenError < StandardError`, not
+  # a `RuntimeError`) is treated as "not switched yet" so the bounded poll keeps
   # retrying instead of aborting on the first blip.
   def domain_workload_update_confirmed?(domain_name, workload)
     refreshed_domain_data = cp.fetch_domain(domain_name)
     @domain_data = refreshed_domain_data if refreshed_domain_data
     refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, workload)
-  rescue RuntimeError
+  rescue StandardError
     false
   end
 

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MaintenanceMode
+class MaintenanceMode # rubocop:disable Metrics/ClassLength
   extend Forwardable
 
   DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS = 30
@@ -119,15 +119,17 @@ class MaintenanceMode
 
   # Refetches the domain, refreshes the cached `@domain_data` when the fetch
   # returns a routable domain, and reports whether the route now points at
-  # `workload`. Any API error (a 5xx while the route is still propagating, or a
-  # transient 403 — `ControlplaneApiDirect::ForbiddenError < StandardError`, not
-  # a `RuntimeError`) is treated as "not switched yet" so the bounded poll keeps
-  # retrying instead of aborting on the first blip.
+  # `workload`. Any error — a 5xx mid-propagation, a transient 403
+  # (`ForbiddenError < StandardError`, not a `RuntimeError`), or a network blip —
+  # is treated as "not switched yet" so the poll keeps retrying. The broad rescue
+  # logs each error to the step's stderr, so a latent bug (e.g. `NoMethodError`)
+  # surfaces in the "failed!" output on timeout instead of being swallowed.
   def domain_workload_update_confirmed?(domain_name, workload)
     refreshed_domain_data = cp.fetch_domain(domain_name)
     @domain_data = refreshed_domain_data if refreshed_domain_data
     refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, workload)
-  rescue StandardError
+  rescue StandardError => e
+    Shell.write_to_tmp_stderr("#{e.class}: #{e.message}\n")
     false
   end
 

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -33,7 +33,7 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   def enable!
     if enabled?
       progress.puts("Maintenance mode is already enabled for app '#{config.app}'.")
-      ensure_workloads_stopped
+      ensure_app_workloads_stopped
     else
       enable_maintenance_mode
     end
@@ -42,7 +42,7 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   def disable!
     if disabled?
       progress.puts("Maintenance mode is already disabled for app '#{config.app}'.")
-      ensure_workloads_stopped
+      ensure_maintenance_workload_stopped
     else
       disable_maintenance_mode
     end
@@ -83,12 +83,25 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   end
 
   # A run that already switched the route but hit the poll timeout aborts before
-  # `start_or_stop_all_workloads(:stop)` runs, leaving the app workloads up. The
-  # next `enable!`/`disable!` short-circuits on the route check, so stop the
-  # workloads here too — that lets a re-run finish what the timed-out run started.
-  # `ps:stop` is idempotent, so it is a no-op once the workloads are stopped.
-  def ensure_workloads_stopped
+  # its final workload-stop step runs. The next `enable!`/`disable!` short-circuits
+  # on the route check, so finish that stop here — a re-run completes what the
+  # timed-out run started. `ps:stop` is idempotent, so each is a no-op once the
+  # target workload is already stopped.
+  #
+  # The stop target differs by direction. `ps:stop -a` covers only
+  # `app_workloads` + `additional_workloads`, never the maintenance workload:
+  #   - enable!: the route now points at the maintenance workload, so the *app*
+  #     workloads are the ones left running and `ps:stop -a` is correct.
+  #   - disable!: the route now points at the app workloads (and a short-circuit
+  #     `disable!` can run on an app whose app workloads are serving live traffic),
+  #     so stopping all workloads would cause an outage. The workload a timed-out
+  #     `disable!` leaves running is the maintenance workload, so stop only that.
+  def ensure_app_workloads_stopped
     start_or_stop_all_workloads(:stop)
+  end
+
+  def ensure_maintenance_workload_stopped
+    start_or_stop_maintenance_workload(:stop)
   end
 
   def start_or_stop_all_workloads(action)
@@ -120,16 +133,21 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
       cp.set_domain_workload(domain_data_for_update, to)
     end
 
-    # If the route never switches within the bounded poll window, this step aborts
-    # (abort_on_error) before any workloads are stopped, so traffic stays on the
-    # current workload. The label tells the user how to recover, since an exhausted
-    # poll has no error message of its own to print.
+    wait_for_domain_workload_switch(domain_name, to)
+
+    progress.puts
+  end
+
+  # If the route never switches within the bounded poll window, this step aborts
+  # (abort_on_error) before any workloads are stopped, so traffic stays on the
+  # current workload. The label tells the user how to recover, since an exhausted
+  # poll has no error message of its own to print.
+  def wait_for_domain_workload_switch(domain_name, to)
+    @last_poll_error = nil # reset the poll-error dedup state for this poll window
     step("Waiting for domain '#{domain_name}' workload to switch to '#{to}' " \
          "(re-run this command if it times out)", **DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS) do
       domain_workload_update_confirmed?(domain_name, to)
     end
-
-    progress.puts
   end
 
   # Refetches the domain, refreshes the cached `@domain_data` when the fetch

--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -5,14 +5,12 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
 
   DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS = 30
   DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS = 1
-  # `with_retry` runs the block while `retry_count <= max_retry_count`, where
-  # `retry_count` starts at 0, so total attempts == max_retry_count + 1. Subtract
-  # 1 here so the bounded poll runs exactly MAX_POLL_ATTEMPTS times. Naming the
-  # value keeps that off-by-one explicit if `with_retry`'s loop ever changes.
-  DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT = DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1
   DOMAIN_WORKLOAD_UPDATE_STEP_OPTIONS = {
     retry_on_failure: true,
-    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_RETRY_COUNT,
+    # `with_retry` loops while `retry_count <= max_retry_count` starting from 0, so
+    # total attempts == max_retry_count + 1. Subtract 1 so the bounded poll runs
+    # exactly DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS times.
+    max_retry_count: DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS - 1,
     wait: DOMAIN_WORKLOAD_UPDATE_RETRY_WAIT_SECONDS
   }.freeze
 
@@ -139,14 +137,23 @@ class MaintenanceMode # rubocop:disable Metrics/ClassLength
   # `workload`. Any error — a 5xx mid-propagation, a transient 403
   # (`ForbiddenError < StandardError`, not a `RuntimeError`), or a network blip —
   # is treated as "not switched yet" so the poll keeps retrying. The broad rescue
-  # logs each error to the step's stderr, so a latent bug (e.g. `NoMethodError`)
+  # logs the error to the step's stderr, so a latent bug (e.g. `NoMethodError`)
   # surfaces in the "failed!" output on timeout instead of being swallowed.
   def domain_workload_update_confirmed?(domain_name, workload)
     refreshed_domain_data = cp.fetch_domain(domain_name)
     @domain_data = refreshed_domain_data if refreshed_domain_data
     refreshed_domain_data && cp.domain_workload_matches?(refreshed_domain_data, workload)
   rescue StandardError => e
-    Shell.write_to_tmp_stderr("#{e.class}: #{e.message} (#{e.backtrace&.first})\n")
+    # A persistent failure (bad domain name, network outage, a latent bug) repeats
+    # the same error on every poll attempt, so only log when the message changes —
+    # otherwise the timeout output would carry up to MAX_POLL_ATTEMPTS identical
+    # lines. Guard on `tmp_stderr` so this stays safe if ever called outside a
+    # `step` block, where no tmp stderr is set up.
+    message = "#{e.class}: #{e.message} (#{e.backtrace&.first})\n"
+    if message != @last_poll_error
+      Shell.write_to_tmp_stderr(message) if Shell.tmp_stderr
+      @last_poll_error = message
+    end
     false
   end
 

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -145,6 +145,17 @@ describe MaintenanceMode do
                                                 .exactly(MaintenanceMode::DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS).times
       expect(command_calls).to eq([["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"]])
     end
+
+    it "keeps cached domain data when polling never returns a routable domain" do
+      maintenance_mode = described_class.new(command)
+
+      stub_domain_switch(from: "maintenance", to: "web", polls: [nil])
+
+      expect { maintenance_mode.disable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+
+      expect(maintenance_mode.enabled?).to be(true)
+      expect(cp).to have_received(:find_domain_for).once
+    end
   end
 
   def stub_domain_switch(from:, to:, polls: nil)

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -66,6 +66,17 @@ describe MaintenanceMode do
       expect(command_calls).to be_empty
       expect(progress.string).to include("Maintenance mode is already enabled for app 'my-app'.")
     end
+
+    it "keeps cached domain data when polling never returns a routable domain" do
+      maintenance_mode = described_class.new(command)
+
+      stub_domain_switch(from: "web", to: "maintenance", polls: [nil])
+
+      expect { maintenance_mode.enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+
+      expect(maintenance_mode.disabled?).to be(true)
+      expect(cp).to have_received(:find_domain_for).once
+    end
   end
 
   describe "#disable!" do
@@ -89,17 +100,6 @@ describe MaintenanceMode do
       expect(command_calls).to be_empty
       expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")
     end
-  end
-
-  it "keeps cached domain data when polling never returns a routable domain" do
-    maintenance_mode = described_class.new(command)
-
-    stub_domain_switch(from: "web", to: "maintenance", polls: [nil])
-
-    expect { maintenance_mode.enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
-
-    expect(maintenance_mode.disabled?).to be(true)
-    expect(cp).to have_received(:find_domain_for).once
   end
 
   def stub_domain_switch(from:, to:, polls: nil)

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -102,6 +102,28 @@ describe MaintenanceMode do
       expect(command_calls).to eq(expected_workload_commands)
     end
 
+    it "continues polling when the fetched domain temporarily has no routable route" do
+      stub_domain_switch(from: "maintenance", to: "web", polls: [nil, domain_routed_to("web")])
+
+      described_class.new(command).disable!
+
+      expect_domain_update_requested_for("web")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_workload_commands)
+    end
+
+    it "continues polling when a transient API error is raised mid-switch" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("maintenance"))
+      poll_responses = [->(*) { raise "transient API error" }, ->(*) { domain_routed_to("web") }]
+      allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_invoke(*poll_responses)
+
+      described_class.new(command).disable!
+
+      expect_domain_update_requested_for("web")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_workload_commands)
+    end
+
     it "skips work when maintenance mode is already disabled" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
 

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -135,14 +135,16 @@ describe MaintenanceMode do
       expect(command_calls).to eq(expected_workload_commands)
     end
 
-    it "stops app workloads when the route is already on the app workload, completing a timed-out run" do
+    it "stops the maintenance workload when the route is already on the app workload, completing a timed-out run" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
 
       described_class.new(command).disable!
 
-      # The route is already correct, so it is not re-switched, but the app
-      # workloads are stopped idempotently so a run that timed out before
-      # stopping them can recover on re-run.
+      # The route is already correct, so it is not re-switched. The app workloads
+      # were already stopped when maintenance was first enabled; what a timed-out
+      # disable! leaves running is the maintenance workload (started before the
+      # route switch). `ps:stop -a` clears it idempotently so the re-run finishes
+      # the cleanup the timed-out run never reached.
       expect(cp).not_to have_received(:set_domain_workload)
       expect(command_calls).to eq([["ps:stop", "-a", "my-app", "--wait"]])
       expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -77,14 +77,16 @@ describe MaintenanceMode do
       expect(progress.string).to include("NoMethodError: boom")
     end
 
-    it "skips work when maintenance mode is already enabled" do
+    it "stops app workloads when the route is already on maintenance, completing a timed-out run" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("maintenance"))
 
       described_class.new(command).enable!
 
-      expect(cp).not_to have_received(:fetch_workload!)
+      # The route is already correct, so it is not re-switched, but the app
+      # workloads are stopped idempotently so a run that timed out before
+      # stopping them can recover on re-run.
       expect(cp).not_to have_received(:set_domain_workload)
-      expect(command_calls).to be_empty
+      expect(command_calls).to eq([["ps:stop", "-a", "my-app", "--wait"]])
       expect(progress.string).to include("Maintenance mode is already enabled for app 'my-app'.")
     end
 
@@ -133,14 +135,16 @@ describe MaintenanceMode do
       expect(command_calls).to eq(expected_workload_commands)
     end
 
-    it "skips work when maintenance mode is already disabled" do
+    it "stops app workloads when the route is already on the app workload, completing a timed-out run" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
 
       described_class.new(command).disable!
 
-      expect(cp).not_to have_received(:fetch_workload!)
+      # The route is already correct, so it is not re-switched, but the app
+      # workloads are stopped idempotently so a run that timed out before
+      # stopping them can recover on re-run.
       expect(cp).not_to have_received(:set_domain_workload)
-      expect(command_calls).to be_empty
+      expect(command_calls).to eq([["ps:stop", "-a", "my-app", "--wait"]])
       expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")
     end
 

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -68,6 +68,15 @@ describe MaintenanceMode do
       expect(command_calls).to eq([["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"]])
     end
 
+    it "surfaces an unexpected error in the failure output when the poll times out" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
+      allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_raise(NoMethodError.new("boom"))
+
+      expect { described_class.new(command).enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+
+      expect(progress.string).to include("NoMethodError: boom")
+    end
+
     it "skips work when maintenance mode is already enabled" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("maintenance"))
 

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -5,7 +5,13 @@ require "spec_helper"
 describe MaintenanceMode do
   let(:config) { instance_double(Config, app: "my-app", domain: nil, current: { maintenance_workload: "maintenance" }) }
   let(:command) { Command::Base.new(config) }
-  let(:cp) { instance_double(Controlplane) }
+  let(:cp) do
+    Controlplane.allocate.tap do |controlplane|
+      controlplane.instance_variable_set(:@api, instance_double(ControlplaneApi, update_domain: true))
+      controlplane.instance_variable_set(:@gvc, "my-app")
+      controlplane.instance_variable_set(:@org, "my-org")
+    end
+  end
   let(:progress) { StringIO.new }
   let(:command_calls) { [] }
 
@@ -15,10 +21,7 @@ describe MaintenanceMode do
     allow(command).to receive(:run_cpflow_command) { |*args| command_calls << args }
     allow(Kernel).to receive(:sleep).and_return(0)
     allow(cp).to receive(:fetch_workload!)
-    allow(cp).to receive(:set_domain_workload).and_return(true)
-    allow(cp).to receive(:domain_workload_matches?) do |data, workload|
-      domain_routed_to_workload?(data, workload)
-    end
+    allow(cp).to receive(:set_domain_workload).and_call_original
   end
 
   describe "#enable!" do
@@ -29,7 +32,7 @@ describe MaintenanceMode do
 
       expect_domain_update_requested_for("maintenance")
       expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
-      expect(command_calls).to eq(expected_enable_commands)
+      expect(command_calls).to eq(expected_workload_commands)
     end
 
     it "continues polling when the fetched domain temporarily has no routable route" do
@@ -39,7 +42,7 @@ describe MaintenanceMode do
 
       expect_domain_update_requested_for("maintenance")
       expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
-      expect(command_calls).to eq(expected_enable_commands)
+      expect(command_calls).to eq(expected_workload_commands)
     end
 
     it "stops after the bounded retry count when the domain route never updates" do
@@ -48,7 +51,8 @@ describe MaintenanceMode do
       expect { described_class.new(command).enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
 
       expect_domain_update_requested_for("maintenance")
-      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").exactly(31).times
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com")
+                                                .exactly(MaintenanceMode::DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS).times
       expect(command_calls).to eq([["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"]])
     end
 
@@ -72,7 +76,7 @@ describe MaintenanceMode do
 
       expect_domain_update_requested_for("web")
       expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
-      expect(command_calls).to eq(expected_disable_commands)
+      expect(command_calls).to eq(expected_workload_commands)
     end
 
     it "skips work when maintenance mode is already disabled" do
@@ -87,14 +91,12 @@ describe MaintenanceMode do
     end
   end
 
-  it "keeps cached domain data when a poll temporarily returns no routable domain" do
+  it "keeps cached domain data when polling never returns a routable domain" do
     maintenance_mode = described_class.new(command)
 
-    allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
-    allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(nil)
-    allow(command).to receive(:step).and_yield
+    stub_domain_switch(from: "web", to: "maintenance", polls: [nil])
 
-    maintenance_mode.send(:switch_domain_workload, to: "maintenance")
+    expect { maintenance_mode.enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
 
     expect(maintenance_mode.disabled?).to be(true)
     expect(cp).to have_received(:find_domain_for).once
@@ -114,26 +116,11 @@ describe MaintenanceMode do
     end
   end
 
-  def expected_enable_commands
+  def expected_workload_commands
     [
       ["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"],
       ["ps:stop", "-a", "my-app", "--wait"]
     ]
-  end
-
-  def expected_disable_commands
-    [
-      ["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"],
-      ["ps:stop", "-a", "my-app", "--wait"]
-    ]
-  end
-
-  def domain_routed_to_workload?(data, workload)
-    data.dig("spec", "ports").any? do |port|
-      port["routes"].any? do |route|
-        route["prefix"] == "/" && route["workloadLink"].end_with?("/workload/#{workload}")
-      end
-    end
   end
 
   def domain_routed_to(workload)

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe MaintenanceMode do
+  let(:config) { instance_double(Config, app: "my-app", domain: nil, current: { maintenance_workload: "maintenance" }) }
+  let(:command) { Command::Base.new(config) }
+  let(:cp) { instance_double(Controlplane) }
+  let(:command_calls) { [] }
+
+  before do
+    allow(config).to receive(:[]).with(:one_off_workload).and_return("web")
+    allow(command).to receive_messages(cp: cp, progress: StringIO.new)
+    allow(command).to receive(:run_cpflow_command) { |*args| command_calls << args }
+    allow(Kernel).to receive(:sleep).and_return(0)
+    allow(cp).to receive(:fetch_workload!)
+    allow(cp).to receive(:set_domain_workload)
+    allow(cp).to receive(:domain_workload_matches?) do |data, workload|
+      domain_routed_to_workload?(data, workload)
+    end
+  end
+
+  describe "#enable!" do
+    before do
+      stub_domain_switch(from: "web", to: "maintenance")
+    end
+
+    it "waits for the fetched domain route to point at the maintenance workload" do
+      described_class.new(command).enable!
+
+      expect_domain_update_requested_for("maintenance")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_switch_commands)
+    end
+  end
+
+  describe "#disable!" do
+    before do
+      stub_domain_switch(from: "maintenance", to: "web")
+    end
+
+    it "waits for the fetched domain route to point at the app workload" do
+      described_class.new(command).disable!
+
+      expect_domain_update_requested_for("web")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_switch_commands)
+    end
+  end
+
+  def stub_domain_switch(from:, to:)
+    allow(cp).to receive(:find_domain_for).and_return(domain_routed_to(from))
+    allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(
+      domain_routed_to(from),
+      domain_routed_to(to)
+    )
+  end
+
+  def expect_domain_update_requested_for(workload)
+    expect(cp).to have_received(:set_domain_workload).once do |domain_data, requested_workload|
+      expect(domain_data["name"]).to eq("my-app.example.com")
+      expect(requested_workload).to eq(workload)
+    end
+  end
+
+  def expected_switch_commands
+    [
+      ["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"],
+      ["ps:stop", "-a", "my-app", "--wait"]
+    ]
+  end
+
+  def domain_routed_to_workload?(data, workload)
+    data.dig("spec", "ports").any? do |port|
+      port["routes"].any? do |route|
+        route["prefix"] == "/" && route["workloadLink"].end_with?("/workload/#{workload}")
+      end
+    end
+  end
+
+  def domain_routed_to(workload)
+    {
+      "name" => "my-app.example.com",
+      "spec" => { "ports" => [domain_port_routed_to(workload)] }
+    }
+  end
+
+  def domain_port_routed_to(workload)
+    {
+      "number" => 443,
+      "routes" => [
+        {
+          "prefix" => "/",
+          "workloadLink" => "/org/my-org/gvc/my-app/workload/#{workload}"
+        }
+      ]
+    }
+  end
+end

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -6,53 +6,104 @@ describe MaintenanceMode do
   let(:config) { instance_double(Config, app: "my-app", domain: nil, current: { maintenance_workload: "maintenance" }) }
   let(:command) { Command::Base.new(config) }
   let(:cp) { instance_double(Controlplane) }
+  let(:progress) { StringIO.new }
   let(:command_calls) { [] }
 
   before do
     allow(config).to receive(:[]).with(:one_off_workload).and_return("web")
-    allow(command).to receive_messages(cp: cp, progress: StringIO.new)
+    allow(command).to receive_messages(cp: cp, progress: progress)
     allow(command).to receive(:run_cpflow_command) { |*args| command_calls << args }
     allow(Kernel).to receive(:sleep).and_return(0)
     allow(cp).to receive(:fetch_workload!)
-    allow(cp).to receive(:set_domain_workload)
+    allow(cp).to receive(:set_domain_workload).and_return(true)
     allow(cp).to receive(:domain_workload_matches?) do |data, workload|
       domain_routed_to_workload?(data, workload)
     end
   end
 
   describe "#enable!" do
-    before do
-      stub_domain_switch(from: "web", to: "maintenance")
-    end
-
     it "waits for the fetched domain route to point at the maintenance workload" do
+      stub_domain_switch(from: "web", to: "maintenance")
+
       described_class.new(command).enable!
 
       expect_domain_update_requested_for("maintenance")
       expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
-      expect(command_calls).to eq(expected_switch_commands)
+      expect(command_calls).to eq(expected_enable_commands)
+    end
+
+    it "continues polling when the fetched domain temporarily has no routable route" do
+      stub_domain_switch(from: "web", to: "maintenance", polls: [nil, domain_routed_to("maintenance")])
+
+      described_class.new(command).enable!
+
+      expect_domain_update_requested_for("maintenance")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_enable_commands)
+    end
+
+    it "stops after the bounded retry count when the domain route never updates" do
+      stub_domain_switch(from: "web", to: "maintenance", polls: [domain_routed_to("web")])
+
+      expect { described_class.new(command).enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+
+      expect_domain_update_requested_for("maintenance")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").exactly(31).times
+      expect(command_calls).to eq([["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"]])
+    end
+
+    it "skips work when maintenance mode is already enabled" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("maintenance"))
+
+      described_class.new(command).enable!
+
+      expect(cp).not_to have_received(:fetch_workload!)
+      expect(cp).not_to have_received(:set_domain_workload)
+      expect(command_calls).to be_empty
+      expect(progress.string).to include("Maintenance mode is already enabled for app 'my-app'.")
     end
   end
 
   describe "#disable!" do
-    before do
-      stub_domain_switch(from: "maintenance", to: "web")
-    end
-
     it "waits for the fetched domain route to point at the app workload" do
+      stub_domain_switch(from: "maintenance", to: "web")
+
       described_class.new(command).disable!
 
       expect_domain_update_requested_for("web")
       expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
-      expect(command_calls).to eq(expected_switch_commands)
+      expect(command_calls).to eq(expected_disable_commands)
+    end
+
+    it "skips work when maintenance mode is already disabled" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
+
+      described_class.new(command).disable!
+
+      expect(cp).not_to have_received(:fetch_workload!)
+      expect(cp).not_to have_received(:set_domain_workload)
+      expect(command_calls).to be_empty
+      expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")
     end
   end
 
-  def stub_domain_switch(from:, to:)
+  it "keeps cached domain data when a poll temporarily returns no routable domain" do
+    maintenance_mode = described_class.new(command)
+
+    allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
+    allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(nil)
+    allow(command).to receive(:step).and_yield
+
+    maintenance_mode.send(:switch_domain_workload, to: "maintenance")
+
+    expect(maintenance_mode.disabled?).to be(true)
+    expect(cp).to have_received(:find_domain_for).once
+  end
+
+  def stub_domain_switch(from:, to:, polls: nil)
     allow(cp).to receive(:find_domain_for).and_return(domain_routed_to(from))
     allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(
-      domain_routed_to(from),
-      domain_routed_to(to)
+      *(polls || [domain_routed_to(from), domain_routed_to(to)])
     )
   end
 
@@ -63,7 +114,14 @@ describe MaintenanceMode do
     end
   end
 
-  def expected_switch_commands
+  def expected_enable_commands
+    [
+      ["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"],
+      ["ps:stop", "-a", "my-app", "--wait"]
+    ]
+  end
+
+  def expected_disable_commands
     [
       ["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"],
       ["ps:stop", "-a", "my-app", "--wait"]

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -140,13 +140,14 @@ describe MaintenanceMode do
 
       described_class.new(command).disable!
 
-      # The route is already correct, so it is not re-switched. The app workloads
-      # were already stopped when maintenance was first enabled; what a timed-out
-      # disable! leaves running is the maintenance workload (started before the
-      # route switch). `ps:stop -a` clears it idempotently so the re-run finishes
-      # the cleanup the timed-out run never reached.
+      # The route is already correct, so it is not re-switched. A timed-out disable!
+      # leaves the maintenance workload running (it is started before the route
+      # switch), and `ps:stop -a` skips the maintenance workload, so the recovery
+      # stops it explicitly with `-w`. Stopping all workloads here would instead
+      # suspend the app workloads now serving live traffic. The stop is idempotent,
+      # so it is a no-op once the maintenance workload is already stopped.
       expect(cp).not_to have_received(:set_domain_workload)
-      expect(command_calls).to eq([["ps:stop", "-a", "my-app", "--wait"]])
+      expect(command_calls).to eq([["ps:stop", "-a", "my-app", "-w", "maintenance", "--wait"]])
       expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")
     end
 

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -47,7 +47,10 @@ describe MaintenanceMode do
 
     it "continues polling when a transient API error is raised mid-switch" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
-      poll_responses = [->(*) { raise "transient API error" }, ->(*) { domain_routed_to("maintenance") }]
+      # A transient 403/5xx is a non-RuntimeError StandardError, so the in-method
+      # rescue (not the outer `step`, which only rescues RuntimeError) must catch it.
+      error = ControlplaneApiDirect::ForbiddenError.new(url: "/org/my-org", response: "403")
+      poll_responses = [->(*) { raise error }, ->(*) { domain_routed_to("maintenance") }]
       allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_invoke(*poll_responses)
 
       described_class.new(command).enable!
@@ -75,6 +78,33 @@ describe MaintenanceMode do
       expect { described_class.new(command).enable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
 
       expect(progress.string).to include("NoMethodError: boom")
+    end
+
+    it "logs a repeated poll error only once in the timeout output" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
+      allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_raise(NoMethodError.new("boom"))
+
+      expect { described_class.new(command).enable! }.to raise_error(SystemExit)
+
+      # The same error repeats on every poll attempt, but the dedup keeps the
+      # timeout output from carrying one identical line per attempt.
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com")
+                                                .exactly(MaintenanceMode::DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS).times
+      expect(progress.string.scan("NoMethodError: boom").size).to eq(1)
+    end
+
+    it "fetches the configured domain by name instead of searching by workload" do
+      allow(config).to receive(:domain).and_return("my-app.example.com")
+      allow(cp).to receive(:find_domain_for)
+      allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(
+        domain_routed_to("web"), domain_routed_to("maintenance")
+      )
+
+      described_class.new(command).enable!
+
+      expect(cp).not_to have_received(:find_domain_for)
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_workload_commands)
     end
 
     it "stops app workloads when the route is already on maintenance, completing a timed-out run" do
@@ -125,7 +155,10 @@ describe MaintenanceMode do
 
     it "continues polling when a transient API error is raised mid-switch" do
       allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("maintenance"))
-      poll_responses = [->(*) { raise "transient API error" }, ->(*) { domain_routed_to("web") }]
+      # A transient 403/5xx is a non-RuntimeError StandardError, so the in-method
+      # rescue (not the outer `step`, which only rescues RuntimeError) must catch it.
+      error = ControlplaneApiDirect::ForbiddenError.new(url: "/org/my-org", response: "403")
+      poll_responses = [->(*) { raise error }, ->(*) { domain_routed_to("web") }]
       allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_invoke(*poll_responses)
 
       described_class.new(command).disable!

--- a/spec/core/maintenance_mode_spec.rb
+++ b/spec/core/maintenance_mode_spec.rb
@@ -45,6 +45,18 @@ describe MaintenanceMode do
       expect(command_calls).to eq(expected_workload_commands)
     end
 
+    it "continues polling when a transient API error is raised mid-switch" do
+      allow(cp).to receive(:find_domain_for).and_return(domain_routed_to("web"))
+      poll_responses = [->(*) { raise "transient API error" }, ->(*) { domain_routed_to("maintenance") }]
+      allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_invoke(*poll_responses)
+
+      described_class.new(command).enable!
+
+      expect_domain_update_requested_for("maintenance")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com").twice
+      expect(command_calls).to eq(expected_workload_commands)
+    end
+
     it "stops after the bounded retry count when the domain route never updates" do
       stub_domain_switch(from: "web", to: "maintenance", polls: [domain_routed_to("web")])
 
@@ -100,10 +112,25 @@ describe MaintenanceMode do
       expect(command_calls).to be_empty
       expect(progress.string).to include("Maintenance mode is already disabled for app 'my-app'.")
     end
+
+    it "stops after the bounded retry count when the domain route never updates" do
+      stub_domain_switch(from: "maintenance", to: "web", polls: [domain_routed_to("maintenance")])
+
+      expect { described_class.new(command).disable! }.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+
+      expect_domain_update_requested_for("web")
+      expect(cp).to have_received(:fetch_domain).with("my-app.example.com")
+                                                .exactly(MaintenanceMode::DOMAIN_WORKLOAD_UPDATE_MAX_POLL_ATTEMPTS).times
+      expect(command_calls).to eq([["ps:start", "-a", "my-app", "-w", "maintenance", "--wait"]])
+    end
   end
 
   def stub_domain_switch(from:, to:, polls: nil)
     allow(cp).to receive(:find_domain_for).and_return(domain_routed_to(from))
+    # Default polls: the first fetch still sees the old route (simulates one
+    # in-flight propagation delay) and the second sees the new route. RSpec
+    # repeats the final value on any further calls, so this also covers polls
+    # that exhaust the retry budget on a single repeated value.
     allow(cp).to receive(:fetch_domain).with("my-app.example.com").and_return(
       *(polls || [domain_routed_to(from), domain_routed_to(to)])
     )

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
 
     let(:job) { workflow.fetch("jobs").fetch("rspec") }
 
-    it "prevents unrelated PRs from canceling each other in the CI Control Plane org queue" do
+    it "scopes the Control Plane org queue per PR (or ref) and never cancels queued runs" do
+      # The group keys on PR number (or ref for non-PR events), so a PR's own runs
+      # serialize against each other but unrelated PRs don't share one blocking
+      # queue. cancel-in-progress is false, so queued runs wait rather than cancel.
       expected_group =
         "cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}-" \
         "${{ github.event.pull_request.number || github.ref }}"

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -14,9 +14,13 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
 
     let(:job) { workflow.fetch("jobs").fetch("rspec") }
 
-    it "queues jobs that share the CI Control Plane org" do
+    it "prevents unrelated PRs from canceling each other in the CI Control Plane org queue" do
+      expected_group =
+        "cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}-" \
+        "${{ github.event.pull_request.number || github.ref }}"
+
       expect(job.fetch("concurrency")).to eq(
-        "group" => "cpln-shared-org-${{ vars.CPLN_ORG || github.run_id }}",
+        "group" => expected_group,
         "cancel-in-progress" => false
       )
     end


### PR DESCRIPTION
Fixes #157.

Replaces the fixed 30-second sleep after maintenance domain updates with a bounded retry that refetches the domain and confirms the route points at the target workload before continuing.

Adds focused specs for maintenance enable and disable flows so both directions verify the route update behavior.

Validated with `CPLN_ORG=my-org bundle exec rspec spec/command/base_spec.rb spec/core/maintenance_mode_spec.rb` and `bundle exec rubocop lib/core/maintenance_mode.rb spec/core/maintenance_mode_spec.rb`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live traffic routing and workload stop ordering for maintenance commands; behavior is safer on timeout but operators should know about polling limits and re-run semantics.
> 
> **Overview**
> **`cpflow maintenance:on` and `maintenance:off`** no longer wait a fixed 30 seconds after requesting a domain route change. They **poll the Control Plane API** (up to 30 attempts, 1 second apart) until the `/` route actually points at the target workload, then proceed to stop workloads. If the route never updates in that window, the command **fails before stopping workloads** so traffic is not cut over prematurely; transient fetch errors are retried during polling.
> 
> **Re-run behavior** is documented and implemented: when maintenance is already on/off but a prior run timed out after the switch, a repeat run **finishes the missing stop** (app workloads after `on`, maintenance workload only after `off`) without re-switching the domain.
> 
> **CI**: shared RSpec workflow concurrency is keyed by **PR number or ref** (not only org), so unrelated PRs are less likely to block each other while same-PR runs still serialize.
> 
> Changelog, command help, and new **`MaintenanceMode` specs** cover polling, timeouts, error deduplication, and recovery paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba52804db9102497c642134abf88f5232604191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintenance mode now verifies domain route switching by polling the control API with bounded retries instead of a fixed delay.

* **Bug Fixes**
  * Prevents workloads from remaining running after timed-out route switches and treats transient polling errors as retryable.

* **Tests**
  * New specs cover enable/disable flows, polling outcomes, retry bounds, idempotent/no-op cases, and error visibility.

* **Chores**
  * CI concurrency updated to avoid unrelated PR cancellations.

* **Documentation**
  * Changelog and command help updated to document polling, retry behavior, and safe re-run semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->