### PR TITLE
Update CHANGELOG.md for 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,18 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+## [5.1.1] - 2026-06-03
+
 ### Changed
 
 - **Changed `cpflow maintenance:on` and `cpflow maintenance:off` to confirm the domain route has switched by polling the Control Plane API (bounded retry, 30 attempts, 1 second apart) instead of sleeping a fixed 30 seconds.** [PR 337](https://github.com/shakacode/control-plane-flow/pull/337) by [Justin Gordon](https://github.com/justin808). Fixes [issue 157](https://github.com/shakacode/control-plane-flow/issues/157). If the route never updates within the poll window, the command aborts before stopping workloads so traffic stays on the current workload, and transient API errors during polling are retried rather than aborting the switch. Because the route switch and the workload stop run as separate steps, re-running the command also finishes a switch whose poll timed out after the route had already updated.
+- **Reworked generated production-promotion image copy to authenticate directly to the staging and production Docker registries and copy via `docker buildx imagetools create`, handling digest-pinned, plain numeric, commit-suffixed, and multi-arch image refs.** [PR 356](https://github.com/shakacode/control-plane-flow/pull/356) by [Justin Gordon](https://github.com/justin808). Promotion now normalizes Control Plane org variables before each step, preflights environment-variable parity between staging and production at the GVC and app-workload container level (failing before the copy when production is missing names that exist in staging), and requires both `status.ready` and `status.readyLatest` before endpoint health checks and rollback polling so a stale ready replica cannot mask a failed latest revision.
+- **Generated production promotion now emits a workflow warning when a staging image tag lacks a `_<commit>` suffix**, so production tags without commit traceability are visible in logs, and documents the `cpflow-promote-staging-to-production` concurrency group in the copy step. [PR 360](https://github.com/shakacode/control-plane-flow/pull/360) by [Justin Gordon](https://github.com/justin808).
+- **Restored review-app security guidance in generated `.github/cpflow-help.md`** (public-repo staging-token scoping, fork-PR deploy limits, secret exposure via `cpln://secret/...`, and read-only deploy keys for `DOCKER_BUILD_SSH_KEY`), and simplified the promotion workflow's staging image assignment while preserving digest refs. [PR 359](https://github.com/shakacode/control-plane-flow/pull/359) by [Justin Gordon](https://github.com/justin808).
 
 ### Fixed
 
-- **Fixed `cpflow run` so short non-interactive runner jobs no longer hang when the Control Plane cron job finishes before a runner replica is visible.** This prevents generated deploy workflows with release-phase commands from waiting until the GitHub Actions job timeout even though the release job already completed successfully.
+- **Fixed `cpflow run` so short non-interactive runner jobs no longer hang when the Control Plane cron job finishes before a runner replica is visible.** [PR 361](https://github.com/shakacode/control-plane-flow/pull/361) by [Justin Gordon](https://github.com/justin808). This prevents generated deploy workflows with release-phase commands from waiting until the GitHub Actions job timeout even though the release job already completed successfully.
 
 ## [5.1.0] - 2026-06-02
 
@@ -418,7 +423,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.1.0...HEAD
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v5.1.1...HEAD
+[5.1.1]: https://github.com/shakacode/control-plane-flow/compare/v5.1.0...v5.1.1
 [5.1.0]: https://github.com/shakacode/control-plane-flow/compare/v5.0.4...v5.1.0
 [5.0.4]: https://github.com/shakacode/control-plane-flow/compare/v5.0.3...v5.0.4
 [5.0.3]: https://github.com/shakacode/control-plane-flow/compare/v5.0.2...v5.0.3


### PR DESCRIPTION
## Summary

Stamps the **5.1.1** patch release and records the user-visible changes merged since `v5.1.0`. Once this merges, `bundle exec rake release` (no args) will pick up `5.1.1` from the changelog and auto-create the GitHub release.

### Changed

- **PR 356** — reworked generated production-promotion image copy to authenticate directly to the staging/production Docker registries and copy via `docker buildx imagetools create` (digest-pinned, numeric, commit-suffixed, multi-arch). Adds Control Plane org-var normalization, env-var parity preflight (GVC + app-workload container), and stricter `status.ready` + `status.readyLatest` gates before health checks and rollback polling.
- **PR 360** — generated production promotion now warns when a staging image tag lacks a `_<commit>` suffix, and documents the `cpflow-promote-staging-to-production` concurrency group in the copy step.
- **PR 359** — restored review-app security guidance in generated `.github/cpflow-help.md`, and simplified the promotion workflow's staging image assignment while preserving digest refs.

### Fixed

- **PR 361** — fixed `cpflow run` so short non-interactive runner jobs no longer hang when the Control Plane cron job finishes before a runner replica is visible.

### Skipped

- **PR 358** (Control Plane Flow logo + README branding assets) — docs/branding only, no user-facing behavior change.

## Notes

- Version policy: `5.1.1` is a patch bump over `5.1.0`; the section uses only `### Changed` / `### Fixed`, which validate as a patch bump in `expected_bump_type_from_changelog_section`.
- Compare links updated: `[Unreleased]` now points at `v5.1.1...HEAD` and a new `[5.1.1]` link compares `v5.1.0...v5.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog and release metadata; no runtime or CI template changes in this diff.
> 
> **Overview**
> Adds a **5.1.1** release section to `CHANGELOG.md` (dated 2026-06-03) and moves the patch-level **Changed** / **Fixed** notes that belong in that release out of **Unreleased**, including maintenance route polling (PR 337), production-promotion image copy and readiness gates (PR 356), promotion tag warnings (PR 360), review-app help and promotion YAML tweaks (PR 359), and the `cpflow run` hang fix (PR 361).
> 
> The **Unreleased** compare link now targets `v5.1.1...HEAD`, and a new `[5.1.1]` link compares `v5.1.0...v5.1.1`. One duplicate **Fixed** bullet for `cpflow run` is replaced with the version that includes the PR link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae95c5955376ca6c840c0ebb012dc86a053e863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with version 5.1.1 release information, documenting recent changes and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->