### PR TITLE
Adopt agent-workflow binstubs (.agents/bin/ + AGENTS.md pointer)

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -1,0 +1,13 @@
+# Non-command agent-workflow configuration for portable shared skills.
+# Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
+base_branch: main
+changelog: "CHANGELOG.md — Keep-a-Changelog; user-visible changes only"
+follow_up_prefix: "Follow-up:"
+review_gate: "AI reviewers are advisory unless they confirm a blocker; merge gate is the full `gh pr checks` list green (not --required) + all threads resolved + mergeable clean"
+approval_exempt: "at batch closeout, auto-merge ready low-risk PRs that pass the merge gate; keep high-risk (CI/workflow, build-config, dependency or runtime bumps, broad refactors, release) maintainer-gated"
+coordination_backend: "private shakacode/agent-coordination (claims/heartbeats namespaced by full repo name)"
+benchmark_labels: n/a
+merge_ledger: n/a
+ci_parity_environment: "n/a — reproduce CI-only failures from the matching job in .github/workflows/**"
+hosted_ci_trigger: "n/a — CI runs on every PR"
+ci_change_detector: n/a

--- a/.agents/bin/README.md
+++ b/.agents/bin/README.md
@@ -1,0 +1,17 @@
+# Agent Workflow Scripts
+
+Standard entry points that portable agent-workflow skills call, so a skill can
+run `.agents/bin/<name>` in any repo without knowing this repo's specific
+commands. Each script is a thin, repo-owned wrapper. A script that is **absent**
+means that capability is n/a here.
+
+| Script | Purpose | This repo runs |
+| --- | --- | --- |
+| `setup` | Install dependencies | `bundle install` |
+| `validate` | Pre-push gate (run before pushing) | `bundle exec rake` (rspec + rubocop) |
+| `test` | Run tests | `bundle exec rspec` |
+| `lint` | Lint / format (pass `-A` to fix) | `bundle exec rubocop` |
+| `docs` | Check generated command docs | `bundle exec rake check_command_docs` |
+| `build` | Build / type-check | n/a (gem) |
+
+Non-command policy lives in [`../agent-workflow.yml`](../agent-workflow.yml).

--- a/.agents/bin/docs
+++ b/.agents/bin/docs
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Check generated command docs are current.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec bundle exec rake check_command_docs

--- a/.agents/bin/docs
+++ b/.agents/bin/docs
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Check generated command docs are current.
+set -euo pipefail
+exec bundle exec rake check_command_docs

--- a/.agents/bin/lint
+++ b/.agents/bin/lint
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Lint / format check. Pass -A to autocorrect.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec bundle exec rubocop "$@"

--- a/.agents/bin/lint
+++ b/.agents/bin/lint
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Lint / format check. Pass -A to autocorrect.
+set -euo pipefail
+exec bundle exec rubocop "$@"

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Install dependencies.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec bundle install

--- a/.agents/bin/setup
+++ b/.agents/bin/setup
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Install dependencies.
+set -euo pipefail
+exec bundle install

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Run the test suite. Extra args pass through to rspec.
+set -euo pipefail
+exec bundle exec rspec "$@"

--- a/.agents/bin/test
+++ b/.agents/bin/test
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Run the test suite. Extra args pass through to rspec.
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec bundle exec rspec "$@"

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Pre-push gate: full local validation (run before pushing).
+set -euo pipefail
+exec bundle exec rake

--- a/.agents/bin/validate
+++ b/.agents/bin/validate
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 # Pre-push gate: full local validation (run before pushing).
 set -euo pipefail
+cd "$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 exec bundle exec rake

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+Canonical agent instructions for `cpflow` (Control Plane Flow).
+
+## Agent Workflow Configuration
+
+Portable shared skills (from
+[`shakacode/agent-workflows`](https://github.com/shakacode/agent-workflows))
+resolve this repo's commands and policy through:
+
+- **Commands** — run `.agents/bin/<name>` (`setup`, `validate`, `test`, `lint`,
+  `docs`); see [`.agents/bin/README.md`](.agents/bin/README.md). A missing script
+  means that capability is n/a here.
+- **Policy / config** — [`.agents/agent-workflow.yml`](.agents/agent-workflow.yml)
+  (base branch, changelog, review gate, coordination backend, and other
+  non-command keys).
+
+Validate adoption with `agent-workflow-seam-doctor` (add `--shared
+<agent-workflows-root>` when checking user-installed shared skills outside the
+checkout).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See @AGENTS.md for canonical agent instructions, commands, and policy.


### PR DESCRIPTION
## Summary

Adopts the portable agent-workflow contract from
[shakacode/agent-workflows](https://github.com/shakacode/agent-workflows) using the
"Scripts to Rule Them All" pattern, so portable skills resolve this repo's commands
and policy through a stable, durable interface instead of an inline markdown seam:

- **`.agents/bin/<name>`** — executable wrappers (`setup`, `validate`, `test`, `lint`,
  `docs`); a skill runs `.agents/bin/test` without knowing this repo's commands. See
  `.agents/bin/README.md`.
- **`.agents/agent-workflow.yml`** — non-command policy (base branch, changelog, review
  gate, coordination backend, …).
- **`AGENTS.md`** — new canonical file; its `## Agent Workflow Configuration` section is
  a thin pointer to the above.
- **`CLAUDE.md`** — new one-liner that imports `@AGENTS.md`.

The scripts wrap existing commands (`bundle exec rake` / `rspec` / `rubocop`); nothing
executable changes.

## Validation

- `bash -n` on each script; all `chmod +x`; `agent-workflow.yml` parses as YAML.
- `.agents/bin/validate` runs `bundle exec rake` (rspec + rubocop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
