### PR TITLE
Clarify review app security guidance

### DIFF
--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -410,7 +410,7 @@ Advanced optional repository variables:
 - `CPLN_CLI_VERSION`: pin only when Control Plane CLI compatibility requires it.
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
 
-## Review app security for repositories with external contributors
+## Review App Security for Repositories with External Contributors
 
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
 Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, any `release_script` or
@@ -419,16 +419,17 @@ and policy templates applied by `cpflow setup-app` at first deploy with `CPLN_TO
 pull request being deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even
 when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
 the code executes inside the review app workload and can read any secrets mounted into the workload environment.
-The generated setup action also exports `CPLN_TOKEN_STAGING` as `CPLN_TOKEN` to `$GITHUB_ENV` for later runner shell
-steps, so keep any custom runner steps after setup trusted. PR-controlled `release_script` and hook commands normally run
-through `cpflow run` in remote Control Plane containers from the latest image, not as runner shell steps, so they do not
-read that runner token directly unless a custom workflow passes a local token through. Inside the Control Plane workload,
-a separate runtime `CPLN_TOKEN` is available only when the workload spec has an `identityLink`; `skip_secrets_setup`
-skips automatic identity creation and binding, but templates can still attach an identity. Because `cpflow setup-app`
-reads `controlplane.yml` from the PR checkout, a PR can also set `skip_secrets_setup: false` or omit it to re-enable
-automatic identity binding unless the trusted workflow passes `--skip-secrets-setup` as a CLI flag. Do not treat
-`skip_secrets_setup` in `controlplane.yml` as a token-removal control or reliable security boundary. This is why
-workload-mounted secrets and the staging service-account token must remain disposable and scoped to minimum permissions.
+The generated setup action also exports `CPLN_TOKEN_STAGING` as `CPLN_TOKEN` via `GITHUB_ENV`, making it available in the
+process environment of every subsequent runner step for the rest of the job, so keep any custom runner steps after setup
+trusted. PR-controlled `release_script` and hook commands normally run through `cpflow run` in remote Control Plane
+containers from the latest image, not as runner shell steps, so they do not read that runner token directly unless a
+custom workflow passes a local token through. Inside the Control Plane workload, a separate runtime `CPLN_TOKEN` is
+available only when the workload spec has an `identityLink`; `skip_secrets_setup` skips automatic identity creation and
+binding, but templates can still attach an identity. Because `cpflow setup-app` reads `controlplane.yml` from the PR
+checkout, a PR can also set `skip_secrets_setup: false` or omit it to re-enable automatic identity binding unless the
+trusted workflow passes `--skip-secrets-setup` as a CLI flag. Do not treat `skip_secrets_setup` in `controlplane.yml` as
+a token-removal control or reliable security boundary. This is why workload-mounted secrets and the staging
+service-account token must remain disposable and scoped to minimum permissions.
 
 The generated flow uses these defaults:
 
@@ -444,16 +445,17 @@ The generated flow uses these defaults:
   comment events is enforced inside the reusable workflow's source-validation step. These complementary guards cover
   different axes, so preserve both. A trusted commenter can comment on a fork PR and pass the caller's
   `author_association` check; the reusable workflow's source-validation step is what blocks that fork head from being
-  deployed. Removing either guard opens a path to deploy untrusted code with repository-secret access. GitHub also
-  withholds repository secrets from fork `pull_request` runs, but not from `issue_comment` runs, which execute with
-  base-repository secret access. Keep the workflow guards in place because the workflow builds Docker images with
-  repository secrets;
-- `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
+  deployed. Removing the source-validation guard opens a path to deploy untrusted code with repository-secret access,
+  because `issue_comment` events execute with base-repository secret access. Removing the `pull_request` guard still
+  lets untrusted fork code into the staging environment even though GitHub withholds repository secrets from fork
+  `pull_request` runs. Keep both workflow guards in place because the workflow builds Docker images with repository
+  secrets;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
-  so the staging token is available for teardown, and it does not require a trusted commenter. The generated
-  `cpflow-delete-review-app.yml` pins `GITHUB_TOKEN` permissions to the minimum it needs (`contents: read`,
-  `issues: write`, `pull-requests: write`); if you customize this workflow, preserve that `permissions:` block because
-  omitting it can fall back to broader repository defaults;
+  so it runs in the base-repository context and has repository-secret access for teardown. That is also why you must
+  never check out PR or fork code in this job; see the customization guidance below. The PR-close path does not require a
+  trusted commenter. The generated `cpflow-delete-review-app.yml` pins `GITHUB_TOKEN` permissions to the minimum it needs
+  (`contents: read`, `issues: write`, `pull-requests: write`); if you customize this workflow, preserve that
+  `permissions:` block because omitting it can fall back to broader repository defaults;
 - manual workflow dispatch by a repository collaborator can also delete a review app without a `+review-app-delete`
   comment, and does not require a trusted commenter;
 - trusted comments on fork PRs still do not deploy the fork head; the workflow posts no PR comment in this case. The

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -390,7 +390,7 @@ Recommended org layout:
 - keep review apps and staging in a staging org that developers can access
 - keep production in a separate org with tighter access controls
 - for public repositories, use a staging/review token generated from a service account whose policies only allow
-  review/staging CI operations by default; use a dedicated review-app org only if you also customize the generated
+  review/staging CI operations; use a dedicated review-app org only if you also customize the generated
   workflow/configuration to target that org separately
 
 Optional repository secret for private dependency builds:
@@ -422,9 +422,11 @@ The generated flow uses these defaults:
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
   requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
   collaborator;
-- fork pull requests cannot deploy via the generated `pull_request` path because the workflow's same-repository `if:`
-  condition explicitly skips fork-originated runs. GitHub's default secret handling also withholds repository secrets from
-  fork `pull_request` runs, but repository settings can change that behavior, so keep the workflow guard in place;
+- fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
+  condition explicitly skips fork-originated runs. For `issue_comment` events, the fork check is enforced inside the
+  reusable workflow's source-validation step rather than the `if:`; both guards are required. GitHub also withholds
+  repository secrets from fork `pull_request` runs, but keep the workflow guards in place because the workflow builds
+  Docker images with repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
@@ -447,8 +449,8 @@ For public repositories, keep review-app credentials and runtime values disposab
 
 - do not mount production secrets, staging customer data, package-publishing tokens, payment keys, or monitoring tokens
   into review apps;
-- do not use broad Control Plane `superusers` tokens for review-app CI when a narrower review-app service account can do
-  the job;
+- do not use broad Control Plane `superusers` tokens for review-app CI; use a review/staging service account scoped only to
+  review/staging CI operations;
 - keep review databases, Redis instances, object stores, and renderer credentials separate from staging and production;
 - rotate any credential that may have been exposed to a malicious review-app build;
 - use scheduled cleanup so stale review apps stop consuming compute and secrets access.
