### PR TITLE
Warn when staging image lacks commit suffix

### DIFF
--- a/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -471,10 +471,13 @@ jobs:
           staging_commit=""
           if [[ "${staging_tag}" == *_* ]]; then
             staging_commit="${staging_tag##*_}"
+          else
+            echo "::warning::Staging image '${staging_image}' did not include a '_<commit>' suffix; production image tag will omit the commit suffix."
           fi
 
           # The workflow-level concurrency group serializes this sequence so two
           # production promotions cannot derive and publish the same next tag.
+          # See the top-level concurrency group: cpflow-promote-staging-to-production.
           latest_number="$(
             cpln image query --org "${CPLN_ORG_PRODUCTION}" --prop "name~${PRODUCTION_APP_NAME}:" --max 0 -o json |
               jq -r --arg prefix "${PRODUCTION_APP_NAME}:" \

--- a/lib/github_flow_templates/.github/workflows/cpflow-promote-staging-to-production.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-promote-staging-to-production.yml
@@ -490,10 +490,13 @@ jobs:
           staging_commit=""
           if [[ "${staging_tag}" == *_* ]]; then
             staging_commit="${staging_tag##*_}"
+          else
+            echo "::warning::Staging image '${staging_image}' did not include a '_<commit>' suffix; production image tag will omit the commit suffix."
           fi
 
           # The workflow-level concurrency group serializes this sequence so two
           # production promotions cannot derive and publish the same next tag.
+          # See the top-level concurrency group: cpflow-promote-staging-to-production.
           latest_number="$(
             cpln image query --org "${CPLN_ORG_PRODUCTION}" --prop "name~${PRODUCTION_APP_NAME}:" --max 0 -o json |
               jq -r --arg prefix "${PRODUCTION_APP_NAME}:" \

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -843,6 +843,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
     it "copies the image currently deployed on staging instead of the newest pushed staging image" do
       contents = reusable_promote_workflow_path.read
+      wrapper = promote_workflow_path.read
 
       expect(contents).to include("id: staging-image")
       expect(contents).to include('CPLN_TOKEN="${CPLN_TOKEN_STAGING}" cpln workload get')
@@ -881,6 +882,10 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include('if [[ "${staging_tag}" == *_* ]]; then')
       expect(contents).to include('staging_commit="${staging_tag##*_}"')
       expect(contents).to include("workflow-level concurrency group serializes this sequence")
+      expect(contents).to include("top-level concurrency group: cpflow-promote-staging-to-production")
+      expect(contents).to include("Staging image '${staging_image}' did not include a '_<commit>' suffix")
+      expect(wrapper).to include("Staging image '${staging_image}' did not include a '_<commit>' suffix")
+      expect(wrapper).to include("top-level concurrency group: cpflow-promote-staging-to-production")
       expect(contents).to include('--prop "name~${PRODUCTION_APP_NAME}:" --max 0')
       expect(contents).to include("Could not determine the next production image number")
       expect(contents).to include('production_image="${PRODUCTION_APP_NAME}:$((latest_number + 1))"')


### PR DESCRIPTION
## Summary

- Warn when a staging image has no '_<commit>' suffix so production tags that omit commit traceability are visible in logs.
- Name the production promotion concurrency group in the copy step comment.
- Cover both generated workflow details in the generator spec.

## Validation

- git diff --check
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |path| YAML.load_file(path); puts path }'
- CPLN_ORG=dummy-test bundle exec rspec spec/command/generate_github_actions_spec.rb
- bundle exec rubocop spec/command/generate_github_actions_spec.rb
- bundle exec rake check_command_docs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds workflow warnings and comments; production tagging behavior when the suffix is missing was already unchanged.
> 
> **Overview**
> The **staging → production** image copy step now emits a **GitHub Actions `::warning::`** when the staging image tag has no `_<commit>` suffix, so promotions that produce production tags **without** commit traceability show up clearly in logs instead of failing silently.
> 
> A short comment in the same step points reviewers at the workflow-level concurrency group **`cpflow-promote-staging-to-production`**, which serializes tag allocation. The same changes are applied to the **checked-in workflow** and the **generator template**.
> 
> Generator specs now assert the warning text and concurrency comment appear in both the **reusable** and **caller wrapper** promote workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea704c3e9828cfb3b4c0eab6593920a1c638251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Promotion workflow now warns when a staging image tag lacks the expected commit suffix and will omit that suffix for the production tag to avoid incorrect tagging.
* **Tests**
  * Promotion workflow tests extended to verify the warning/omission behavior and the workflow’s top-level concurrency grouping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->