### PR TITLE
docs: share one database across review apps

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -12,6 +12,7 @@
    - [Setting Up a Liveness Probe](#setting-up-a-liveness-probe)
 8. [Minimizing Review App Costs](#minimizing-review-app-costs)
    - [Scale the Web Workload to Zero](#scale-the-web-workload-to-zero)
+   - [Share One Database Across Review Apps](#share-one-database-across-review-apps)
    - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
    - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
 9. [Useful Links](#useful-links)
@@ -191,6 +192,68 @@ usually isn't.
 > **Note:** if you later suspend the app with `cpflow ps:stop`, Control Plane will not auto-wake it on the next
 > request. Run `cpflow ps:start` explicitly first. See
 > [Pause and Resume](#pause-and-resume-with-psstop--psstart).
+
+### Share One Database Across Review Apps
+
+Scaling the web tier to zero only addresses the web workload. By default each review app also provisions its own
+`postgres` workload (it ships in `setup_app_templates` and `additional_workloads`), and that workload runs at
+`type: standard`, `minScale: 1` — always on, even while the web tier sleeps. Across many long-tail PRs, those per-app
+databases are usually the dominant cost.
+
+Instead, you can run a single long-lived Postgres instance and give each review app its own logical database on it.
+`cpflow`'s template interpolation makes the isolation automatic. The default `templates/app.yml` sets:
+
+```yaml
+- name: DATABASE_URL
+  value: postgres://postgres:password123@postgres.{{APP_NAME}}.cpln.local:5432/{{APP_NAME}}
+```
+
+`{{APP_NAME}}` expands to the concrete app name (for example `my-app-review-123`), so the host points at a per-app
+Postgres workload and the database is named after the app. To share, change only the **host** and keep the
+**database name** templated.
+
+1. Provision one shared Postgres app once, as a normal long-lived app in your staging org (for example
+   `my-app-shared-db`), created from the standard `postgres` template. Because it is not a review app, it is never
+   removed by `cleanup-stale-apps`.
+
+2. Create a review-only app template (for example `.controlplane/templates/app-review.yml`) identical to `app.yml`
+   except the `DATABASE_URL` host points at the shared instance while the database name stays `{{APP_NAME}}`:
+
+   ```yaml
+   - name: DATABASE_URL
+     value: postgres://USER:PASSWORD@postgres.my-app-shared-db.cpln.local:5432/{{APP_NAME}}
+   ```
+
+3. Point the review-app entry at that template and drop the per-PR `postgres` workload:
+
+   ```yaml
+   my-app-review:
+     match_if_app_name_starts_with: true
+     setup_app_templates:
+       - app-review   # was: app
+       - rails        # `postgres` removed — no per-PR database workload is created
+     additional_workloads: []   # was: [postgres]
+     hooks:
+       post_creation: bundle exec rails db:prepare   # creates database `my-app-review-123` on the shared server
+       pre_deletion: bundle exec rails db:drop       # drops only that app's database
+   ```
+
+The hooks are what make this safe. Because the database name is still unique per app (`{{APP_NAME}}`), the
+`post_creation` hook creates a fresh database for each PR on the shared server, and the `pre_deletion` hook's
+`rails db:drop` removes only that PR's database — the shared server and every other review app's data are left intact.
+
+A few things to keep in mind:
+
+- **Keep the database name unique per app.** The `{{APP_NAME}}` segment is load-bearing. If you hardcode a single
+  shared database name instead, the `pre_deletion` `rails db:drop` hook will drop the database out from under every
+  other review app.
+- **Noisy neighbor.** All review apps now share one server's CPU, RAM, disk, and connection pool. A runaway query or
+  `max_connections` exhaustion in one PR affects the others; PgBouncer and a per-app connection cap mitigate this.
+- **The shared server is yours to operate.** Provisioning, backups, and access control become your responsibility, and
+  that instance is the always-on cost you are consolidating rather than eliminating.
+- The same pattern extends to Redis and Memcached — `app.yml` templates their URLs with `{{APP_NAME}}` too, so a
+  review-only template can point them at shared instances (use a per-app key prefix or Redis logical-database index to
+  keep PRs isolated). Postgres is usually where the savings concentrate.
 
 ### Delete or Pause Abandoned Apps with `cleanup-stale-apps`
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -205,7 +205,7 @@ Instead, you can run a single long-lived Postgres instance and give each review 
 
 ```yaml
 - name: DATABASE_URL
-  value: postgres://postgres:password123@postgres.{{APP_NAME}}.cpln.local:5432/{{APP_NAME}}
+  value: postgres://the_user:the_password@postgres.{{APP_NAME}}.cpln.local:5432/{{APP_NAME}}
 ```
 
 `{{APP_NAME}}` expands to the concrete app name (for example `my-app-review-123`), so the host points at a per-app
@@ -216,6 +216,21 @@ Postgres workload and the database is named after the app. To share, change only
    `my-app-shared-db`), created from the standard `postgres` template. Because it is not a review app, it is never
    removed by `cleanup-stale-apps`.
 
+   Then open its firewall for cross-GVC access. The standard `postgres` template restricts inbound traffic to the
+   same GVC (`firewallConfig.internal.inboundAllowType: same-gvc`), and every `cpflow` app — including each review
+   app — is its own GVC. Left at the default, review-app workloads cannot reach the shared database. Relax the
+   shared Postgres workload's firewall to accept the other GVCs in your org:
+
+   ```yaml
+   firewallConfig:
+     internal:
+       inboundAllowType: same-org   # was: same-gvc — lets review-app GVCs reach the shared database
+   ```
+
+   Use `workload-list` with `inboundAllowWorkload` instead if you prefer to allow only specific workloads. Because
+   both `.cpln.local` resolution and `same-org` access are scoped to a single org, the shared database and every
+   review app must live in the **same CPLN org**.
+
 2. Create a review-only app template (for example `.controlplane/templates/app-review.yml`) identical to `app.yml`
    except the `DATABASE_URL` host points at the shared instance while the database name stays `{{APP_NAME}}`:
 
@@ -223,6 +238,10 @@ Postgres workload and the database is named after the app. To share, change only
    - name: DATABASE_URL
      value: postgres://USER:PASSWORD@postgres.my-app-shared-db.cpln.local:5432/{{APP_NAME}}
    ```
+
+   `USER:PASSWORD` are placeholders. This template is normally committed to version control, so don't hardcode real
+   credentials in it — point the whole value at a CPLN secret (`value: cpln://secret/my-app-shared-db-url`, the
+   pattern the standard `postgres` template already uses for its own credentials) or inject it at deploy time.
 
 3. Point the review-app entry at that template and drop the per-PR `postgres` workload:
 
@@ -235,12 +254,15 @@ Postgres workload and the database is named after the app. To share, change only
      additional_workloads: []   # was: [postgres]
      hooks:
        post_creation: bundle exec rails db:prepare   # creates database `my-app-review-123` on the shared server
-       pre_deletion: bundle exec rails db:drop       # drops only that app's database
+       pre_deletion: DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rails db:drop   # drops only that app's database
    ```
 
 The hooks are what make this safe. Because the database name is still unique per app (`{{APP_NAME}}`), the
 `post_creation` hook creates a fresh database for each PR on the shared server, and the `pre_deletion` hook's
 `rails db:drop` removes only that PR's database — the shared server and every other review app's data are left intact.
+Review apps inherit `RAILS_ENV=production` from `app.yml`, and Rails refuses to drop a database in a non-development
+environment unless `DISABLE_DATABASE_ENVIRONMENT_CHECK=1` is set. Without it the `pre_deletion` hook exits non-zero and
+`cpflow delete` stops before removing the GVC, leaving the per-PR database behind on the shared server.
 
 A few things to keep in mind:
 


### PR DESCRIPTION
## Summary

Follow-up to #298 (review-app cost docs). Adds a **Share One Database Across Review Apps** subsection to the
*Minimizing Review App Costs* section of `docs/tips.md`.

`#298` covered scaling the **web** tier to zero, but each review app still provisions its own `postgres` workload
by default, and that workload runs at `type: standard`, `minScale: 1` — always on, even while the web tier sleeps.
For long-tail review apps, those per-app databases are usually the dominant cost. This subsection documents the
single biggest remaining lever:

- Run **one long-lived Postgres instance** and give each review app its own logical database on it.
- Relax the shared Postgres firewall from `same-gvc` to `same-org` (or `workload-list`) so review-app GVCs can
  reach it — each `cpflow` app is its own GVC, so the default `same-gvc` rule would otherwise block them, and both
  `.cpln.local` resolution and `same-org` access require everything to live in one CPLN org.
- `cpflow`'s `{{APP_NAME}}` template interpolation provides per-PR isolation automatically — point a review-only
  app template's `DATABASE_URL` **host** at the shared server while keeping the **database name** templated.
- Drop `postgres` from the review entry's `setup_app_templates` / `additional_workloads`, and use
  `post_creation: rails db:prepare` / `pre_deletion: DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop` hooks so
  each PR creates and tears down only its own database. The env override is required because review apps inherit
  `RAILS_ENV=production`, where Rails otherwise refuses to drop the database and halts `cpflow delete`.

It also documents the caveats reviewers will (rightly) look for: the database name must stay unique per app or
`db:drop` wipes shared data; not committing real credentials in the review template (point `DATABASE_URL` at a CPLN
secret); the noisy-neighbor tradeoff; operational ownership of the shared server; and that the same pattern extends
to Redis/Memcached.

Grounded in the actual code paths: default `templates/app.yml` (`DATABASE_URL` uses `{{APP_NAME}}`, `RAILS_ENV=production`),
the standard `postgres` template firewall (`firewallConfig.internal.inboundAllowType: same-gvc`), per-app
`setup_app_templates` override (`lib/command/setup_app.rb:29`), and the documented hooks.

Docs-only. No code, config, or runtime behavior changes.

## Test plan

- [ ] Render `docs/tips.md` on GitHub and confirm the new subsection renders, the TOC anchor
      `#share-one-database-across-review-apps` resolves, and the nested YAML code blocks display correctly.
- [ ] Confirm the numbered-list-with-fenced-code-blocks renders without breaking the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
