### PR TITLE
Clarify production environment secret setup

### DIFF
--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -222,6 +222,7 @@ environment secret with:
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production
+# Paste the token value when prompted.
 gh secret list --repo OWNER/REPO --env production
 ```
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -219,6 +219,8 @@ If promotion fails in the `Validate production token` step with
 check the environment scope first. A repository or organization secret with the
 same name is not enough for this reusable workflow. Create or verify the
 environment secret with:
+You need permission to manage repository environments and secrets to run these
+commands.
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -214,6 +214,17 @@ needs. They do not use `secrets: inherit`; the production token is supplied by
 the protected `production` Environment after approval, not forwarded from a
 repository secret.
 
+If promotion fails in the `Validate production token` step with
+`CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
+check the environment scope first. A repository or organization secret with the
+same name is not enough for this reusable workflow. Create or verify the
+environment secret with:
+
+```sh
+gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production
+gh secret list --repo OWNER/REPO --env production
+```
+
 ## First-Time Control Plane Bootstrap
 
 GitHub settings only give the workflows permission to act. They do not create

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -78,6 +78,7 @@ verify the environment secret with:
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production
+# Paste the token value when prompted.
 gh secret list --repo OWNER/REPO --env production
 ```
 

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -75,6 +75,8 @@ If the promotion workflow fails with
 the token is missing from the environment scope. Creating the same secret at the
 repository or organization level will not satisfy this workflow. Create or
 verify the environment secret with:
+You need permission to manage repository environments and secrets to run these
+commands.
 
 ```sh
 gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -70,6 +70,17 @@ prevent self-review. The generated promotion wrapper passes only the staging
 token from repository secrets; GitHub injects `CPLN_TOKEN_PRODUCTION` only after
 the environment approval gate passes.
 
+If the promotion workflow fails with
+`CPLN_TOKEN_PRODUCTION is not set. Add it as a secret on the 'production' GitHub Environment.`,
+the token is missing from the environment scope. Creating the same secret at the
+repository or organization level will not satisfy this workflow. Create or
+verify the environment secret with:
+
+```sh
+gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production
+gh secret list --repo OWNER/REPO --env production
+```
+
 Before the first promotion, bootstrap the production app the same way in the
 production org, using production-only secrets and values.
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -684,6 +684,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("app secret policy")
       expect(help_md).to include("Add it as a secret on the 'production' GitHub Environment")
       expect(help_md).to include("gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production")
+      expect(help_md).to include("gh secret list --repo OWNER/REPO --env production")
       expect(help_md).not_to include("control_plane_flow_ref")
     end
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -683,6 +683,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("cpflow setup-app -a")
       expect(help_md).to include("app secret policy")
       expect(help_md).to include("Add it as a secret on the 'production' GitHub Environment")
+      expect(help_md).to include("permission to manage repository environments and secrets")
       expect(help_md).to include("gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production")
       expect(help_md).to include("gh secret list --repo OWNER/REPO --env production")
       expect(help_md).not_to include("control_plane_flow_ref")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -682,6 +682,8 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("Before the first staging deploy")
       expect(help_md).to include("cpflow setup-app -a")
       expect(help_md).to include("app secret policy")
+      expect(help_md).to include("Add it as a secret on the 'production' GitHub Environment")
+      expect(help_md).to include("gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production")
       expect(help_md).not_to include("control_plane_flow_ref")
     end
 


### PR DESCRIPTION
## Summary

- Add explicit troubleshooting guidance for the `CPLN_TOKEN_PRODUCTION is not set` promotion failure.
- Clarify that `CPLN_TOKEN_PRODUCTION` must be configured on the protected `production` GitHub Environment, not as a repository or organization secret.
- Add generator spec coverage so generated help keeps the remediation commands.

## Verification

- `git diff --check -- lib/github_flow_templates/.github/cpflow-help.md docs/ci-automation.md spec/command/generate_github_actions_spec.rb`
- `CPLN_ORG=dummy-org bundle exec rspec spec/command/generate_github_actions_spec.rb` (64 examples, 0 failures)
- `/Users/justin/.agents/skills/autoreview/scripts/autoreview --mode local` (clean, no actionable findings)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; no workflow or runtime behavior is modified.
> 
> **Overview**
> Adds **troubleshooting** for promotion failures when `Validate production token` reports `CPLN_TOKEN_PRODUCTION is not set`, in both `docs/ci-automation.md` and the generated template `lib/github_flow_templates/.github/cpflow-help.md`.
> 
> The new text states that **repository or organization secrets with the same name do not satisfy** the reusable promotion workflow—`CPLN_TOKEN_PRODUCTION` must live on the protected **`production` GitHub Environment**—and gives **`gh secret set` / `gh secret list`** examples scoped to `--env production`, plus a note about permissions to manage environment secrets.
> 
> **Generator spec** expectations in `generate_github_actions_spec.rb` were extended so regenerated `.github/cpflow-help.md` keeps the error string, permission note, and remediation commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab9682e6c0b7fb211b7dec327bd4276085f2d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup requirements for configuring the production token as a GitHub Environment-scoped secret with specific commands.
  * Added troubleshooting guidance for promotion workflow failures related to missing or misconfigured production token.

* **Tests**
  * Extended test coverage to verify help documentation includes production token environment secret setup and verification commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->