### PR TITLE
Fix stale CPFLOW_VERSION example in generated cpflow help (#341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed `cpflow generate-github-actions` so the generated `.github/cpflow-help.md` version-locking example uses a `CPFLOW_VERSION=5.0.x` placeholder instead of a hardcoded release that goes stale against the `@v<version>` wrapper refs in the same file.** [PR 343](https://github.com/shakacode/control-plane-flow/pull/343) by [Justin Gordon](https://github.com/justin808). Fixes [issue 341](https://github.com/shakacode/control-plane-flow/issues/341).
+- **Fixed `cpflow generate-github-actions` so the generated `.github/cpflow-help.md` version-locking example derives a `CPFLOW_VERSION=<major>.<minor>.x` placeholder from the installed gem version instead of a hardcoded release that goes stale against the `@v<version>` wrapper refs in the same file.** [PR 343](https://github.com/shakacode/control-plane-flow/pull/343) by [Justin Gordon](https://github.com/justin808). Fixes [issue 341](https://github.com/shakacode/control-plane-flow/issues/341).
 
 ## [5.0.4] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed `cpflow generate-github-actions` so the generated `.github/cpflow-help.md` version-locking example uses a `CPFLOW_VERSION=5.0.x` placeholder instead of a hardcoded release that goes stale against the `@v<version>` wrapper refs in the same file.** [PR 343](https://github.com/shakacode/control-plane-flow/pull/343) by [Justin Gordon](https://github.com/justin808). Fixes [issue 341](https://github.com/shakacode/control-plane-flow/issues/341).
+
 ## [5.0.4] - 2026-05-27
 
 ### Fixed

--- a/lib/command/generate_github_actions.rb
+++ b/lib/command/generate_github_actions.rb
@@ -80,12 +80,9 @@ module Command
       "v#{::Cpflow::VERSION}"
     end
 
-    # The illustrative version-locking example in cpflow-help.md tracks the installed
-    # gem's minor series (e.g. "5.0.x") so it never drifts into a stale concrete
-    # release the way a hardcoded number does (see issue #341).
+    # Returns e.g. "5.0.x" for the version-locking example in cpflow-help.md (issue #341).
     def cpflow_minor_series
-      major, minor = ::Cpflow::VERSION.split(".")
-      "#{major}.#{minor}.x"
+      "#{::Cpflow::VERSION.split('.').first(2).join('.')}.x"
     end
   end
 

--- a/lib/command/generate_github_actions.rb
+++ b/lib/command/generate_github_actions.rb
@@ -42,6 +42,7 @@ module Command
     def template_variables
       {
         "__CPFLOW_GITHUB_ACTIONS_REF__" => cpflow_github_actions_ref,
+        "__CPFLOW_MINOR_SERIES__" => cpflow_minor_series,
         "__STAGING_BRANCH_FILTER__" => staging_branch_filter,
         "__STAGING_BRANCH_DEFAULT__" => staging_branch_default
       }
@@ -77,6 +78,14 @@ module Command
 
     def default_cpflow_github_actions_ref
       "v#{::Cpflow::VERSION}"
+    end
+
+    # The illustrative version-locking example in cpflow-help.md tracks the installed
+    # gem's minor series (e.g. "5.0.x") so it never drifts into a stale concrete
+    # release the way a hardcoded number does (see issue #341).
+    def cpflow_minor_series
+      major, minor = ::Cpflow::VERSION.split(".")
+      "#{major}.#{minor}.x"
     end
   end
 

--- a/lib/command/generate_github_actions.rb
+++ b/lib/command/generate_github_actions.rb
@@ -80,7 +80,7 @@ module Command
       "v#{::Cpflow::VERSION}"
     end
 
-    # Returns e.g. "5.0.x" for the version-locking example in cpflow-help.md (issue #341).
+    # Returns e.g. "5.0.x" for the version-locking placeholder in cpflow-help.md.
     def cpflow_minor_series
       "#{::Cpflow::VERSION.split('.').first(2).join('.')}.x"
     end

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -85,8 +85,9 @@ the same ref, regenerate them with a newer `cpflow`.
 
 Leave `CPFLOW_VERSION` unset so the workflow builds cpflow from the same
 checked-out upstream source. If you set `CPFLOW_VERSION`, it must match the
-release tag, for example `CPFLOW_VERSION=5.0.1` with a wrapper pinned to
-`uses: ...@v5.0.1`.
+release tag your wrappers are pinned to: a `CPFLOW_VERSION=5.0.x` runtime
+override goes with a wrapper pinned to `uses: ...@v5.0.x` (substitute the
+release you pinned above).
 
 After updating the `cpflow` gem in this repo, update the generated wrappers in
 the same PR:

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -85,8 +85,8 @@ the same ref, regenerate them with a newer `cpflow`.
 
 Leave `CPFLOW_VERSION` unset so the workflow builds cpflow from the same
 checked-out upstream source. If you set `CPFLOW_VERSION`, it must match the
-release tag your wrappers are pinned to: a `CPFLOW_VERSION=5.0.x` runtime
-override goes with a wrapper pinned to `uses: ...@v5.0.x` (substitute the
+release tag your wrappers are pinned to: a `CPFLOW_VERSION=__CPFLOW_MINOR_SERIES__` runtime
+override goes with a wrapper pinned to `uses: ...@v__CPFLOW_MINOR_SERIES__` (substitute the
 release you pinned above).
 
 After updating the `cpflow` gem in this repo, update the generated wrappers in

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -865,6 +865,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
         template = template_root.join(relative_path).read
         expected = template
                    .gsub("__CPFLOW_GITHUB_ACTIONS_REF__", "v#{Cpflow::VERSION}")
+                   .gsub("__CPFLOW_MINOR_SERIES__", "#{Cpflow::VERSION.split('.').first(2).join('.')}.x")
                    .gsub("__STAGING_BRANCH_FILTER__", %("main", "master"))
                    .gsub("__STAGING_BRANCH_DEFAULT__", "")
         actual = playground.join(relative_path).read

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -863,6 +863,8 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
       relative_paths.each do |relative_path|
         template = template_root.join(relative_path).read
+        # Re-derive __CPFLOW_MINOR_SERIES__ here rather than calling cpflow_minor_series,
+        # so this snapshot guard stays independent of the code under test.
         expected = template
                    .gsub("__CPFLOW_GITHUB_ACTIONS_REF__", "v#{Cpflow::VERSION}")
                    .gsub("__CPFLOW_MINOR_SERIES__", "#{Cpflow::VERSION.split('.').first(2).join('.')}.x")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -692,6 +692,17 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("DOCKER_BUILD_SSH_KNOWN_HOSTS")
     end
 
+    # Issue #341: the version-locking example must not emit a concrete release number.
+    # A literal version (e.g. 5.0.1) goes stale against the @v#{VERSION} wrapper refs in
+    # the same generated file and reads like a required old runtime override.
+    it "uses a placeholder version in the CPFLOW_VERSION example" do
+      help_md = playground.join(".github/cpflow-help.md").read
+
+      expect(help_md).to include("CPFLOW_VERSION=5.0.x")
+      expect(help_md).to include("uses: ...@v5.0.x")
+      expect(help_md).not_to match(/CPFLOW_VERSION=\d+\.\d+\.\d+/)
+    end
+
     it "documents the review-app deploying icon override in the help markdown" do
       help_md = playground.join(".github/cpflow-help.md").read
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -698,8 +698,8 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
     it "uses a placeholder version in the CPFLOW_VERSION example" do
       help_md = playground.join(".github/cpflow-help.md").read
 
-      expect(help_md).to include("CPFLOW_VERSION=5.0.x")
-      expect(help_md).to include("uses: ...@v5.0.x")
+      expect(help_md).to match(/CPFLOW_VERSION=\d+\.\d+\.x\b/)
+      expect(help_md).to match(/uses: \.\.\.@v\d+\.\d+\.x\b/)
       expect(help_md).not_to match(/CPFLOW_VERSION=\d+\.\d+\.\d+/)
     end
 


### PR DESCRIPTION
## Summary

The generated `.github/cpflow-help.md` "Version Locking" section hardcoded a stale example:

```md
CPFLOW_VERSION=5.0.1
uses: ...@v5.0.1
```

The rest of that generated doc is release-specific — the upstream guide link and the wrapper `uses:` refs render at the installed `@v<version>` (via the `__CPFLOW_GITHUB_ACTIONS_REF__` substitution, currently `v5.0.4`). Seeing `5.0.1` in the same file made it look like downstream maintainers needed to set an old runtime override.

## Change

The example now **derives a `CPFLOW_VERSION=<major>.<minor>.x` placeholder from the installed gem version** instead of hardcoding a release. A new `__CPFLOW_MINOR_SERIES__` substitution token (computed from `Cpflow::VERSION` → e.g. `5.0.x`) is added to `template_variables`, reusing the same machinery as `__CPFLOW_GITHUB_ACTIONS_REF__`. The example reads as "substitute the release you pinned," tracks the installed gem's minor series automatically, and never drifts into a stale concrete release at any granularity (minor or major).

Tests:
- A regression spec asserts the example keeps an `x`-placeholder *shape* (`/CPFLOW_VERSION=\d+\.\d+\.x\b/`) and never reintroduces a concrete `CPFLOW_VERSION=<x.y.z>`.
- The existing snapshot-guard spec (generated output must equal template + documented substitutions) is extended with the new token, keeping generation byte-exact.

Review history: this started as a static `5.0.x` placeholder; per review feedback it was upgraded to the version-derived token (Option A) so the example can never go stale, and the positive assertions were loosened from a literal match to the placeholder shape.

## Testing

- `CPLN_ORG=dummy-test-org bundle exec rspec spec/command/generate_github_actions_spec.rb` → 64 examples, 0 failures
- `./script/update_command_docs` → no diff (Command Docs unaffected)
- `bundle exec rubocop lib/command/generate_github_actions.rb spec/command/generate_github_actions_spec.rb` → no offenses

Fixes #341. (Issue #340 is a duplicate of #341 and is also addressed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * generate-github-actions output now uses a minor-series placeholder (e.g., 5.0.x) instead of a hardcoded release in the version-locking example.

* **Documentation**
  * Clarified guidance so the runtime override and the reusable workflow pin use the same minor-series placeholder.

* **Tests**
  * Added tests to validate the generated documentation uses the placeholder format for version references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generator substitution only; no runtime workflow or CLI behavior changes beyond regenerated help text.
> 
> **Overview**
> **`cpflow generate-github-actions`** now substitutes a new **`__CPFLOW_MINOR_SERIES__`** token (e.g. `5.0.x` from `Cpflow::VERSION`) into generated **`.github/cpflow-help.md`**, replacing a hardcoded **`CPFLOW_VERSION=5.0.1`** / **`@v5.0.1`** example that could drift from the **`@v<version>`** wrapper refs in the same doc.
> 
> The Version Locking section text is updated so the runtime override and wrapper pin are described as matching minor-series placeholders, with a note to substitute the release you actually pinned.
> 
> Specs add a regression for placeholder-shaped examples (no concrete **`x.y.z`**) and extend the template snapshot guard for the new substitution. **CHANGELOG** records the fix for #341.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9a0804742dc1e4f05bffe5d177f72ceae75306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->