### PR TITLE
Handle completed runner jobs before replicas appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed `cpflow run` so short non-interactive runner jobs no longer hang when the Control Plane cron job finishes before a runner replica is visible.** This prevents generated deploy workflows with release-phase commands from waiting until the GitHub Actions job timeout even though the release job already completed successfully.
+
 ## [5.1.0] - 2026-06-02
 
 ### Added

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -466,6 +466,8 @@ timeout 300 cpflow ps:wait -a $APP_NAME
   and also overridden per job through `--cpu` and `--memory`)
 - By default, the job is stopped if it takes longer than 6 hours to finish
   (can be configured though `runner_job_timeout` in `controlplane.yml`)
+- Non-interactive jobs return the Control Plane cron job status even when the job finishes before
+  Control Plane exposes a runner replica to attach logs to
 
 ```sh
 # Opens shell (bash by default).

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -47,6 +47,8 @@ module Command
         and also overridden per job through `--cpu` and `--memory`)
       - By default, the job is stopped if it takes longer than 6 hours to finish
         (can be configured though `runner_job_timeout` in `controlplane.yml`)
+      - Non-interactive jobs return the Control Plane cron job status even when the job finishes before
+        Control Plane exposes a runner replica to attach logs to
     DESC
     EXAMPLES = <<~EX.freeze
       ```sh
@@ -97,7 +99,7 @@ module Command
 
     attr_reader :interactive, :detached, :location, :original_workload, :runner_workload,
                 :default_image, :default_cpu, :default_memory, :job_timeout, :job_history_limit,
-                :container, :job, :replica, :command
+                :container, :job, :replica, :command, :job_completed_before_replica_exit_status
 
     def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       @interactive = config.options[:interactive] || interactive_command?
@@ -129,6 +131,7 @@ module Command
       update_runner_workload
       start_job
       wait_for_replica_for_job
+      exit(job_completed_before_replica_exit_status) if job_completed_before_replica_exit_status
 
       progress.puts
       if interactive
@@ -269,7 +272,20 @@ module Command
         result = cp.fetch_workload_replicas(runner_workload, location: location)
         @replica = result&.dig("items")&.find { |item| item.include?(job) }
 
-        replica || false
+        replica || completed_job_before_replica? || false
+      end
+    end
+
+    def completed_job_before_replica?
+      case current_job_status
+      when "successful"
+        @job_completed_before_replica_exit_status = ExitCode::SUCCESS
+        true
+      when nil, "active", "pending"
+        false
+      else
+        @job_completed_before_replica_exit_status = ExitCode::ERROR_DEFAULT
+        true
       end
     end
 
@@ -505,9 +521,7 @@ module Command
 
     def resolve_job_status # rubocop:disable Metrics/MethodLength
       loop do
-        result = cp.fetch_cron_workload(runner_workload, location: location)
-        job_details = result&.dig("items")&.find { |item| item["id"] == job }
-        status = job_details&.dig("status")
+        status = current_job_status
 
         Shell.debug("JOB STATUS", status)
 
@@ -520,6 +534,12 @@ module Command
           break ExitCode::ERROR_DEFAULT
         end
       end
+    end
+
+    def current_job_status
+      result = cp.fetch_cron_workload(runner_workload, location: location)
+      job_details = result&.dig("items")&.find { |item| item["id"] == job }
+      job_details&.dig("status")
     end
 
     ###########################################

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -3,6 +3,42 @@
 require "spec_helper"
 
 describe Command::Run do
+  describe "#call" do
+    let(:config) do
+      instance_double(
+        Config,
+        app: "test-app",
+        args: ["bin/rails db:migrate"],
+        current: {},
+        location: "aws-us-east-2",
+        options: { interactive: false, detached: false, log_method: 3 }
+      )
+    end
+    let(:cp) { instance_double(Controlplane) }
+    let(:progress) { instance_double(IO, puts: nil) }
+    let(:command) { described_class.new(config) }
+
+    before do
+      allow(config).to receive(:[]).with(:one_off_workload).and_return("rails")
+      allow(command).to receive_messages(cp: cp, progress: progress)
+      allow(cp).to receive(:fetch_workload).with("rails-runner").and_return({})
+      allow(command).to receive(:update_runner_workload)
+      allow(command).to receive(:start_job)
+      allow(command).to receive(:wait_for_replica_for_job) do
+        command.instance_variable_set(:@job_completed_before_replica_exit_status, ExitCode::SUCCESS)
+      end
+      allow(command).to receive(:run_non_interactive)
+    end
+
+    it "exits with the cron job status when the job finishes before a replica is observed" do
+      expect { command.call }.to raise_error(SystemExit) do |error|
+        expect(error.status).to eq(ExitCode::SUCCESS)
+      end
+
+      expect(command).not_to have_received(:run_non_interactive)
+    end
+  end
+
   describe "#update_runner_workload" do
     let(:config) { instance_double(Config) }
     let(:cp) { instance_double(Controlplane) }