@@ -510,8 +512,9 @@ dependency access, and never use a personal SSH key.
   [Enable Capacity AI for Demo and Starter Staging Apps](tips.md#enable-capacity-ai-for-demo-and-starter-staging-apps).
 - Accepts `+review-app-deploy` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
 - Skips fork-based PR deploys because the workflow builds Docker images with repository secrets. A trusted comment on a
-  fork PR still does not deploy the fork head, and manual dispatch should target only a trusted base-repository ref; move
-  the change to a branch in the base repository if it needs a review app.
+  fork PR still does not deploy the fork head, and manual dispatch must target a base-repository ref; dispatching with a
+  fork PR number causes a hard workflow failure. Move the change to a branch in the base repository if it needs a review
+  app.
 
 `cpflow-delete-review-app.yml`
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -413,23 +413,25 @@ dependency access, and never use a personal SSH key.
 ## Review App Security For Public Repositories
 
 Review-app deployment executes pull request code. Even when the workflow itself is trusted, the Dockerfile, package
-scripts, Rails initializers, server-rendering code, and application runtime can all be changed by the pull request being
+scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
+`hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
 deployed.
 
 The generated flow uses these defaults:
 
-- same-repository pull requests from any contributor with push access can create or update review apps automatically on
-  each push;
-- fork pull requests are skipped for review-app deploys;
+- same-repository pull requests can update existing review apps automatically on each push; creating the first review app
+  requires a `+review-app-deploy` comment from a trusted commenter;
+- fork pull requests cannot deploy via the `pull_request` event because GitHub withholds repository secrets from
+  fork-originated runs; the workflow's same-repository `if:` condition is an additional explicit guard;
 - `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
 - trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
   it needs a generated review app;
 - production promotion is manual and uses production environment secrets separately from review and staging.
 
-The generated review-app workflow targets the staging/review Control Plane org and token from `CPLN_ORG_STAGING` and
-`CPLN_TOKEN_STAGING`. A fully separate review-app org or token requires workflow/configuration customization; otherwise,
-keep review apps and staging in the generated staging/review org and make that token disposable and unable to access
-production resources.
+The generated review-app workflow targets the staging/review Control Plane org inferred from `cpln_org` in
+`controlplane.yml`, or overridden by `CPLN_ORG_STAGING`, and uses the token from `CPLN_TOKEN_STAGING`. A fully separate
+review-app org or token requires workflow/configuration customization; otherwise, keep review apps and staging in the
+generated staging/review org and make that token disposable and unable to access production resources.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -416,12 +416,15 @@ Dockerfile, package scripts, Rails initializers, server-rendering code, applicat
 deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, so malicious image
 content can execute during review-app deletion or scheduled cleanup even when the hook command comes from the base
 branch config.
+For example, a PR author can embed code that runs during `hooks.pre_deletion`
+inside the PR-built image while `CPLN_TOKEN_STAGING` is present during teardown.
 
 The generated flow uses these defaults:
 
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
   requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
-  collaborator;
+  collaborator. The trusted-commenter gate applies only to creating the first review app; later pushes to a
+  base-repository branch PR redeploy without another approval while the review app exists;
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
   condition explicitly skips fork-originated runs. For `issue_comment` events, the fork check is enforced inside the
   reusable workflow's source-validation step rather than the `if:`; that internal check is the sole fork guard for
@@ -457,6 +460,8 @@ For public repositories, keep review-app credentials and runtime values disposab
 
 - do not mount production secrets, staging customer data, package-publishing tokens, payment keys, or monitoring tokens
   into review apps;
+- do not use `DOCKER_BUILD_SSH_KEY` with a long-lived personal key or broad deploy key; restrict it to a read-only,
+  revocable deploy key scoped to the minimum private dependency access;
 - do not use broad Control Plane `superusers` tokens for review-app CI; use a review/staging service account scoped only to
   review/staging CI operations;
 - keep review databases, Redis instances, object stores, and renderer credentials separate from staging and production;
@@ -492,7 +497,7 @@ DOCKER_BUILD_EXTRA_ARGS=--build-arg=BUNDLE_WITHOUT=development:test
 The action will start an SSH agent, add the key, write `known_hosts`, and pass `--ssh=default` to `cpflow build-image`. When `DOCKER_BUILD_SSH_KNOWN_HOSTS` is unset, the generated action uses pinned GitHub.com host keys by default. If your Dockerfile relies on `RUN --mount=type=ssh`, validate the build locally with `cpflow build-image -a <app> --ssh=default` before relying on CI.
 
 Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
-allowed review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
+all review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
 dependency access, and never use a personal SSH key.
 
 ## Generated Workflow Behavior

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -448,6 +448,10 @@ review-app prefix. This is a shell-level guard, not a token policy; use a scoped
 itself is limited to review/staging operations. A configured `hooks.pre_deletion` command still runs through the latest
 PR-built image, so review-app credentials must remain disposable even during deletion.
 
+If you customize the generated `pull_request_target` workflow, never check out fork code with
+`github.event.pull_request.head.sha` or another fork-controlled ref. That would run untrusted fork code with repository
+secret access.
+
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -419,12 +419,13 @@ and policy templates applied by `cpflow setup-app` at first deploy with `CPLN_TO
 pull request being deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even
 when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
 the code executes inside the review app workload and can read any secrets mounted into the workload environment.
-`CPLN_TOKEN_STAGING` is also exported as `CPLN_TOKEN` for later runner shell steps after the generated setup action runs,
-so PR-controlled `release_script` and hook commands can read the staging token directly while they execute on the runner.
-Inside the Control Plane workload, a separate runtime `CPLN_TOKEN` is available only when the workload spec has an
-`identityLink`; `skip_secrets_setup` skips automatic identity creation and binding, but templates can still attach an
-identity. Do not treat `skip_secrets_setup` as a token-removal control. This is why workload-mounted secrets and the
-staging service-account token must remain disposable and scoped to minimum permissions.
+The generated setup action also exports `CPLN_TOKEN_STAGING` as `CPLN_TOKEN` for later runner shell steps, so keep any
+custom runner steps after setup trusted. PR-controlled `release_script` and hook commands normally run through
+`cpflow run` in the latest image, not as runner shell, so they do not read that runner token directly unless a custom
+workflow passes a local token through. Inside the Control Plane workload, a separate runtime `CPLN_TOKEN` is available
+only when the workload spec has an `identityLink`; `skip_secrets_setup` skips automatic identity creation and binding,
+but templates can still attach an identity. Do not treat `skip_secrets_setup` as a token-removal control. This is why
+workload-mounted secrets and the staging service-account token must remain disposable and scoped to minimum permissions.
 
 The generated flow uses these defaults:
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -408,10 +408,6 @@ Advanced optional repository variables:
 - `CPLN_CLI_VERSION`: pin only when Control Plane CLI compatibility requires it.
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
 
-Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
-allowed review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
-dependency access, and never use a personal SSH key.
-
 ## Review App Security For Public Repositories
 
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
@@ -424,12 +420,13 @@ branch config.
 The generated flow uses these defaults:
 
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
-  requires a `+review-app-deploy` comment from a trusted commenter;
+  requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
+  collaborator;
 - fork pull requests cannot deploy via the `pull_request` event because GitHub withholds repository secrets from
   fork-originated runs; the workflow's same-repository `if:` condition is an additional explicit guard;
 - `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
-- review apps are also deleted automatically when the pull request closes; that PR-close path does not require a trusted
-  commenter;
+- review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
+  so the staging token is available for teardown, and it does not require a trusted commenter;
 - trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
   it needs a generated review app;
 - production promotion is manual and uses production environment secrets separately from review and staging.
@@ -438,6 +435,10 @@ The generated review-app workflow targets the staging/review Control Plane org i
 `controlplane.yml`, or overridden by `CPLN_ORG_STAGING`, and uses the token from `CPLN_TOKEN_STAGING`. A fully separate
 review-app org or token requires workflow/configuration customization; otherwise, keep review apps and staging in the
 generated staging/review org and make that token disposable and unable to access production resources.
+
+The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
+PR review apps. The risk is bounded by `cpflow delete`, but a configured `hooks.pre_deletion` command still runs through
+the latest PR-built image, so review-app credentials must remain disposable even during deletion.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:
@@ -478,6 +479,10 @@ DOCKER_BUILD_EXTRA_ARGS=--build-arg=BUNDLE_WITHOUT=development:test
 
 The action will start an SSH agent, add the key, write `known_hosts`, and pass `--ssh=default` to `cpflow build-image`. When `DOCKER_BUILD_SSH_KNOWN_HOSTS` is unset, the generated action uses pinned GitHub.com host keys by default. If your Dockerfile relies on `RUN --mount=type=ssh`, validate the build locally with `cpflow build-image -a <app> --ssh=default` before relying on CI.
 
+Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
+allowed review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
+dependency access, and never use a personal SSH key.
+
 ## Generated Workflow Behavior
 
 `cpflow-review-app-help.yml`
@@ -494,6 +499,7 @@ The action will start an SSH agent, add the key, write `known_hosts`, and pass `
 `cpflow-deploy-review-app.yml`
 
 - Creates a review app when someone comments `+review-app-deploy`.
+- Also supports manual workflow dispatch by a repository collaborator.
 - Redeploys an existing review app automatically on later PR pushes.
 - Creates a GitHub deployment and comments with the review URL and logs.
 - Leaves PR pushes alone until the first review app is explicitly requested, which keeps demo-app costs down.
@@ -508,7 +514,8 @@ The action will start an SSH agent, add the key, write `known_hosts`, and pass `
 `cpflow-delete-review-app.yml`
 
 - Deletes the review app on `+review-app-delete`.
-- Also deletes it automatically when the pull request closes.
+- Also deletes it automatically when the pull request closes through a `pull_request_target` event, so repository secrets
+  are available for teardown.
 - Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
 
 `cpflow-deploy-staging.yml`

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -448,10 +448,11 @@ review-app org or token requires workflow/configuration customization; otherwise
 generated staging/review org and make that token disposable and unable to access production resources.
 
 The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
-PR review apps. The generated workflow script refuses to call `cpflow delete` on any app whose name does not match the
-review-app prefix. This is a shell-level guard, not a token policy; use a scoped staging service account so the token
-itself is limited to review/staging operations. A configured `hooks.pre_deletion` command still runs through the latest
-PR-built image, so review-app credentials must remain disposable even during deletion.
+PR review apps. The generated `cpflow-delete-control-plane-app` composite action script refuses to call `cpflow delete`
+on any app whose name does not match the review-app prefix. This is a shell-level guard, not a token policy; use a scoped
+staging service account so the token itself is limited to review/staging operations. A configured `hooks.pre_deletion`
+command still runs through the latest PR-built image, so review-app credentials must remain disposable even during
+deletion.
 
 If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
 fork-controlled ref to `actions/checkout`. Checking out fork code in a `pull_request_target` job runs untrusted code with
@@ -499,9 +500,9 @@ DOCKER_BUILD_EXTRA_ARGS=--build-arg=BUNDLE_WITHOUT=development:test
 
 The action will start an SSH agent, add the key, write `known_hosts`, and pass `--ssh=default` to `cpflow build-image`. When `DOCKER_BUILD_SSH_KNOWN_HOSTS` is unset, the generated action uses pinned GitHub.com host keys by default. If your Dockerfile relies on `RUN --mount=type=ssh`, validate the build locally with `cpflow build-image -a <app> --ssh=default` before relying on CI.
 
-Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
-all review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
-dependency access, and never use a personal SSH key.
+Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to all
+review-app and staging Docker builds; follow the review-app security guidance above by using a read-only, revocable
+deploy key scoped to the minimum private dependency access, and never use a personal SSH key.
 
 ## Generated Workflow Behavior
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -420,16 +420,19 @@ pull request being deployed. Teardown can also run a `hooks.pre_deletion` comman
 when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
 the code executes inside the review app workload and can read any secrets mounted into the workload environment.
 `CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the container. Control
-Plane's workload identity mechanism still injects a separate workload-scoped `CPLN_TOKEN` into the container at runtime;
-PR code can use it to reveal any secret that identity is permitted to access. This is why workload-mounted secrets must
-remain disposable and the review app identity must be scoped to minimum permissions.
+Plane's workload identity mechanism injects a separate workload-scoped `CPLN_TOKEN` into the container at runtime when
+the workload has an identity bound, which is the default `setup-app` behavior; PR code can use it to reveal any secret
+that identity is permitted to access. Workloads created with `skip_secrets_setup` have no identity and therefore no
+injected `CPLN_TOKEN`, but they may still have secrets mounted directly. This is why workload-mounted secrets must remain
+disposable and the review app identity must be scoped to minimum permissions.
 
 The generated flow uses these defaults:
 
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
   requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
-  collaborator. The trusted-commenter gate applies only to creating the first review app; later pushes to a
-  base-repository branch PR redeploy without another approval while the review app exists;
+  collaborator. The trusted-commenter gate applies to every `+review-app-deploy` comment, whether or not a review app
+  already exists. Later pushes to a base-repository branch PR redeploy automatically without another approval because the
+  auto-push path (`pull_request` event) has no trusted-commenter check; only the `issue_comment` path does;
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
   condition explicitly skips fork-originated runs. For `issue_comment` events, the caller `if:` restricts commands to
   trusted author associations (`OWNER`, `MEMBER`, `COLLABORATOR`) but does not check fork status; the fork check for
@@ -439,11 +442,15 @@ The generated flow uses these defaults:
   workflow builds Docker images with repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
-  so the staging token is available for teardown, and it does not require a trusted commenter;
+  so the staging token is available for teardown, and it does not require a trusted commenter. `pull_request_target` also
+  runs with base-repository `GITHUB_TOKEN` permissions, which may include write access unless restricted; if you customize
+  this workflow, pin `permissions:` to the minimum required;
 - manual workflow dispatch by a repository collaborator can also delete a review app without a `+review-app-delete`
   comment, and does not require a trusted commenter;
-- trusted comments on fork PRs still do not deploy the fork head; review the code carefully, then move the change to a
-  branch in the base repository if it needs a generated review app. That build will run with repository-secret access;
+- trusted comments on fork PRs still do not deploy the fork head; the workflow posts no PR comment in this case. The
+  commenter receives a rocket reaction and the skip appears only in the Actions step summary. Review the fork code
+  carefully, then move the change to a branch in the base repository if it needs a generated review app. That build will
+  run with repository-secret access;
 - production promotion is manual and uses production environment secrets separately from review and staging.
 
 The generated review-app workflow targets the staging/review Control Plane org inferred from `cpln_org` in
@@ -481,7 +488,8 @@ For repositories with external contributors, keep review-app credentials and run
 
 Secret indirection such as `cpln://secret/...` protects values in Control Plane configuration. It does not protect a
 value after that secret is mounted into a workload that runs pull request code. See
-[Secrets and ENV Values](./secrets-and-env-values.md) for review-app secret handling guidance.
+[Secrets and ENV Values - Review app secrets](./secrets-and-env-values.md#review-app-secrets) for review-app secret
+handling guidance.
 
 ## Docker Builds with Private Dependencies
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -10,6 +10,11 @@ The goal is to bring the Heroku Flow model into any `cpflow` project:
 4. Promote the already-built staging artifact to production from the Actions tab.
 5. Let a nightly workflow clean up stale review apps.
 
+For public repositories, review apps are intentionally limited to branches in the base repository. Fork pull requests can
+receive help comments, but generated deploy workflows skip fork heads because review-app deployment builds Docker images
+with repository secrets. If a forked change needs a review app, a maintainer should first move the change into a trusted
+branch in the base repository or otherwise review it through a separate, disposable environment.
+
 ## Quick Start
 
 End-to-end rollout in one view:
@@ -165,7 +170,8 @@ Important points:
 
 For a normal generated review-app setup, configure one repository secret:
 
-- `CPLN_TOKEN_STAGING`: token for the staging Control Plane org
+- `CPLN_TOKEN_STAGING`: token for the staging/review Control Plane org. For public repositories, prefer a tightly scoped
+  token that cannot read production secrets or manage production workloads.
 
 No GitHub repository variables are required for review apps when `.controlplane/controlplane.yml`
 has exactly one review app entry with `match_if_app_name_starts_with: true` and
@@ -382,6 +388,8 @@ Recommended org layout:
 
 - keep review apps and staging in a staging org that developers can access
 - keep production in a separate org with tighter access controls
+- for open-source repositories, use a tightly scoped staging/review token by default; use a dedicated review-app org only
+  if you also customize the generated workflow/configuration to target that org separately
 
 Optional repository secret for private dependency builds:
 
@@ -397,6 +405,45 @@ Advanced optional repository variables:
 - `REVIEW_APP_DEPLOYING_ICON_URL`: custom image URL for the animated icon in review-app PR comments. Ignore this for the standard setup; it is cosmetic only.
 - `CPLN_CLI_VERSION`: pin only when Control Plane CLI compatibility requires it.
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
+
+Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
+allowed review-app Docker builds. Use a read-only, revocable deploy key scoped to the minimum private dependency access,
+and never use a personal SSH key.
+
+## Review App Security For Public Repositories
+
+Review-app deployment executes pull request code. Even when the workflow itself is trusted, the Dockerfile, package
+scripts, Rails initializers, server-rendering code, and application runtime can all be changed by the pull request being
+deployed.
+
+The generated flow uses these defaults:
+
+- same-repository pull requests can create or update review apps;
+- fork pull requests are skipped for review-app deploys;
+- `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
+- trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
+  it needs a generated review app;
+- production promotion is manual and uses production environment secrets separately from review and staging.
+
+The generated review-app workflow targets the staging/review Control Plane org and token from `CPLN_ORG_STAGING` and
+`CPLN_TOKEN_STAGING`. A fully separate review-app org or token requires workflow/configuration customization; otherwise,
+keep review apps and staging in the generated staging/review org and make that token disposable and unable to access
+production resources.
+
+These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
+For public repositories, keep review-app credentials and runtime values disposable:
+
+- do not mount production secrets, staging customer data, package-publishing tokens, payment keys, or monitoring tokens
+  into review apps;
+- do not use broad Control Plane `superusers` tokens for review-app CI when a narrower review-app service account can do
+  the job;
+- keep review databases, Redis instances, object stores, and renderer credentials separate from staging and production;
+- rotate any credential that may have been exposed to a malicious review-app build;
+- use scheduled cleanup so stale review apps stop consuming compute and secrets access.
+
+Secret indirection such as `cpln://secret/...` protects values in Control Plane configuration. It does not protect a
+value after that secret is mounted into a workload that runs pull request code. See
+[Secrets and ENV Values](./secrets-and-env-values.md) for review-app secret handling guidance.
 
 ## Docker Builds with Private Dependencies
 
@@ -445,7 +492,9 @@ The action will start an SSH agent, add the key, write `known_hosts`, and pass `
   metric for public demos, starter staging apps, and long-lived review apps; see
   [Enable Capacity AI for Demo and Starter Staging Apps](tips.md#enable-capacity-ai-for-demo-and-starter-staging-apps).
 - Accepts `+review-app-deploy` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
-- Skips fork-based PR deploys because the workflow builds Docker images with repository secrets.
+- Skips fork-based PR deploys because the workflow builds Docker images with repository secrets. A trusted comment on a
+  fork PR still does not deploy the fork head; move the change to a branch in the base repository if it needs a review
+  app.
 
 `cpflow-delete-review-app.yml`
 
@@ -725,6 +774,7 @@ In practice, porting the flow into a demo app usually follows five phases.
 
 13. Validate the real production Docker build before relying on the workflows, especially if asset compilation or SSR requires Node, extra system packages, multiple processes, extra Docker build flags, or persistent writable paths.
 14. Expect review app deploys to run only for branches in the base repository; fork PRs still get help comments, but deploys are skipped because the workflow uses repository secrets.
+15. For public repositories, confirm that review-app secrets are disposable and that `CPLN_TOKEN_STAGING` cannot access production resources.
 
 ## AI Playbook
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -408,14 +408,17 @@ Advanced optional repository variables:
 - `CPLN_CLI_VERSION`: pin only when Control Plane CLI compatibility requires it.
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
 
-## Review App Security For Public Repositories
+## Review app security for public repositories
 
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
 Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
 `hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
 deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even when the hook
-command comes from the base-branch config, so a PR author can embed malicious code in the image that executes with
-mounted review-app secrets and runtime values during deletion or scheduled cleanup.
+command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime the code
+executes with the review app's Control Plane workload identity token and can read any secrets mounted into the workload
+environment. `CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the
+container. This is why workload-mounted secrets must remain disposable and the review app identity must be scoped to
+minimum permissions.
 
 The generated flow uses these defaults:
 
@@ -424,11 +427,12 @@ The generated flow uses these defaults:
   collaborator. The trusted-commenter gate applies only to creating the first review app; later pushes to a
   base-repository branch PR redeploy without another approval while the review app exists;
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
-  condition explicitly skips fork-originated runs. For `issue_comment` events, the fork check is enforced inside the
-  reusable workflow's source-validation step rather than the `if:`; that internal check is the sole fork guard for
-  comment events. GitHub also withholds repository secrets from fork `pull_request` runs, but not from `issue_comment`
-  runs, which execute with base-repository secret access. Keep the workflow guards in place because the workflow builds
-  Docker images with repository secrets;
+  condition explicitly skips fork-originated runs. For `issue_comment` events, the caller `if:` restricts commands to
+  trusted author associations (`OWNER`, `MEMBER`, `COLLABORATOR`) but does not check fork status; the fork check for
+  comment events is enforced inside the reusable workflow's source-validation step. These complementary guards cover
+  different axes, so preserve both. GitHub also withholds repository secrets from fork `pull_request` runs, but not from
+  `issue_comment` runs, which execute with base-repository secret access. Keep the workflow guards in place because the
+  workflow builds Docker images with repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
@@ -449,9 +453,10 @@ review-app prefix. This is a shell-level guard, not a token policy; use a scoped
 itself is limited to review/staging operations. A configured `hooks.pre_deletion` command still runs through the latest
 PR-built image, so review-app credentials must remain disposable even during deletion.
 
-If you customize the generated `pull_request_target` workflow, never check out fork code with
-`github.event.pull_request.head.sha` or another fork-controlled ref. That would run untrusted fork code with repository
-secret access.
+If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
+fork-controlled ref to `actions/checkout`. Checking out fork code in a `pull_request_target` job runs untrusted code with
+repository secret access. Referencing the SHA for other purposes, such as deployment status updates, comments, or API
+calls, is safe.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -422,9 +422,10 @@ The generated flow uses these defaults:
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
   requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
   collaborator;
-- fork pull requests cannot deploy via the `pull_request` event because GitHub withholds repository secrets from
-  fork-originated runs; the workflow's same-repository `if:` condition is an additional explicit guard;
-- `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
+- fork pull requests cannot deploy via the `pull_request` event because the workflow's same-repository `if:`
+  condition explicitly skips fork-originated runs, and GitHub also withholds repository secrets from fork
+  `pull_request` runs as a platform-level safeguard;
+- `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
 - trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
@@ -437,8 +438,9 @@ review-app org or token requires workflow/configuration customization; otherwise
 generated staging/review org and make that token disposable and unable to access production resources.
 
 The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
-PR review apps. The risk is bounded by `cpflow delete`, but a configured `hooks.pre_deletion` command still runs through
-the latest PR-built image, so review-app credentials must remain disposable even during deletion.
+PR review apps. The workflow can only call `cpflow delete` on an app whose name matches the review-app prefix, but a
+configured `hooks.pre_deletion` command still runs through the latest PR-built image, so review-app credentials must
+remain disposable even during deletion.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:
@@ -514,9 +516,11 @@ dependency access, and never use a personal SSH key.
 `cpflow-delete-review-app.yml`
 
 - Deletes the review app on `+review-app-delete`.
+- Also supports manual workflow dispatch by a repository collaborator.
 - Also deletes it automatically when the pull request closes through a `pull_request_target` event, so repository secrets
   are available for teardown.
-- Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
+- Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`); manual dispatch and
+  automatic PR-close teardown do not require a trusted commenter.
 
 `cpflow-deploy-staging.yml`
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -424,14 +424,15 @@ The generated flow uses these defaults:
   collaborator;
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
   condition explicitly skips fork-originated runs. For `issue_comment` events, the fork check is enforced inside the
-  reusable workflow's source-validation step rather than the `if:`; both guards are required. GitHub also withholds
-  repository secrets from fork `pull_request` runs, but keep the workflow guards in place because the workflow builds
+  reusable workflow's source-validation step rather than the `if:`; that internal check is the sole fork guard for
+  comment events. GitHub also withholds repository secrets from fork `pull_request` runs, but keep the workflow guards in
+  place because the workflow builds
   Docker images with repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
-- trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
-  it needs a generated review app;
+- trusted comments on fork PRs still do not deploy the fork head; review the code carefully, then move the change to a
+  branch in the base repository if it needs a generated review app. That build will run with repository-secret access;
 - production promotion is manual and uses production environment secrets separately from review and staging.
 
 The generated review-app workflow targets the staging/review Control Plane org inferred from `cpln_org` in
@@ -503,7 +504,8 @@ dependency access, and never use a personal SSH key.
 `cpflow-deploy-review-app.yml`
 
 - Creates a review app when someone comments `+review-app-deploy`.
-- Also supports manual workflow dispatch by a repository collaborator for trusted base-repository refs.
+- Also supports manual workflow dispatch by a repository collaborator. Provide the PR number; the workflow rejects fork
+  PRs at runtime.
 - Redeploys an existing review app automatically on later PR pushes.
 - Creates a GitHub deployment and comments with the review URL and logs.
 - Leaves PR pushes alone until the first review app is explicitly requested, which keeps demo-app costs down.
@@ -512,9 +514,9 @@ dependency access, and never use a personal SSH key.
   [Enable Capacity AI for Demo and Starter Staging Apps](tips.md#enable-capacity-ai-for-demo-and-starter-staging-apps).
 - Accepts `+review-app-deploy` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
 - Skips fork-based PR deploys because the workflow builds Docker images with repository secrets. A trusted comment on a
-  fork PR still does not deploy the fork head, and manual dispatch must target a base-repository ref; dispatching with a
-  fork PR number causes a hard workflow failure. Move the change to a branch in the base repository if it needs a review
-  app.
+  fork PR still does not deploy the fork head, and manual dispatch must use a base-repository PR number; dispatching with
+  a fork PR number causes a hard workflow failure. To give a fork PR a review app, review the code carefully first, then
+  move the change to a branch in the base repository. The build will then run with repository-secret access.
 
 `cpflow-delete-review-app.yml`
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -388,7 +388,7 @@ Recommended org layout:
 
 - keep review apps and staging in a staging org that developers can access
 - keep production in a separate org with tighter access controls
-- for open-source repositories, use a tightly scoped staging/review token by default; use a dedicated review-app org only
+- for public repositories, use a tightly scoped staging/review token by default; use a dedicated review-app org only
   if you also customize the generated workflow/configuration to target that org separately
 
 Optional repository secret for private dependency builds:
@@ -407,8 +407,8 @@ Advanced optional repository variables:
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
 
 Do not configure `DOCKER_BUILD_SSH_KEY` unless the Dockerfile truly needs it. When configured, it is available to
-allowed review-app Docker builds. Use a read-only, revocable deploy key scoped to the minimum private dependency access,
-and never use a personal SSH key.
+allowed review-app and staging Docker builds. Use a read-only, revocable deploy key scoped to the minimum private
+dependency access, and never use a personal SSH key.
 
 ## Review App Security For Public Repositories
 
@@ -418,7 +418,8 @@ deployed.
 
 The generated flow uses these defaults:
 
-- same-repository pull requests can create or update review apps;
+- same-repository pull requests from any contributor with push access can create or update review apps automatically on
+  each push;
 - fork pull requests are skipped for review-app deploys;
 - `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
 - trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -12,8 +12,10 @@ The goal is to bring the Heroku Flow model into any `cpflow` project:
 
 For public repositories, review apps are intentionally limited to branches in the base repository. Fork pull requests can
 receive help comments, but generated deploy workflows skip fork heads because review-app deployment builds Docker images
-with repository secrets. If a forked change needs a review app, a maintainer should first move the change into a trusted
-branch in the base repository or otherwise review it through a separate, disposable environment.
+with repository secrets. The skip is enforced by complementary guards on different trigger axes; see
+[Review app security for repositories with external contributors](#review-app-security-for-repositories-with-external-contributors)
+before customizing these workflows. If a forked change needs a review app, a maintainer should first move the change into
+a trusted branch in the base repository or otherwise review it through a separate, disposable environment.
 
 ## Quick Start
 
@@ -411,11 +413,12 @@ Advanced optional repository variables:
 ## Review app security for repositories with external contributors
 
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
-Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
-`hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
-deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even when the hook
-command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime the code
-executes inside the review app workload and can read any secrets mounted into the workload environment.
+Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, any `release_script` or
+`hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml`, and `.controlplane/templates/*.yaml` identity
+and policy templates applied by `cpflow setup-app` at first deploy with `CPLN_TOKEN_STAGING` can all be changed by the
+pull request being deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even
+when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
+the code executes inside the review app workload and can read any secrets mounted into the workload environment.
 `CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the container. Control
 Plane's workload identity mechanism still injects a separate workload-scoped `CPLN_TOKEN` into the container at runtime;
 PR code can use it to reveal any secret that identity is permitted to access. This is why workload-mounted secrets must
@@ -456,9 +459,9 @@ command still runs through the latest PR-built image, so review-app credentials 
 deletion.
 
 If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
-fork-controlled ref to `actions/checkout`. Checking out fork code in a `pull_request_target` job runs untrusted code with
-repository secret access. Referencing the SHA for other purposes, such as deployment status updates, comments, or API
-calls, is safe.
+fork-controlled ref to `actions/checkout`, `git fetch`, `git merge`, `git cherry-pick`, or any other step that fetches,
+materializes, or executes the ref. Those operations run untrusted fork code with repository secret access. Referencing the
+SHA as an opaque identifier for deployment status updates, comments, or API calls is safe.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For repositories with external contributors, keep review-app credentials and runtime values disposable:

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -170,9 +170,9 @@ Important points:
 
 For a normal generated review-app setup, configure one repository secret:
 
-- `CPLN_TOKEN_STAGING`: token for the staging/review Control Plane org. For public repositories, generate it from a
-  Control Plane service account whose policies only allow review/staging CI operations; it must not read production
-  secrets or manage production workloads.
+- `CPLN_TOKEN_STAGING`: token for the staging/review Control Plane org. Generate it from a Control Plane service account
+  whose policies only allow review/staging CI operations; it must not read production secrets or manage production
+  workloads.
 
 No GitHub repository variables are required for review apps when `.controlplane/controlplane.yml`
 has exactly one review app entry with `match_if_app_name_starts_with: true` and
@@ -422,9 +422,9 @@ The generated flow uses these defaults:
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
   requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
   collaborator;
-- fork pull requests cannot deploy via the `pull_request` event because the workflow's same-repository `if:`
-  condition explicitly skips fork-originated runs, and GitHub also withholds repository secrets from fork
-  `pull_request` runs as a platform-level safeguard;
+- fork pull requests cannot deploy via the generated `pull_request` path because the workflow's same-repository `if:`
+  condition explicitly skips fork-originated runs. GitHub's default secret handling also withholds repository secrets from
+  fork `pull_request` runs, but repository settings can change that behavior, so keep the workflow guard in place;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
@@ -501,7 +501,7 @@ dependency access, and never use a personal SSH key.
 `cpflow-deploy-review-app.yml`
 
 - Creates a review app when someone comments `+review-app-deploy`.
-- Also supports manual workflow dispatch by a repository collaborator.
+- Also supports manual workflow dispatch by a repository collaborator for trusted base-repository refs.
 - Redeploys an existing review app automatically on later PR pushes.
 - Creates a GitHub deployment and comments with the review URL and logs.
 - Leaves PR pushes alone until the first review app is explicitly requested, which keeps demo-app costs down.
@@ -510,8 +510,8 @@ dependency access, and never use a personal SSH key.
   [Enable Capacity AI for Demo and Starter Staging Apps](tips.md#enable-capacity-ai-for-demo-and-starter-staging-apps).
 - Accepts `+review-app-deploy` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`).
 - Skips fork-based PR deploys because the workflow builds Docker images with repository secrets. A trusted comment on a
-  fork PR still does not deploy the fork head; move the change to a branch in the base repository if it needs a review
-  app.
+  fork PR still does not deploy the fork head, and manual dispatch should target only a trusted base-repository ref; move
+  the change to a branch in the base repository if it needs a review app.
 
 `cpflow-delete-review-app.yml`
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -14,8 +14,8 @@ For public repositories, review apps are intentionally limited to branches in th
 receive help comments, but generated deploy workflows skip fork heads because review-app deployment builds Docker images
 with repository secrets. The skip is enforced by complementary guards on different trigger axes; see
 [Review app security for repositories with external contributors](#review-app-security-for-repositories-with-external-contributors)
-before customizing these workflows. If a forked change needs a review app, a maintainer should first move the change into
-a trusted branch in the base repository or otherwise review it through a separate, disposable environment.
+before customizing these workflows. If a forked change needs a review app, a maintainer should first review the code and
+move the change into a trusted branch in the base repository.
 
 ## Quick Start
 
@@ -419,12 +419,12 @@ and policy templates applied by `cpflow setup-app` at first deploy with `CPLN_TO
 pull request being deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even
 when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
 the code executes inside the review app workload and can read any secrets mounted into the workload environment.
-`CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the container. Control
-Plane's workload identity mechanism injects a separate workload-scoped `CPLN_TOKEN` into the container at runtime when
-the workload has an identity bound, which is the default `setup-app` behavior; PR code can use it to reveal any secret
-that identity is permitted to access. Workloads created with `skip_secrets_setup` have no identity and therefore no
-injected `CPLN_TOKEN`, but they may still have secrets mounted directly. This is why workload-mounted secrets must remain
-disposable and the review app identity must be scoped to minimum permissions.
+`CPLN_TOKEN_STAGING` is also exported as `CPLN_TOKEN` for later runner shell steps after the generated setup action runs,
+so PR-controlled `release_script` and hook commands can read the staging token directly while they execute on the runner.
+Inside the Control Plane workload, a separate runtime `CPLN_TOKEN` is available only when the workload spec has an
+`identityLink`; `skip_secrets_setup` skips automatic identity creation and binding, but templates can still attach an
+identity. Do not treat `skip_secrets_setup` as a token-removal control. This is why workload-mounted secrets and the
+staging service-account token must remain disposable and scoped to minimum permissions.
 
 The generated flow uses these defaults:
 
@@ -437,14 +437,18 @@ The generated flow uses these defaults:
   condition explicitly skips fork-originated runs. For `issue_comment` events, the caller `if:` restricts commands to
   trusted author associations (`OWNER`, `MEMBER`, `COLLABORATOR`) but does not check fork status; the fork check for
   comment events is enforced inside the reusable workflow's source-validation step. These complementary guards cover
-  different axes, so preserve both. GitHub also withholds repository secrets from fork `pull_request` runs, but not from
-  `issue_comment` runs, which execute with base-repository secret access. Keep the workflow guards in place because the
-  workflow builds Docker images with repository secrets;
+  different axes, so preserve both. A trusted commenter can comment on a fork PR and pass the caller's
+  `author_association` check; the reusable workflow's source-validation step is what blocks that fork head from being
+  deployed. Removing either guard opens a path to deploy untrusted code with repository-secret access. GitHub also
+  withholds repository secrets from fork `pull_request` runs, but not from `issue_comment` runs, which execute with
+  base-repository secret access. Keep the workflow guards in place because the workflow builds Docker images with
+  repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
-  so the staging token is available for teardown, and it does not require a trusted commenter. `pull_request_target` also
-  runs with base-repository `GITHUB_TOKEN` permissions, which may include write access unless restricted; if you customize
-  this workflow, pin `permissions:` to the minimum required;
+  so the staging token is available for teardown, and it does not require a trusted commenter. The generated
+  `cpflow-delete-review-app.yml` pins `GITHUB_TOKEN` permissions to the minimum it needs (`contents: read`,
+  `issues: write`, `pull-requests: write`); if you customize this workflow, preserve that `permissions:` block because
+  omitting it can fall back to broader repository defaults;
 - manual workflow dispatch by a repository collaborator can also delete a review app without a `+review-app-delete`
   comment, and does not require a trusted commenter;
 - trusted comments on fork PRs still do not deploy the fork head; the workflow posts no PR comment in this case. The
@@ -460,15 +464,20 @@ generated staging/review org and make that token disposable and unable to access
 
 The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
 PR review apps. The generated `cpflow-delete-control-plane-app` composite action script refuses to call `cpflow delete`
-on any app whose name does not match the review-app prefix. This is a shell-level guard, not a token policy; use a scoped
-staging service account so the token itself is limited to review/staging operations. A configured `hooks.pre_deletion`
+on any app whose name does not match the review-app prefix. This shell-level guard is effective because the delete
+workflow checks out base-branch code, not PR or fork code. If you customize this workflow, never check out PR or fork code
+in the same job as the delete step; doing so could let a PR replace the guard script itself. This is still not a token
+policy, so use a scoped staging service account limited to review/staging operations. A configured `hooks.pre_deletion`
 command still runs through the latest PR-built image on all delete paths: PR-close teardown, `+review-app-delete`
 comments, manual dispatch, and scheduled cleanup. Review-app credentials must remain disposable even during deletion.
 
 If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
 fork-controlled ref to `actions/checkout`, `git fetch`, `git merge`, `git cherry-pick`, or any other step that fetches,
 materializes, or executes the ref. Those operations run untrusted fork code with repository secret access. Referencing the
-SHA as an opaque identifier for deployment status updates, comments, or API calls is safe.
+SHA as an opaque identifier for deployment status updates, comments, or API calls is safe because SHA values are hex-only
+and cannot contain shell metacharacters. Do not apply that reasoning to other PR event fields such as `head.ref` or
+`head.label`; pass user-controlled strings through environment variables instead of interpolating them directly into
+`run:` steps.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For repositories with external contributors, keep review-app credentials and runtime values disposable:
@@ -534,9 +543,10 @@ deploy key scoped to the minimum private dependency access, and never use a pers
 
 `cpflow-deploy-review-app.yml`
 
-- Creates a review app when someone comments `+review-app-deploy`.
-- Also supports manual workflow dispatch by a repository collaborator. Provide the PR number; the workflow rejects fork
-  PRs at runtime.
+- Creates a review app when someone comments `+review-app-deploy` or via manual workflow dispatch by a repository
+  collaborator.
+- For manual dispatch, provide the PR number; the workflow rejects fork PRs at runtime because it builds Docker images
+  with repository secrets.
 - Redeploys an existing review app automatically on later PR pushes.
 - Creates a GitHub deployment and comments with the review URL and logs.
 - Leaves PR pushes alone until the first review app is explicitly requested, which keeps demo-app costs down.

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -408,17 +408,18 @@ Advanced optional repository variables:
 - `CPLN_CLI_VERSION`: pin only when Control Plane CLI compatibility requires it.
 - `CPFLOW_VERSION`: pin a published RubyGems version only when intentionally overriding the default build-from-ref behavior.
 
-## Review app security for public repositories
+## Review app security for repositories with external contributors
 
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
 Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
 `hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
 deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even when the hook
 command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime the code
-executes with the review app's Control Plane workload identity token and can read any secrets mounted into the workload
-environment. `CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the
-container. This is why workload-mounted secrets must remain disposable and the review app identity must be scoped to
-minimum permissions.
+executes inside the review app workload and can read any secrets mounted into the workload environment.
+`CPLN_TOKEN_STAGING` is a GitHub Actions secret that stays on the runner and is not injected into the container. Control
+Plane's workload identity mechanism still injects a separate workload-scoped `CPLN_TOKEN` into the container at runtime;
+PR code can use it to reveal any secret that identity is permitted to access. This is why workload-mounted secrets must
+remain disposable and the review app identity must be scoped to minimum permissions.
 
 The generated flow uses these defaults:
 
@@ -460,17 +461,20 @@ repository secret access. Referencing the SHA for other purposes, such as deploy
 calls, is safe.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
-For public repositories, keep review-app credentials and runtime values disposable:
+For repositories with external contributors, keep review-app credentials and runtime values disposable:
 
 - do not mount production secrets, staging customer data, package-publishing tokens, payment keys, or monitoring tokens
   into review apps;
-- do not use `DOCKER_BUILD_SSH_KEY` with a long-lived personal key or broad deploy key; restrict it to a read-only,
-  revocable deploy key scoped to the minimum private dependency access;
+- do not use `DOCKER_BUILD_SSH_KEY` with a long-lived personal key or broad deploy key; see
+  [Docker Builds with Private Dependencies](#docker-builds-with-private-dependencies) for the minimum-access deploy-key
+  requirements;
 - do not use broad Control Plane `superusers` tokens for review-app CI; use a review/staging service account scoped only to
   review/staging CI operations;
 - keep review databases, Redis instances, object stores, and renderer credentials separate from staging and production;
 - rotate any credential that may have been exposed to a malicious review-app build;
-- use scheduled cleanup so stale review apps stop consuming compute and secrets access.
+- use scheduled cleanup so stale review apps stop consuming compute and secrets access. Cleanup deletes apps through
+  `cpflow delete`, so any configured `hooks.pre_deletion` still runs through the latest PR-built image; review-app
+  credentials must remain disposable for this path too.
 
 Secret indirection such as `cpln://secret/...` protects values in Control Plane configuration. It does not protect a
 value after that secret is mounted into a workload that runs pull request code. See

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -425,12 +425,14 @@ The generated flow uses these defaults:
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
   condition explicitly skips fork-originated runs. For `issue_comment` events, the fork check is enforced inside the
   reusable workflow's source-validation step rather than the `if:`; that internal check is the sole fork guard for
-  comment events. GitHub also withholds repository secrets from fork `pull_request` runs, but keep the workflow guards in
-  place because the workflow builds
+  comment events. GitHub also withholds repository secrets from fork `pull_request` runs, but not from `issue_comment`
+  runs, which execute with base-repository secret access. Keep the workflow guards in place because the workflow builds
   Docker images with repository secrets;
 - `+review-app-deploy` and `+review-app-delete` comment commands are accepted only from trusted commenters;
 - review apps are also deleted automatically when the pull request closes; that PR-close path uses `pull_request_target`
   so the staging token is available for teardown, and it does not require a trusted commenter;
+- manual workflow dispatch by a repository collaborator can also delete a review app without a `+review-app-delete`
+  comment, and does not require a trusted commenter;
 - trusted comments on fork PRs still do not deploy the fork head; review the code carefully, then move the change to a
   branch in the base repository if it needs a generated review app. That build will run with repository-secret access;
 - production promotion is manual and uses production environment secrets separately from review and staging.
@@ -441,9 +443,10 @@ review-app org or token requires workflow/configuration customization; otherwise
 generated staging/review org and make that token disposable and unable to access production resources.
 
 The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
-PR review apps. The workflow can only call `cpflow delete` on an app whose name matches the review-app prefix, but a
-configured `hooks.pre_deletion` command still runs through the latest PR-built image, so review-app credentials must
-remain disposable even during deletion.
+PR review apps. The generated workflow script refuses to call `cpflow delete` on any app whose name does not match the
+review-app prefix. This is a shell-level guard, not a token policy; use a scoped staging service account so the token
+itself is limited to review/staging operations. A configured `hooks.pre_deletion` command still runs through the latest
+PR-built image, so review-app credentials must remain disposable even during deletion.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For public repositories, keep review-app credentials and runtime values disposable:
@@ -521,7 +524,7 @@ dependency access, and never use a personal SSH key.
 `cpflow-delete-review-app.yml`
 
 - Deletes the review app on `+review-app-delete`.
-- Also supports manual workflow dispatch by a repository collaborator.
+- Also supports manual workflow dispatch by a repository collaborator without requiring a trusted-commenter command.
 - Also deletes it automatically when the pull request closes through a `pull_request_target` event, so repository secrets
   are available for teardown.
 - Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`); manual dispatch and

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -415,7 +415,7 @@ Dockerfile, package scripts, Rails initializers, server-rendering code, applicat
 `hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
 deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even when the hook
 command comes from the base-branch config, so a PR author can embed malicious code in the image that executes with
-`CPLN_TOKEN_STAGING` present during deletion or scheduled cleanup.
+mounted review-app secrets and runtime values during deletion or scheduled cleanup.
 
 The generated flow uses these defaults:
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -170,8 +170,9 @@ Important points:
 
 For a normal generated review-app setup, configure one repository secret:
 
-- `CPLN_TOKEN_STAGING`: token for the staging/review Control Plane org. For public repositories, prefer a tightly scoped
-  token that cannot read production secrets or manage production workloads.
+- `CPLN_TOKEN_STAGING`: token for the staging/review Control Plane org. For public repositories, generate it from a
+  Control Plane service account whose policies only allow review/staging CI operations; it must not read production
+  secrets or manage production workloads.
 
 No GitHub repository variables are required for review apps when `.controlplane/controlplane.yml`
 has exactly one review app entry with `match_if_app_name_starts_with: true` and
@@ -388,8 +389,9 @@ Recommended org layout:
 
 - keep review apps and staging in a staging org that developers can access
 - keep production in a separate org with tighter access controls
-- for public repositories, use a tightly scoped staging/review token by default; use a dedicated review-app org only
-  if you also customize the generated workflow/configuration to target that org separately
+- for public repositories, use a staging/review token generated from a service account whose policies only allow
+  review/staging CI operations by default; use a dedicated review-app org only if you also customize the generated
+  workflow/configuration to target that org separately
 
 Optional repository secret for private dependency builds:
 
@@ -412,10 +414,12 @@ dependency access, and never use a personal SSH key.
 
 ## Review App Security For Public Repositories
 
-Review-app deployment executes pull request code. Even when the workflow itself is trusted, the Dockerfile, package
-scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
+Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
+Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
 `hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
-deployed.
+deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, so malicious image
+content can execute during review-app deletion or scheduled cleanup even when the hook command comes from the base
+branch config.
 
 The generated flow uses these defaults:
 
@@ -424,6 +428,8 @@ The generated flow uses these defaults:
 - fork pull requests cannot deploy via the `pull_request` event because GitHub withholds repository secrets from
   fork-originated runs; the workflow's same-repository `if:` condition is an additional explicit guard;
 - `+review-app-deploy` and `+review-app-delete` are accepted only from trusted commenters;
+- review apps are also deleted automatically when the pull request closes; that PR-close path does not require a trusted
+  commenter;
 - trusted comments on fork PRs still do not deploy the fork head; move the change to a branch in the base repository if
   it needs a generated review app;
 - production promotion is manual and uses production environment secrets separately from review and staging.

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -462,8 +462,8 @@ The PR-close teardown workflow runs trusted base-branch workflow code with repos
 PR review apps. The generated `cpflow-delete-control-plane-app` composite action script refuses to call `cpflow delete`
 on any app whose name does not match the review-app prefix. This is a shell-level guard, not a token policy; use a scoped
 staging service account so the token itself is limited to review/staging operations. A configured `hooks.pre_deletion`
-command still runs through the latest PR-built image, so review-app credentials must remain disposable even during
-deletion.
+command still runs through the latest PR-built image on all delete paths: PR-close teardown, `+review-app-delete`
+comments, manual dispatch, and scheduled cleanup. Review-app credentials must remain disposable even during deletion.
 
 If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
 fork-controlled ref to `actions/checkout`, `git fetch`, `git merge`, `git cherry-pick`, or any other step that fetches,
@@ -554,7 +554,8 @@ deploy key scoped to the minimum private dependency access, and never use a pers
 - Deletes the review app on `+review-app-delete`.
 - Also supports manual workflow dispatch by a repository collaborator without requiring a trusted-commenter command.
 - Also deletes it automatically when the pull request closes through a `pull_request_target` event, so repository secrets
-  are available for teardown.
+  are available for teardown; `hooks.pre_deletion` still executes through the latest PR-built image on this path, so
+  review-app credentials must remain disposable.
 - Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`); manual dispatch and
   automatic PR-close teardown do not require a trusted commenter.
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -413,11 +413,9 @@ Advanced optional repository variables:
 Review-app deployment and teardown can execute pull request code. Even when the workflow itself is trusted, the
 Dockerfile, package scripts, Rails initializers, server-rendering code, application runtime, and any `release_script` or
 `hooks.post_creation` defined in the PR's `.controlplane/controlplane.yml` can all be changed by the pull request being
-deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, so malicious image
-content can execute during review-app deletion or scheduled cleanup even when the hook command comes from the base
-branch config.
-For example, a PR author can embed code that runs during `hooks.pre_deletion`
-inside the PR-built image while `CPLN_TOKEN_STAGING` is present during teardown.
+deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even when the hook
+command comes from the base-branch config, so a PR author can embed malicious code in the image that executes with
+`CPLN_TOKEN_STAGING` present during deletion or scheduled cleanup.
 
 The generated flow uses these defaults:
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -419,20 +419,24 @@ and policy templates applied by `cpflow setup-app` at first deploy with `CPLN_TO
 pull request being deployed. Teardown can also run a `hooks.pre_deletion` command through the latest PR-built image, even
 when the hook command comes from the base-branch config. A PR author can embed malicious code in that image; at runtime
 the code executes inside the review app workload and can read any secrets mounted into the workload environment.
-The generated setup action also exports `CPLN_TOKEN_STAGING` as `CPLN_TOKEN` for later runner shell steps, so keep any
-custom runner steps after setup trusted. PR-controlled `release_script` and hook commands normally run through
-`cpflow run` in the latest image, not as runner shell, so they do not read that runner token directly unless a custom
-workflow passes a local token through. Inside the Control Plane workload, a separate runtime `CPLN_TOKEN` is available
-only when the workload spec has an `identityLink`; `skip_secrets_setup` skips automatic identity creation and binding,
-but templates can still attach an identity. Do not treat `skip_secrets_setup` as a token-removal control. This is why
+The generated setup action also exports `CPLN_TOKEN_STAGING` as `CPLN_TOKEN` to `$GITHUB_ENV` for later runner shell
+steps, so keep any custom runner steps after setup trusted. PR-controlled `release_script` and hook commands normally run
+through `cpflow run` in remote Control Plane containers from the latest image, not as runner shell steps, so they do not
+read that runner token directly unless a custom workflow passes a local token through. Inside the Control Plane workload,
+a separate runtime `CPLN_TOKEN` is available only when the workload spec has an `identityLink`; `skip_secrets_setup`
+skips automatic identity creation and binding, but templates can still attach an identity. Because `cpflow setup-app`
+reads `controlplane.yml` from the PR checkout, a PR can also set `skip_secrets_setup: false` or omit it to re-enable
+automatic identity binding unless the trusted workflow passes `--skip-secrets-setup` as a CLI flag. Do not treat
+`skip_secrets_setup` in `controlplane.yml` as a token-removal control or reliable security boundary. This is why
 workload-mounted secrets and the staging service-account token must remain disposable and scoped to minimum permissions.
 
 The generated flow uses these defaults:
 
 - same-repository pull requests can update existing review apps automatically on each push; creating the first review app
-  requires either a `+review-app-deploy` comment from a trusted commenter or a manual workflow dispatch by a repository
-  collaborator. The trusted-commenter gate applies to every `+review-app-deploy` comment, whether or not a review app
-  already exists. Later pushes to a base-repository branch PR redeploy automatically without another approval because the
+  requires either a `+review-app-deploy` comment from a trusted commenter (`OWNER`, `MEMBER`, or `COLLABORATOR`
+  association, regardless of permission level) or a manual workflow dispatch by a repository collaborator with write
+  access. The trusted-commenter gate applies to every `+review-app-deploy` comment, whether or not a review app already
+  exists. Later pushes to a base-repository branch PR redeploy automatically without another approval because the
   auto-push path (`pull_request` event) has no trusted-commenter check; only the `issue_comment` path does;
 - fork pull requests cannot deploy via the generated `pull_request` path because the caller workflow's job-level `if:`
   condition explicitly skips fork-originated runs. For `issue_comment` events, the caller `if:` restricts commands to
@@ -465,20 +469,22 @@ generated staging/review org and make that token disposable and unable to access
 
 The PR-close teardown workflow runs trusted base-branch workflow code with repository secret access so it can delete fork
 PR review apps. The generated `cpflow-delete-control-plane-app` composite action script refuses to call `cpflow delete`
-on any app whose name does not match the review-app prefix. This shell-level guard is effective because the delete
-workflow checks out base-branch code, not PR or fork code. If you customize this workflow, never check out PR or fork code
-in the same job as the delete step; doing so could let a PR replace the guard script itself. This is still not a token
-policy, so use a scoped staging service account limited to review/staging operations. A configured `hooks.pre_deletion`
-command still runs through the latest PR-built image on all delete paths: PR-close teardown, `+review-app-delete`
-comments, manual dispatch, and scheduled cleanup. Review-app credentials must remain disposable even during deletion.
+on any app whose name does not match the review-app prefix. This shell-level guard is effective because the generated
+delete workflow checks out base/default-branch code, not PR or fork code: its repository checkout has no `ref:` override,
+so `pull_request_target` runs use the base branch. If you customize this workflow, never check out PR or fork code in the
+same job as the delete step; doing so could let a PR replace the guard script itself and would also make
+`hooks.pre_deletion` come from the PR's `controlplane.yml`. This is still not a token policy, so use a scoped staging
+service account limited to review/staging operations. A configured `hooks.pre_deletion` command still runs through the
+latest PR-built image on all delete paths: PR-close teardown, `+review-app-delete` comments, manual dispatch, and
+scheduled cleanup. Review-app credentials must remain disposable even during deletion.
 
 If you customize the generated `pull_request_target` workflow, never pass `github.event.pull_request.head.sha` or another
 fork-controlled ref to `actions/checkout`, `git fetch`, `git merge`, `git cherry-pick`, or any other step that fetches,
 materializes, or executes the ref. Those operations run untrusted fork code with repository secret access. Referencing the
 SHA as an opaque identifier for deployment status updates, comments, or API calls is safe because SHA values are hex-only
-and cannot contain shell metacharacters. Do not apply that reasoning to other PR event fields such as `head.ref` or
-`head.label`; pass user-controlled strings through environment variables instead of interpolating them directly into
-`run:` steps.
+and cannot contain shell metacharacters. Do not apply that reasoning to other attacker-controlled PR event fields such as
+`head.ref`, `head.label`, `title`, `body`, `head.repo.full_name`, or repository descriptions; pass user-controlled strings
+through environment variables instead of interpolating them directly into `run:` steps.
 
 These defaults protect repository secrets from direct fork PR execution, but they do not make deployed PR code harmless.
 For repositories with external contributors, keep review-app credentials and runtime values disposable:

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -26,10 +26,9 @@ Control Plane org, keep review-app secret dictionaries separate from persistent 
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
-same-repository PRs. The caller workflow and reusable workflow each guard a distinct trigger axis: the caller `if:`
-blocks fork-originated `pull_request` runs, while the reusable workflow's source-validation step is the fork guard for
-`issue_comment` and `workflow_dispatch` runs. Removing either guard leaves one or more trigger paths unprotected; see
-[Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors).
+same-repository PRs. Each generated trigger path has its own fork guard; see
+[Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors)
+for details. Removing any guard leaves one or more trigger paths unprotected.
 For repositories with external contributors, treat the entire review-app identity and policy scope as untrusted and ensure
 the staging token cannot reach sensitive resources even if the PR changes the template.
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -26,8 +26,9 @@ Control Plane org, keep review-app secret dictionaries separate from persistent 
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
-same-repository PRs. Generated fork PR deployments stay blocked only while the complementary caller and reusable-workflow
-guards are both preserved; see
+same-repository PRs. The caller workflow and reusable workflow each guard a distinct trigger axis: the caller `if:`
+blocks fork-originated `pull_request` runs, while the reusable workflow's source-validation step is the fork guard for
+`issue_comment` and `workflow_dispatch` runs. Removing either guard leaves one or more trigger paths unprotected; see
 [Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors).
 For repositories with external contributors, treat the entire review-app identity and policy scope as untrusted and ensure
 the staging token cannot reach sensitive resources even if the PR changes the template.

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -23,6 +23,11 @@ Avoid pointing review-app templates at shared production secret dictionaries. If
 Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets, and restrict the Control
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
+Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time. For
+public repositories, either lock those templates to the base branch in the deploy workflow, or treat the entire review-app
+identity and policy scope as untrusted and ensure the staging token cannot reach sensitive resources even if the PR changes
+the template.
+
 For setting up secrets, you'll need:
 
 - **Org-level Secret:** This is where the values will be stored.

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -23,9 +23,10 @@ Avoid pointing review-app templates at shared production secret dictionaries. If
 Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets, and restrict the Control
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
-Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time. For
-public repositories, treat the entire review-app identity and policy scope as untrusted and ensure the staging token cannot
-reach sensitive resources even if the PR changes the template.
+Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
+same-repository PRs; fork PRs cannot deploy through the generated workflow. For public repositories, treat the entire
+review-app identity and policy scope as untrusted and ensure the staging token cannot reach sensitive resources even if
+the PR changes the template.
 
 For setting up secrets, you'll need:
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -9,11 +9,11 @@ For your "review apps," it is convenient to have simple ENVs stored in plain tex
 keep some ENVs, like the Rails' `SECRET_KEY_BASE`, out of your source code. For staging and production apps, you will
 set these values directly at the GVC or workload levels, so none of these ENV values are committed to the source code.
 
-Review apps run application code from pull requests. For public repositories, do not put sensitive production or
-long-lived staging secrets in review apps. A secret reference such as `cpln://secret/...` protects the value while it is
-stored in Control Plane configuration, but the value becomes readable by application code after it is mounted into the
-review-app workload. Use generated dummy values, disposable databases, review-only renderer credentials, and revocable
-service tokens for review apps.
+Review apps run application code from pull requests. For repositories with external contributors, do not put sensitive
+production or long-lived staging secrets in review apps. A secret reference such as `cpln://secret/...` protects the
+value while it is stored in Control Plane configuration, but the value becomes readable by application code after it is
+mounted into the review-app workload. Use generated dummy values, disposable databases, review-only renderer credentials,
+and revocable service tokens for review apps.
 
 For storing ENVs in the source code, we can use a level of indirection so that you can store an ENV value in your source
 code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then have the secret value stored at the org
@@ -24,9 +24,10 @@ Control Plane org, keep review-app secret dictionaries separate from persistent 
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
-same-repository PRs; fork PRs cannot deploy through the generated workflow. For public repositories, treat the entire
-review-app identity and policy scope as untrusted and ensure the staging token cannot reach sensitive resources even if
-the PR changes the template.
+same-repository PRs. Generated fork PR deployments stay blocked only while the complementary caller and reusable-workflow
+guards are both preserved; see [CI Automation - Review app security](./ci-automation.md#review-app-security-for-repositories-with-external-contributors).
+For repositories with external contributors, treat the entire review-app identity and policy scope as untrusted and ensure
+the staging token cannot reach sensitive resources even if the PR changes the template.
 
 For setting up secrets, you'll need:
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -24,9 +24,8 @@ Control Plane org, keep review-app secret dictionaries separate from persistent 
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time. For
-public repositories, either lock those templates to the base branch in the deploy workflow, or treat the entire review-app
-identity and policy scope as untrusted and ensure the staging token cannot reach sensitive resources even if the PR changes
-the template.
+public repositories, treat the entire review-app identity and policy scope as untrusted and ensure the staging token cannot
+reach sensitive resources even if the PR changes the template.
 
 For setting up secrets, you'll need:
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -25,10 +25,11 @@ Avoid pointing review-app templates at shared production secret dictionaries. If
 Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets, and restrict the Control
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
-Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
-same-repository PRs and applied by `cpflow setup-app` at first review-app creation. A PR can modify these templates to
-bind the review workload's identity to any secret dictionary, including staging ones. Each generated trigger path has its
-own fork guard; see
+Review-app identity and policy templates in `.controlplane/templates/`, plus any `shared_secret_grants` in
+`controlplane.yml`, are read from the PR branch at deploy time for same-repository PRs. `cpflow setup-app` applies
+templates at first review-app creation, and `cpflow deploy-image` can bind configured shared-secret policies on later
+redeploys. A PR can modify either path to bind the review workload's identity to any secret dictionary, including staging
+ones. Each generated trigger path has its own fork guard; see
 [Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors)
 for details. Removing any guard leaves one or more trigger paths unprotected.
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -9,6 +9,8 @@ For your "review apps," it is convenient to have simple ENVs stored in plain tex
 keep some ENVs, like the Rails' `SECRET_KEY_BASE`, out of your source code. For staging and production apps, you will
 set these values directly at the GVC or workload levels, so none of these ENV values are committed to the source code.
 
+## Review app secrets
+
 Review apps run application code from pull requests. For repositories with external contributors, do not put sensitive
 production or long-lived staging secrets in review apps. A secret reference such as `cpln://secret/...` protects the
 value while it is stored in Control Plane configuration, but the value becomes readable by application code after it is
@@ -25,7 +27,8 @@ Plane identity bound to review workloads so it can reveal only the values those 
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
 same-repository PRs. Generated fork PR deployments stay blocked only while the complementary caller and reusable-workflow
-guards are both preserved; see [CI Automation - Review app security](./ci-automation.md#review-app-security-for-repositories-with-external-contributors).
+guards are both preserved; see
+[Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors).
 For repositories with external contributors, treat the entire review-app identity and policy scope as untrusted and ensure
 the staging token cannot reach sensitive resources even if the PR changes the template.
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -20,8 +20,8 @@ code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then hav
 level, which applies to your GVCs mapped to that org.
 
 Avoid pointing review-app templates at shared production secret dictionaries. If staging and review apps live in the same
-Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets and scope identities so
-temporary review workloads can reveal only the values they need.
+Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets, and restrict the Control
+Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 For setting up secrets, you'll need:
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -9,9 +9,19 @@ For your "review apps," it is convenient to have simple ENVs stored in plain tex
 keep some ENVs, like the Rails' `SECRET_KEY_BASE`, out of your source code. For staging and production apps, you will
 set these values directly at the GVC or workload levels, so none of these ENV values are committed to the source code.
 
+Review apps run application code from pull requests. For public repositories, do not put sensitive production or
+long-lived staging secrets in review apps. A secret reference such as `cpln://secret/...` protects the value while it is
+stored in Control Plane configuration, but the value becomes readable by application code after it is mounted into the
+review-app workload. Use generated dummy values, disposable databases, review-only renderer credentials, and revocable
+service tokens for review apps.
+
 For storing ENVs in the source code, we can use a level of indirection so that you can store an ENV value in your source
 code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then have the secret value stored at the org
 level, which applies to your GVCs mapped to that org.
+
+Avoid pointing review-app templates at shared production secret dictionaries. If staging and review apps live in the same
+Control Plane org, keep review-app secret dictionaries separate from persistent staging secrets and scope identities so
+temporary review workloads can reveal only the values they need.
 
 For setting up secrets, you'll need:
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -26,9 +26,12 @@ Control Plane org, keep review-app secret dictionaries separate from persistent 
 Plane identity bound to review workloads so it can reveal only the values those workloads need.
 
 Review-app identity and policy templates in `.controlplane/templates/` are read from the PR branch at deploy time for
-same-repository PRs. Each generated trigger path has its own fork guard; see
+same-repository PRs and applied by `cpflow setup-app` at first review-app creation. A PR can modify these templates to
+bind the review workload's identity to any secret dictionary, including staging ones. Each generated trigger path has its
+own fork guard; see
 [Review app security for repositories with external contributors](./ci-automation.md#review-app-security-for-repositories-with-external-contributors)
 for details. Removing any guard leaves one or more trigger paths unprotected.
+
 For repositories with external contributors, treat the entire review-app identity and policy scope as untrusted and ensure
 the staging token cannot reach sensitive resources even if the PR changes the template.
 


### PR DESCRIPTION
## Summary

- document that generated review-app workflows skip fork PR heads in public repositories
- clarify that trusted `+review-app-deploy` comments still require a branch in the base repository
- add review-app secret guidance for disposable credentials, scoped Control Plane tokens, SSH deploy keys, and `cpln://secret` runtime exposure

## Verification

- `git diff --check`
- `script/check_cpln_links`
- `script/check_command_docs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, workflow, or secret configuration changes.
> 
> **Overview**
> **Documentation-only** updates to `docs/ci-automation.md` and `docs/secrets-and-env-values.md` that spell out review-app security for public and open-source repos—no workflow or generator changes.
> 
> `ci-automation.md` now states upfront that review deploys only run for **base-repo branches** (fork PRs get help but not deploys because builds use repo secrets), and that maintainers must land fork work on a trusted branch for a review app. It expands **`CPLN_TOKEN_STAGING`** guidance (prefer a review/staging token that cannot touch production), **`DOCKER_BUILD_SSH_KEY`** cautions (minimal read-only deploy keys), and a new **Review App Security For Public Repositories** section covering trusted commenters, fork skips, disposable credentials, scoped tokens, separate data stores, rotation, and cleanup. Workflow descriptions and the demo rollout checklist add matching bullets (including verifying staging tokens cannot reach production).
> 
> `secrets-and-env-values.md` adds that review apps execute **PR code**, so `cpln://secret/...` does not protect values once mounted, and recommends dummy/disposable/revocable review credentials plus **separate secret dictionaries** from production or long-lived staging when orgs are shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f553d9a9159db519a2c111234b2877f0f95e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD automation documentation with enhanced guidance for review-app deployments on public repositories, including security considerations and fork-PR handling.
  * Added comprehensive secrets management best practices for review apps, emphasizing the use of protected secret references and scoped credentials to prevent production access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->