### PR TITLE
Regenerate docs/commands.md for cpflow 5.0.4

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -544,7 +544,7 @@ cpflow terraform import
 Regenerates the generated cpflow GitHub Actions wrappers and helper files
 from the currently installed cpflow gem. Use this after updating the
 cpflow gem so checked-in workflow wrappers move to the matching upstream
-release tag, for example `v5.0.3`.
+release tag, for example `v5.0.4`.
 
 If the existing generated staging workflow uses a custom single staging
 branch, the command preserves it. Pass `--staging-branch BRANCH` to set or


### PR DESCRIPTION
## Summary

`docs/commands.md` is checked in and validated by the **Command Docs** CI check (`rake check_command_docs`), which regenerates it and fails if the working tree differs.

The `update-github-actions` command's `LONG_DESCRIPTION` interpolates `Cpflow::VERSION`:

> ...so checked-in workflow wrappers move to the matching upstream release tag, for example `v5.0.4`.

The `5.0.4` version bump ([de7e9d8](https://github.com/shakacode/control-plane-flow/commit/de7e9d8)) bumped `VERSION` but did not regenerate `docs/commands.md`, so the snapshot still says `v5.0.3`. That makes Command Docs fail on **every open PR** (e.g. #342, #343), unrelated to those PRs' own changes.

## Change

Regenerate the snapshot via `script/update_command_docs`:

```diff
-release tag, for example `v5.0.3`.
+release tag, for example `v5.0.4`.
```

One line, generated — no hand edits.

## Testing

- `bundle exec rake check_command_docs` → passes (no diff after regeneration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single generated documentation line with no runtime or behavioral changes.
> 
> **Overview**
> Regenerates the checked-in **`docs/commands.md`** snapshot so the **`update-github-actions`** example release tag matches **`Cpflow::VERSION`** after the **5.0.4** bump (`v5.0.3` → **`v5.0.4`**).
> 
> This is generated output from **`script/update_command_docs`** / **`rake check_command_docs`**, not a hand edit—intended to stop **Command Docs** CI from failing on unrelated PRs when the doc drifted from the gem version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86662525d69796b1d1dba362dff2367f8d6223f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->