@@ -150,6 +186,36 @@ describe Command::Run do
       let(:exec_success) { nil }
 
       it_behaves_like "an aborted interactive session", ExitCode::INTERRUPT
+    end
+  end
+
+  describe "#wait_for_replica_for_job" do
+    let(:config) { instance_double(Config) }
+    let(:cp) { instance_double(Controlplane) }
+    let(:command) { described_class.new(config) }
+
+    before do
+      allow(command).to receive_messages(cp: cp)
+      allow(command).to receive(:step) { |_message, **_options, &block| block.call }
+
+      command.instance_variable_set(:@runner_workload, "rails-runner")
+      command.instance_variable_set(:@job, "job-123")
+      command.instance_variable_set(:@location, "aws-us-east-2")
+    end
+
+    it "stops waiting when the cron job finishes before a replica is observed" do
+      allow(cp).to receive(:fetch_workload_replicas)
+        .with("rails-runner", location: "aws-us-east-2")
+        .and_return({ "items" => [] })
+      allow(cp).to receive(:fetch_cron_workload)
+        .with("rails-runner", location: "aws-us-east-2")
+        .and_return({ "items" => [{ "id" => "job-123", "status" => "successful" }] })
+
+      result = command.send(:wait_for_replica_for_job)
+
+      expect(result).to be(true)
+      expect(command.instance_variable_get(:@replica)).to be_nil
+      expect(command.instance_variable_get(:@job_completed_before_replica_exit_status)).to eq(ExitCode::SUCCESS)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Fix cpflow run so short non-interactive cron jobs can complete before a runner replica is observed without hanging in replica polling
- Exit with the completed cron job status before trying to attach logs when no replica is available
- Document the behavior in generated command docs and add an Unreleased changelog note

## Root cause
The react-webpack-rails-tutorial staging deploy run https://github.com/shakacode/react-webpack-rails-tutorial/actions/runs/26867270700 timed out in the release-phase deploy step. Control Plane showed the rails-runner cron job completed successfully from 2026-06-03T06:21:52Z to 2026-06-03T06:22:22Z, but cpflow kept polling for a runner replica until GitHub cancelled the job at 30 minutes.

## Verification
- CPLN_ORG=dummy-test bundle exec rspec spec/command/run_unit_spec.rb spec/command/deploy_image_unit_spec.rb spec/command/promote_app_from_upstream_unit_spec.rb spec/command/generate_github_actions_spec.rb
- bundle exec rubocop lib/command/run.rb spec/command/run_unit_spec.rb
- bundle exec rake check_command_docs
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to non-interactive `run` wait logic with unit tests; improves CI reliability without altering interactive sessions or deploy paths beyond earlier exit.
> 
> **Overview**
> Fixes **`cpflow run`** for short **non-interactive** cron jobs (including release-phase steps invoked via **`deploy-image`**) that finish on Control Plane before a **`-runner`** replica shows up in replica polling.
> 
> While waiting for a replica, the command now consults the cron job status via a shared **`current_job_status`** helper. If the job is already **`successful`** or failed, it stops polling, records the exit code, and **`exit`s immediately**—skipping log attach / **`run_non_interactive`**—instead of retrying until CI times out.
> 
> Docs and changelog note that non-interactive runs return the cron job status even when no replica is available for logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffe4d0ab222585e47618ddbbfa0a7bee95dba73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `cpflow run` hanging for short non-interactive runner jobs when the Control Plane cron job completes before a runner replica becomes visible.

* **Documentation**
  * Updated `cpflow run` command documentation to clarify behavior for non-interactive jobs completing quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->