### PR TITLE
Regenerate docs/commands.md for v5.0.4 (fix Command Docs CI)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -544,7 +544,7 @@ cpflow terraform import
 Regenerates the generated cpflow GitHub Actions wrappers and helper files
 from the currently installed cpflow gem. Use this after updating the
 cpflow gem so checked-in workflow wrappers move to the matching upstream
-release tag, for example `v5.0.3`.
+release tag, for example `v5.0.4`.
 
 If the existing generated staging workflow uses a custom single staging
 branch, the command preserves it. Pass `--staging-branch BRANCH` to set or


### PR DESCRIPTION
## Problem

The **Command Docs** CI check (`bundle exec rake check_command_docs`) regenerates `docs/commands.md` from the CLI definitions and fails if it differs from the checked-in copy. It is currently **red on `main`** (since the 5.0.4 version bump in de7e9d8): the `update-github-actions` description interpolates `Cpflow::VERSION` for its example tag, so the generated text says `v5.0.4` while the checked-in doc still says `v5.0.3`.

This fails the check on `main` and on every branch cut from it.

## Fix

Ran `bundle exec ruby script/update_command_docs`. The only change is the example tag:

```
- release tag, for example `v5.0.3`.
+ release tag, for example `v5.0.4`.
```

`rake check_command_docs` passes locally after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only regeneration with no runtime, security, or data-handling impact.
> 
> **Overview**
> Regenerates **`docs/commands.md`** so the **`update-github-actions`** section’s example upstream release tag matches the current gem version (**`v5.0.4`** instead of **`v5.0.3`**).
> 
> No CLI behavior changes—this only aligns the checked-in auto-generated command docs with **`script/update_command_docs`** / **`rake check_command_docs`** after the 5.0.4 version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a65c13e3bd9b3d36bda740972a84993aabcc90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->