### PR TITLE
docs: address tips.md review feedback from Eric (followup to #296)

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,21 +1,23 @@
 # Tips
 
 1. [GVCs vs. Orgs](#gvcs-vs-orgs)
-2. [RAM](#ram)
-3. [Remote IP](#remote-ip)
-4. [Secrets and ENV Values](/docs/secrets-and-env-values.md)
-5. [CI](#ci)
-6. [Logs](#logs)
-7. [Memcached](#memcached)
-8. [Sidekiq](#sidekiq)
-   - [Quieting Non-Critical Workers During Deployments](#quieting-non-critical-workers-during-deployments)
-   - [Setting Up a Pre Stop Hook](#setting-up-a-pre-stop-hook)
-   - [Setting Up a Liveness Probe](#setting-up-a-liveness-probe)
-9. [Minimizing Review App Costs](#minimizing-review-app-costs)
-   - [Scale the Web Workload to Zero](#scale-the-web-workload-to-zero)
-   - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
-   - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
-10. [Useful Links](#useful-links)
+2. [Heroku Mappings](#heroku-mappings)
+3. [RAM](#ram)
+4. [CPU](#cpu)
+5. [Remote IP](#remote-ip)
+6. [Secrets and ENV Values](/docs/secrets-and-env-values.md)
+7. [CI](#ci)
+8. [Logs](#logs)
+9. [Memcached](#memcached)
+10. [Sidekiq](#sidekiq)
+    - [Quieting Non-Critical Workers During Deployments](#quieting-non-critical-workers-during-deployments)
+    - [Setting Up a Pre Stop Hook](#setting-up-a-pre-stop-hook)
+    - [Setting Up a Liveness Probe](#setting-up-a-liveness-probe)
+11. [Minimizing Review App Costs](#minimizing-review-app-costs)
+    - [Scale the Web Workload to Zero](#scale-the-web-workload-to-zero)
+    - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
+    - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
+12. [Useful Links](#useful-links)
 
 ## GVCs vs. Orgs
 
@@ -24,6 +26,23 @@
 - Multiple GVCs within an org can use the same image.
 - You can have different images within a GVC and even within a workload. This flexibility is one of the key differences
   compared to Heroku apps.
+
+## Heroku Mappings
+
+If you're coming from Heroku, these concepts map roughly as follows:
+
+| Heroku           | Control Plane                       |
+| ---------------- | ----------------------------------- |
+| App              | GVC                                 |
+| Dyno             | Replica                             |
+| Procfile Process | Workload                            |
+| Config Var       | Secret / Environment Variable       |
+| Add-on           | Managed Service or External Service |
+| Release Phase    | Deployment Workflow                 |
+
+These are conceptual equivalents rather than exact matches — see [GVCs vs. Orgs](#gvcs-vs-orgs) above for one key
+difference. For a mapping of Heroku _CLI commands_ to `cpflow`/`cpln`, see
+[Mapping of Heroku Commands](/README.md#mapping-of-heroku-commands-to-cpflow-and-cpln).
 
 ## RAM
 
@@ -64,6 +83,23 @@ The steps for configuring an alert for workload restarts are almost identical, b
 
 For more information on Grafana alerts, see: https://grafana.com/docs/grafana/latest/alerting/
 
+## CPU
+
+Control Plane workloads can be configured with CPU reservations and limits. If a workload consistently operates near its
+CPU limit, request latency may increase. If CPU is configured as the workload's autoscaling metric (with `maxScale`
+greater than `minScale`), Control Plane will add replicas in response — but the default `templates/rails.yml` pins
+`minScale: 1`, `maxScale: 1`, so it holds a single replica until you configure autoscaling.
+
+Worth monitoring:
+
+- CPU utilization
+- Request latency
+- Replica count
+- Container restarts
+
+Consider configuring an alert for sustained CPU utilization above 80%. You can set this up with the same Grafana
+alerting steps described under [RAM](#ram) above, substituting a CPU utilization query for the memory one.
+
 ## Remote IP
 
 The actual remote IP of the workload container is in the 127.0.0.x network, so that will be the value of the
@@ -74,6 +110,9 @@ https://shakadocs.controlplane.com/concepts/security#headers). On Rails, the `Ac
 pick those up and automatically populate `request.remote_ip`.
 
 So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
+
+> **Warning:** Do not use `REMOTE_ADDR` for authentication, rate limiting, auditing, or IP allowlists. Always use
+> framework-specific mechanisms that understand proxy headers (such as Rails' `request.remote_ip`).
 
 ## CI
 
@@ -86,6 +125,11 @@ Make sure to create a profile on CI before running any `cpln` or `cpflow` comman
 CPLN_TOKEN=...
 cpln profile create default --token ${CPLN_TOKEN}
 ```
+
+The `CPLN_TOKEN=...` line above is illustrative. In CI, don't write the literal token into your workflow file — store it
+in your provider's secret store and let CI inject it as the `CPLN_TOKEN` environment variable, which
+`cpln profile create ... --token ${CPLN_TOKEN}` then reads. See [`examples/circleci.yml`](/examples/circleci.yml) for the
+recommended pattern.
 
 Also, log in to the Control Plane Docker repository if building and pushing an image.
 
@@ -163,6 +207,11 @@ server-side cap may be lower than the flag value.
 On the workload container for Memcached (using the `memcached:alpine` image), configure the command with the args
 `-l 0.0.0.0`.
 
+This makes Memcached listen on all network interfaces so other workloads in the GVC can reach it at
+`memcached.APP_GVC.cpln.local`. The `memcached` image already defaults to all interfaces, but passing `-l 0.0.0.0`
+explicitly keeps the intent clear and guards against the listen address being restricted by a future base-image or
+config change.
+
 To do this:
 
 1. Navigate to the workload container for Memcached
@@ -183,6 +232,9 @@ There's no need to unquiet the workers, as that will happen automatically after 
 ```sh
 cpflow run 'rails runner "Sidekiq::ProcessSet.new.each { |w| w.quiet! unless w[%q(hostname)].start_with?(%q(criticalworker.)) }"' -a my-app
 ```
+
+> **Note:** This assumes critical workers share a consistent hostname prefix (the check matches `hostname`, not
+> Sidekiq's `tag` attribute). If you use a custom naming convention, adjust the `start_with?` check accordingly.
 
 ### Setting Up a Pre Stop Hook
 
@@ -218,6 +270,10 @@ To set up a liveness probe on port 7433, see: https://github.com/arturictus/side
 
 Long-tail review apps — PRs that linger for days or weeks with little traffic — can drive up Control Plane spend if every
 workload runs full-time. `cpflow` already provides several knobs to manage this without custom orchestration.
+
+> **Note:** Scaling workloads to zero or stopping review apps does not reduce costs from external databases, managed
+> Redis instances, object storage, or other third-party services. Those continue to bill independently of Control Plane
+> workload state.
 
 ### Scale the Web Workload to Zero
 


### PR DESCRIPTION
## Summary

Followup to #296 — applies Eric Kotler's review of the [Tips page](https://controlplaneflow.com/docs/tips/). All changes are in `docs/tips.md`.

## Changes

- **Heroku Mappings** — new concept table near the top (App→GVC, Dyno→Replica, Procfile Process→Workload, Config Var→Secret/Env Var, Add-on→Managed/External Service, Release Phase→Deployment Workflow), cross-linking the existing Heroku **CLI command** mapping in the README.
- **CPU** — new section: reservations/limits, what to monitor (CPU utilization, request latency, replica count, container restarts), and alerting on sustained CPU >80% via the existing Grafana steps. The autoscaling note is qualified because the default `templates/rails.yml` pins `minScale: 1`/`maxScale: 1` and won't autoscale until configured.
- **Remote IP** — added a warning: never use `REMOTE_ADDR` for auth, rate limiting, auditing, or IP allowlists; use `request.remote_ip`.
- **CI** — clarified that the `CPLN_TOKEN=...` snippet is illustrative; store the token as a secret and inject it as an env var, linking `examples/circleci.yml`.
- **Memcached** — explained *why* `-l 0.0.0.0` is set.
- **Sidekiq** — added a caveat to the quieting example about hostname-prefix matching.

## Accuracy note (from review)

I ran a multi-agent verification pass over the new content. Two of Eric's suggested phrasings were technically inaccurate and were corrected before committing:

- **Memcached:** the suggested "binds only to localhost" is wrong for the `memcached:alpine` image — stock `memcached` runs with no `-l` flag and defaults to `INADDR_ANY` (all interfaces). Reframed positively: `-l 0.0.0.0` makes Memcached listen on all interfaces so other workloads reach it at `memcached.APP_GVC.cpln.local`, stated explicitly to guard against base-image/config drift. (The localhost-only default is a Debian/Ubuntu *packaging* behavior, not this image.)
- **CPU autoscaling:** "autoscaling may become more aggressive" is only true when CPU is the configured autoscaling metric *and* `maxScale > minScale` — not the case under the shipped defaults — so the clause was qualified.

Also dropped the one-off ⚠️ emoji on the Remote IP callout to match the file's existing plain `> **Note:**`/`> **Warning:**` style, and tightened the Sidekiq note to clarify it matches on `hostname` (not Sidekiq's `tag` attribute).

## Not included — manual follow-up

Eric also asked that the three UI screenshots be updated to the new Control Plane UI:

- [ ] `docs/assets/grafana-alert.png`
- [ ] `docs/assets/memcached.png`
- [ ] `docs/assets/sidekiq-pre-stop-hook.png`

Regenerating these requires capturing new images from the Control Plane console, so it can't be done as a text edit. Tracking it as a separate task.

## Verification

- `script/check_cpln_links docs/tips.md` passes.
- TOC renumbered; all anchors (incl. new `#heroku-mappings`, `#cpu`) and the `/README.md#mapping-of-heroku-commands-to-cpflow-and-cpln` cross-link verified against actual headings.
- Docs-only change; no specs or version bump affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to `docs/tips.md`; no application code, config defaults, or runtime behavior changes.
> 
> **Overview**
> **Docs-only follow-up** to review feedback on `docs/tips.md`: the table of contents is renumbered to add **Heroku Mappings** and **CPU**, without changing the rest of the page structure.
> 
> Adds a **Heroku → Control Plane concept table** (App/GVC, Dyno/Replica, etc.) with links to the existing README **CLI command** mapping and **GVCs vs. Orgs**. New **CPU** guidance covers limits, what to watch (utilization, latency, replicas, restarts), Grafana alerting (>80%), and notes that default `templates/rails.yml` keeps `minScale`/`maxScale` at 1 until autoscaling is configured.
> 
> Several existing sections get tighter operational notes: **Remote IP** warns against using `REMOTE_ADDR` for auth/rate limits; **CI** says to inject `CPLN_TOKEN` from secrets (points at `examples/circleci.yml`); **Memcached** explains why `-l 0.0.0.0` is set; **Sidekiq** quieting documents hostname-prefix vs `tag`; **Minimizing Review App Costs** notes that pausing workloads does not stop billing for external DB/Redis/storage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb555a91115b04c0aed31dccb76a37b8f0a708a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced new sections for platform mappings and CPU monitoring guidance with alerting best practices.
  * Strengthened security documentation with guidance on proxy-aware mechanisms for remote IP handling.
  * Added clarifications on CI token management, configuration settings, and review app cost implications for external services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shakacode/control-plane-flow/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->