### PR TITLE
Add PR 338 boot-order fix to Unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+## [5.0.4] - 2026-05-27
+
 ### Fixed
 
 - **Fixed `cpflow` CLI boot order so packaged gems load `cpflow/version` before command modules, preventing a load-time `NameError` on `Cpflow::VERSION` from constants like `Command::UpdateGithubActions::LONG_DESCRIPTION`.** [PR 338](https://github.com/shakacode/control-plane-flow/pull/338) by [Justin Gordon](https://github.com/justin808). Fixes [issue 335](https://github.com/shakacode/control-plane-flow/issues/335).
@@ -396,7 +398,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.3...HEAD
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.0.4...HEAD
+[5.0.4]: https://github.com/shakacode/control-plane-flow/compare/v5.0.3...v5.0.4
 [5.0.3]: https://github.com/shakacode/control-plane-flow/compare/v5.0.2...v5.0.3
 [5.0.2]: https://github.com/shakacode/control-plane-flow/compare/v5.0.1...v5.0.2
 [5.0.1]: https://github.com/shakacode/control-plane-flow/compare/v5.0.0...v5.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed `cpflow` CLI boot order so packaged gems load `cpflow/version` before command modules, preventing a load-time `NameError` on `Cpflow::VERSION` from constants like `Command::UpdateGithubActions::LONG_DESCRIPTION`.** [PR 338](https://github.com/shakacode/control-plane-flow/pull/338) by [Justin Gordon](https://github.com/justin808). Fixes [issue 335](https://github.com/shakacode/control-plane-flow/issues/335).
+
 ## [5.0.3] - 2026-05-26
 
 ### Changed

--- a/lib/cpflow/version.rb
+++ b/lib/cpflow/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Cpflow
-  VERSION = "5.0.3"
+  VERSION = "5.0.4"
   MIN_CPLN_VERSION = "3.1.0"
 end

--- a/lib/cpflow/version.rb
+++ b/lib/cpflow/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Cpflow
-  VERSION = "5.0.4"
+  VERSION = "5.0.3"
   MIN_CPLN_VERSION = "3.1.0"
 end


### PR DESCRIPTION
## Summary

PR #338 (CLI boot load order fix) was merged after the 5.0.3 changelog section was stamped, so it was missing from the changelog. This adds it under `[Unreleased]` so it gets documented in whichever release ships next.

Skipped CI-only PRs from the same window: #329 (RSpec/Rubocop docs-only path filter), #330 (docs-site dispatch action bumps), #333 (the previous changelog PR itself).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and version link updates with no application or release tooling behavior changes in the diff.
> 
> **Overview**
> Documents the merged **PR 338** CLI boot-order fix in **CHANGELOG** under **`[5.0.4] - 2026-05-27`**, in **### Fixed**, describing that packaged gems now load `cpflow/version` before command modules to avoid a load-time `NameError` on `Cpflow::VERSION` (issue 335).
> 
> Updates release compare links so **`[Unreleased]`** compares **`v5.0.4...HEAD`** and adds **`[5.0.4]`** as **`v5.0.3...v5.0.4`**. No runtime or gem code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10f858539c1740be6e1feba24b68122b49dc20c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->