### PR TITLE
Fix cpflow CLI boot load order

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -544,7 +544,7 @@ cpflow terraform import
 Regenerates the generated cpflow GitHub Actions wrappers and helper files
 from the currently installed cpflow gem. Use this after updating the
 cpflow gem so checked-in workflow wrappers move to the matching upstream
-release tag, for example `v5.0.2`.
+release tag, for example `v5.0.3`.
 
 If the existing generated staging workflow uses a custom single staging
 branch, the command preserves it. Pass `--staging-branch BRANCH` to set or

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -13,6 +13,7 @@ require "tempfile"
 require "thor"
 require "yaml"
 
+# Load version before command files because command constants interpolate Cpflow::VERSION at load time.
 require_relative "cpflow/version"
 require_relative "constants/exit_code"
 

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -13,6 +13,7 @@ require "tempfile"
 require "thor"
 require "yaml"
 
+require_relative "cpflow/version"
 require_relative "constants/exit_code"
 
 # We need to require base before all commands, since the commands inherit from it

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -29,8 +29,12 @@ describe Cpflow do
       puts Cpflow::VERSION
     RUBY
 
+    child_env = ENV.each_key.grep(/\ABUNDLE/).to_h { |key| [key, nil] }
+    child_env["RUBYLIB"] = nil
+    child_env["RUBYOPT"] = nil
+
     stdout, stderr, status = Open3.capture3(
-      { "RUBYOPT" => nil },
+      child_env,
       RbConfig.ruby,
       "-I",
       File.expand_path("../lib", __dir__),

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -27,6 +27,7 @@ describe Cpflow do
 
       require "cpflow"
       puts Cpflow::VERSION
+      puts Command::UpdateGithubActions::LONG_DESCRIPTION.length
     RUBY
 
     child_env = ENV.each_key.grep(/\ABUNDLE/).to_h { |key| [key, nil] }
@@ -43,7 +44,9 @@ describe Cpflow do
     )
 
     expect(status).to be_success, stderr
-    expect(stdout).to include(Cpflow::VERSION)
+    stdout_lines = stdout.lines.map(&:chomp)
+    expect(stdout_lines).to include(Cpflow::VERSION)
+    expect(stdout_lines.last.to_i).to be_positive
   end
 
   non_boolean_options_by_key_name.each do |option_key_name, option|

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -46,7 +46,7 @@ describe Cpflow do
     expect(status).to be_success, stderr
     stdout_lines = stdout.lines.map(&:chomp)
     expect(stdout_lines).to include(Cpflow::VERSION)
-    expect(stdout_lines.last.to_i).to be_positive
+    expect(Integer(stdout_lines.fetch(1))).to be_positive
   end
 
   non_boolean_options_by_key_name.each do |option_key_name, option|


### PR DESCRIPTION
## Summary

- Load `cpflow/version` before command files so command constants can safely interpolate `Cpflow::VERSION` during CLI boot.
- Harden the runtime-load regression spec to clear Bundler env leakage and directly verify `Command::UpdateGithubActions::LONG_DESCRIPTION` resolves after `require "cpflow"`.
- Regenerate command docs so the `update-github-actions` example uses the current `v5.0.3` release tag.

Fixes #335.

## Review Notes

- Addressed both unresolved optional Claude review threads.
- No must-fix review threads were present.
- CodeRabbit skipped review because the PR is still draft.

## Validation

- `bundle exec rake check_command_docs`
- `CPLN_ORG=dummy bundle exec rspec spec/cpflow_spec.rb spec/command/generate_github_actions_spec.rb`
- `bundle exec rubocop lib/cpflow.rb spec/cpflow_spec.rb`
- `ruby -Ilib -e 'require "cpflow"; puts Cpflow::VERSION; puts Command::UpdateGithubActions::LONG_DESCRIPTION.length'`
- `bundle exec cpflow --version`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boot-order and test/doc-only changes with no runtime behavior change beyond fixing a load-time constant resolution bug.
> 
> **Overview**
> **CLI boot order** now loads `cpflow/version` before the bulk require of command modules, so constants like `Command::UpdateGithubActions::LONG_DESCRIPTION` that embed `Cpflow::VERSION` at load time no longer fail during `require "cpflow"`.
> 
> The **runtime-load spec** clears Bundler/`RUBYLIB`/`RUBYOPT` in the child process and asserts `UpdateGithubActions::LONG_DESCRIPTION` resolves to a non-empty string after boot.
> 
> **Generated docs** refresh the `update-github-actions` example release tag from `v5.0.2` to **`v5.0.3`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f4ea71c78f6b4a12ac69840a65711585de9b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version reference in command documentation example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->