### PR TITLE
[codex] Document telemetry setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Added
+
+- **Added generic telemetry documentation for deploying an OpenTelemetry Collector with Control Plane Flow**, including collector workload templates, application instrumentation, telemetry pipelines, review-app isolation, and troubleshooting guidance. [PR 369](https://github.com/shakacode/control-plane-flow/pull/369) by [Justin Gordon](https://github.com/justin808).
+
 ## [5.1.1] - 2026-06-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Additionally, the documentation includes numerous examples and practical tips fo
 10. [Scheduled Jobs](#scheduled-jobs)
 11. [CLI Commands Reference](#cli-commands-reference)
 12. [Mapping of Heroku Commands to `cpflow` and `cpln`](#mapping-of-heroku-commands-to-cpflow-and-cpln)
-13. [Telemetry](https://www.shakacode.com/control-plane-flow/docs/telemetry/)
+13. [Telemetry](docs/telemetry/index.md)
 14. [Examples](#examples)
 15. [Migrating Postgres Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/postgres/)
 16. [Migrating Redis Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/redis/)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Additionally, the documentation includes numerous examples and practical tips fo
 10. [Scheduled Jobs](#scheduled-jobs)
 11. [CLI Commands Reference](#cli-commands-reference)
 12. [Mapping of Heroku Commands to `cpflow` and `cpln`](#mapping-of-heroku-commands-to-cpflow-and-cpln)
-13. [Telemetry](docs/telemetry/index.md)
+13. [Telemetry](https://www.shakacode.com/control-plane-flow/docs/telemetry/)
 14. [Examples](#examples)
 15. [Migrating Postgres Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/postgres/)
 16. [Migrating Redis Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/redis/)

--- a/README.md
+++ b/README.md
@@ -65,11 +65,12 @@ Additionally, the documentation includes numerous examples and practical tips fo
 10. [Scheduled Jobs](#scheduled-jobs)
 11. [CLI Commands Reference](#cli-commands-reference)
 12. [Mapping of Heroku Commands to `cpflow` and `cpln`](#mapping-of-heroku-commands-to-cpflow-and-cpln)
-13. [Examples](#examples)
-14. [Migrating Postgres Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/postgres/)
-15. [Migrating Redis Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/redis/)
-16. [Tips](https://www.shakacode.com/control-plane-flow/docs/tips/)
-17. [Thruster HTTP/2 Proxy on Control Plane](https://www.shakacode.com/control-plane-flow/docs/thruster/)
+13. [Telemetry](https://www.shakacode.com/control-plane-flow/docs/telemetry/)
+14. [Examples](#examples)
+15. [Migrating Postgres Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/postgres/)
+16. [Migrating Redis Database from Heroku Infrastructure](https://www.shakacode.com/control-plane-flow/docs/redis/)
+17. [Tips](https://www.shakacode.com/control-plane-flow/docs/tips/)
+18. [Thruster HTTP/2 Proxy on Control Plane](https://www.shakacode.com/control-plane-flow/docs/thruster/)
 
 ## Key Features
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,239 @@
+# Telemetry
+
+This guide shows how to run application telemetry on Control Plane with `cpflow`.
+`cpflow` does not instrument your application code. Instead, it helps you deploy
+the Control Plane workloads and environment variables that instrumented apps use
+to send traces, metrics, and logs.
+
+The recommended shape is:
+
+```text
+Application workloads
+  -> OpenTelemetry Collector workload in the same GVC
+  -> tracing, metrics, and logging backends
+```
+
+## What `cpflow` Provides
+
+`cpflow apply-template` can already apply ordinary Control Plane workload
+templates from `.controlplane/templates`. That means telemetry can be added with
+project templates and app environment values; no custom `cpflow` command is
+required.
+
+Use `cpflow` for:
+
+1. Deploying an OpenTelemetry Collector workload template.
+2. Applying app or workload environment variables that point to the collector.
+3. Reusing the same setup for review, staging, and production apps.
+4. Tailing collector logs with `cpflow logs`.
+
+Application code is still responsible for:
+
+1. Installing OpenTelemetry, StatsD, Prometheus, or framework-specific
+   instrumentation libraries.
+2. Setting service names and resource attributes.
+3. Creating custom spans or metrics.
+4. Filtering sensitive data before it leaves the process.
+
+## Collector Workload
+
+Add a collector workload template such as
+`.controlplane/templates/open-telemetry-collector.yml`.
+
+The exact image and config path depend on how your team packages collector
+configuration. For production, pin the collector image version and make sure the
+image or mounted configuration contains your full collector config.
+
+```yaml
+kind: workload
+name: open-telemetry-collector
+spec:
+  type: standard
+  containers:
+    - name: open-telemetry-collector
+      image: "otel/opentelemetry-collector-contrib:0.103.0"
+      args:
+        - "--config=/etc/otelcol/config.yaml"
+      cpu: 100m
+      memory: 256Mi
+      ports:
+        # OTLP over HTTP from app SDKs
+        - number: 4318
+          protocol: http
+        # StatsD direct metrics
+        - number: 9126
+          protocol: udp
+        # StatsD TCP fallback
+        - number: 9127
+          protocol: tcp
+        # Prometheus-formatted metrics exposed by the collector
+        - number: 9292
+          protocol: http
+  defaultOptions:
+    autoscaling:
+      metric: disabled
+      minScale: 1
+      maxScale: 1
+    capacityAI: false
+  firewallConfig:
+    internal:
+      inboundAllowType: same-gvc
+    external:
+      outboundAllowCIDR:
+        - 0.0.0.0/0
+```
+
+Then include the collector in app setup:
+
+```yaml
+aliases:
+  common: &common
+    setup_app_templates:
+      - app
+      - open-telemetry-collector
+      - rails
+      - sidekiq
+
+    app_workloads:
+      - rails
+      - sidekiq
+
+    additional_workloads:
+      - open-telemetry-collector
+```
+
+Apply it with:
+
+```sh
+cpflow apply-template open-telemetry-collector -a $APP_NAME
+```
+
+Or let `cpflow setup-app` apply it with the rest of the configured templates.
+
+## Application Environment
+
+Set application telemetry env vars at the GVC level when every app workload
+should inherit them, or at the workload container level when only one workload
+should emit telemetry.
+
+For OTLP over HTTP:
+
+```yaml
+env:
+  - name: ENABLE_OPEN_TELEMETRY
+    value: "true"
+  - name: OTEL_SERVICE_NAME
+    value: "my-app-rails"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://open-telemetry-collector.{{APP_NAME}}.cpln.local:4318"
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: "http/protobuf"
+```
+
+For StatsD direct metrics:
+
+```yaml
+env:
+  - name: STATSD_HOST
+    value: "open-telemetry-collector.{{APP_NAME}}.cpln.local"
+  - name: STATSD_PORT
+    value: "9126"
+```
+
+Prefer direct metrics when application code can emit them. Direct metrics avoid
+collector-side regex parsing and are usually cheaper and easier to reason about
+than deriving metrics from logs.
+
+## Signals
+
+### Traces
+
+Use OpenTelemetry SDKs or framework auto-instrumentation in your application.
+Send traces to the collector's OTLP HTTP endpoint on port `4318`.
+
+Good default attributes include:
+
+- `service.name`
+- `deployment.environment`
+- `service.version` or commit SHA
+- low-cardinality workload names
+
+Avoid high-cardinality attributes such as request IDs, user IDs, raw URLs, and
+unbounded error messages.
+
+### Metrics
+
+For application-defined metrics, emit StatsD or OTLP metrics directly from the
+application. Common examples include:
+
+- request counters
+- queue depth gauges
+- job duration histograms
+- integration failure counters
+
+The collector can expose Prometheus-formatted metrics on port `9292`. Configure
+your metrics backend to scrape that endpoint according to your Control Plane and
+Grafana setup.
+
+### Logs
+
+Keep application logs useful on their own: structured, redacted, and emitted to
+stdout/stderr. Use log-derived metrics only for temporary prototyping or legacy
+paths where direct instrumentation is not practical, because regex processing in
+the collector can become expensive.
+
+## Review Apps
+
+Telemetry for review apps should be isolated from production telemetry.
+
+Recommended defaults:
+
+1. Use a collector inside each review app GVC or a staging-only collector.
+2. Keep collector inbound access internal with `same-gvc` unless there is a
+   specific reason to expose it.
+3. Do not give review apps production telemetry tokens.
+4. Keep sampling rates and retention lower for noisy review environments.
+5. Avoid sending request bodies, secrets, credentials, or personally identifiable
+   information in spans, labels, or logs.
+
+## Troubleshooting
+
+Check that the collector workload exists:
+
+```sh
+cpflow ps -a $APP_NAME -w open-telemetry-collector
+```
+
+Tail collector logs:
+
+```sh
+cpflow logs -a $APP_NAME -w open-telemetry-collector
+```
+
+Check application logs for exporter errors:
+
+```sh
+cpflow logs -a $APP_NAME -w rails
+```
+
+If telemetry is missing:
+
+1. Confirm the app workload can resolve
+   `open-telemetry-collector.$APP_NAME.cpln.local`.
+2. Confirm the collector listens on the expected ports.
+3. Confirm app env vars are set on the GVC or workload container.
+4. Confirm the application instrumentation library is enabled.
+5. Confirm the collector config exports to the expected backend.
+
+## Future `cpflow` Enhancements
+
+The docs-only setup above works with existing `cpflow` behavior. A small future
+code enhancement could make telemetry safer by adding a deploy-time required ENV
+check. Apps could declare names such as `OTEL_SERVICE_NAME`,
+`OTEL_EXPORTER_OTLP_ENDPOINT`, `STATSD_HOST`, and `STATSD_PORT` in
+`controlplane.yml`, and `cpflow deploy-image` or `cpflow doctor` could fail
+before deployment when those values are missing from the GVC or app workload.
+
+Another optional enhancement would be an opt-in generated collector template.
+That should stay opt-in because teams package collector config and exporters in
+different ways.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -113,7 +113,10 @@ StatsD client or when a metric library cannot emit OTLP yet.
 4. Add the collector to `additional_workloads`.
 5. Set application env vars such as `OTEL_SERVICE_NAME`,
    `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
-6. Apply templates with `cpflow setup-app` or `cpflow apply-template`.
+6. Apply the collector template with
+   `cpflow apply-template open-telemetry-collector -a $APP_NAME`. For a
+   brand-new app, `cpflow setup-app` applies it with the other configured
+   templates.
 7. Confirm collector logs, application exporter logs, and backend ingestion.
 
 The collector workload and its `config.yaml` must be kept in sync. If the

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,31 +1,57 @@
 # Telemetry
 
-This guide shows how to run application telemetry on Control Plane with `cpflow`.
-`cpflow` does not instrument your application code. Instead, it helps you deploy
-the Control Plane workloads and environment variables that instrumented apps use
-to send traces, metrics, and logs.
+This guide explains how to run application telemetry on Control Plane with
+`cpflow`. It is intentionally generic: the examples use placeholder service
+names, simple metric names, and backend-neutral collector configuration.
 
-The recommended shape is:
+`cpflow` does not instrument application code. It helps deploy the Control Plane
+workloads and environment values that already-instrumented applications use to
+send traces, metrics, and logs.
 
-```text
-Application workloads
-  -> OpenTelemetry Collector workload in the same GVC
-  -> tracing, metrics, and logging backends
+## Quick Navigation
+
+| Page | Use it for |
+| --- | --- |
+| [Collector workload](telemetry/collector.md) | Control Plane workload template, collector ports, and matching `config.yaml` |
+| [Application instrumentation](telemetry/application-instrumentation.md) | Generic app env vars and simple Ruby/Node examples |
+| [Pipelines](telemetry/pipelines.md) | Receivers, processors, exporters, and how signals flow |
+| [Review apps](telemetry/review-apps.md) | Review-app isolation, sampling, secrets, and egress controls |
+| [Troubleshooting](telemetry/troubleshooting.md) | Commands and checks for missing telemetry |
+
+## Recommended Shape
+
+```mermaid
+flowchart LR
+  app["Application workload(s)"]
+  collector["OpenTelemetry Collector workload"]
+  backend["Telemetry backend(s)"]
+  dashboard["Dashboards and alerts"]
+
+  app -->|"OTLP HTTP :4318"| collector
+  app -->|"Optional StatsD TCP :9127"| collector
+  collector -->|"Traces, metrics, logs"| backend
+  backend --> dashboard
 ```
+
+Keep the collector inside the same GVC as the application unless your team has a
+separate, intentionally shared telemetry GVC. A same-GVC collector keeps review,
+staging, and production wiring easy to reason about and avoids accidental
+cross-environment data mixing.
 
 ## What `cpflow` Provides
 
-`cpflow apply-template` can already apply ordinary Control Plane workload
-templates from `.controlplane/templates`. That means telemetry can be added with
-project templates and app environment values; no custom `cpflow` command is
-required.
+`cpflow apply-template` already applies ordinary Control Plane workload
+templates from `.controlplane/templates`. Telemetry can therefore be added with
+project templates and app environment values; no custom `cpflow telemetry`
+command is required.
 
 Use `cpflow` for:
 
 1. Deploying an OpenTelemetry Collector workload template.
-2. Applying app or workload environment variables that point to the collector.
-3. Reusing the same setup for review, staging, and production apps.
-4. Tailing collector logs with `cpflow logs`.
+2. Applying GVC or workload environment variables that point apps at the
+   collector.
+3. Reusing the same setup shape for review, staging, and production apps.
+4. Tailing application and collector logs with `cpflow logs`.
 
 Application code is still responsible for:
 
@@ -35,205 +61,80 @@ Application code is still responsible for:
 3. Creating custom spans or metrics.
 4. Filtering sensitive data before it leaves the process.
 
-## Collector Workload
+## Signal Flow
 
-Add a collector workload template such as
-`.controlplane/templates/open-telemetry-collector.yml`.
+```mermaid
+flowchart TB
+  subgraph app["Application process"]
+    trace_sdk["Trace SDK"]
+    metric_sdk["Metric SDK"]
+    otlp_logs["OTLP logs"]
+    stdout_logs["stdout/stderr logs"]
+  end
 
-The exact image and config path depend on how your team packages collector
-configuration. For production, pin the collector image version and make sure the
-image or mounted configuration contains your full collector config.
+  subgraph collector["Collector workload"]
+    receivers["Receivers"]
+    processors["Processors"]
+    exporters["Exporters"]
+  end
 
-```yaml
-kind: workload
-name: open-telemetry-collector
-spec:
-  type: standard
-  containers:
-    - name: open-telemetry-collector
-      image: "otel/opentelemetry-collector-contrib:0.103.0"
-      args:
-        - "--config=/etc/otelcol/config.yaml"
-      cpu: 100m
-      memory: 256Mi
-      ports:
-        # OTLP over HTTP from app SDKs
-        - number: 4318
-          protocol: http
-        # StatsD direct metrics
-        - number: 9126
-          protocol: udp
-        # StatsD TCP fallback
-        - number: 9127
-          protocol: tcp
-        # Prometheus-formatted metrics exposed by the collector
-        - number: 9292
-          protocol: http
-  defaultOptions:
-    autoscaling:
-      metric: disabled
-      minScale: 1
-      maxScale: 1
-    capacityAI: false
-  firewallConfig:
-    internal:
-      inboundAllowType: same-gvc
-    external:
-      outboundAllowCIDR:
-        - 0.0.0.0/0
+  traces["Trace backend"]
+  metrics["Metrics backend"]
+  logs["OTLP log backend"]
+  platform_logs["Platform log backend"]
+
+  trace_sdk -->|"OTLP traces"| receivers
+  metric_sdk -->|"OTLP metrics or StatsD TCP"| receivers
+  otlp_logs -->|"OTLP logs"| receivers
+  stdout_logs --> platform_logs
+  receivers --> processors
+  processors --> exporters
+  exporters --> traces
+  exporters --> metrics
+  exporters --> logs
 ```
 
-Then include the collector in app setup:
+For new instrumentation, prefer OTLP over HTTP on port `4318`. It is the most
+portable path because it can carry traces, metrics, and logs through one
+well-known protocol. Use StatsD only when your application already has a simple
+StatsD client or when a metric library cannot emit OTLP yet.
 
-```yaml
-aliases:
-  common: &common
-    setup_app_templates:
-      - app
-      - open-telemetry-collector
-      - rails
-      - sidekiq
+## Minimal Rollout Checklist
 
-    app_workloads:
-      - rails
-      - sidekiq
+1. Add `.controlplane/templates/open-telemetry-collector.yml`.
+2. Package a collector `config.yaml` that binds every port exposed by the
+   workload template.
+3. Add the collector template to `setup_app_templates`.
+4. Add the collector to `additional_workloads`.
+5. Set application env vars such as `OTEL_SERVICE_NAME`,
+   `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
+6. Apply templates with `cpflow setup-app` or `cpflow apply-template`.
+7. Confirm collector logs, application exporter logs, and backend ingestion.
 
-    additional_workloads:
-      - open-telemetry-collector
-```
+The collector workload and its `config.yaml` must be kept in sync. If the
+workload exposes `4318`, `9127`, or `9292`, the collector config must bind those
+same ports. Exposing a port in Control Plane does not automatically enable a
+collector receiver or exporter.
 
-Apply it with:
+## Generic Naming
 
-```sh
-cpflow apply-template open-telemetry-collector -a $APP_NAME
-```
+Use names that describe the application or workload without leaking
+environment-specific details.
 
-Or let `cpflow setup-app` apply it with the rest of the configured templates.
+Good examples:
 
-## Application Environment
+- `example-web`
+- `example-worker`
+- `example.tasks.completed`
+- `example.jobs.duration_ms`
+- `deployment.environment=staging`
 
-Set application telemetry env vars at the GVC level when every app workload
-should inherit them, or at the workload container level when only one workload
-should emit telemetry.
+Avoid examples that include real company names, user IDs, request IDs, raw URLs,
+or domain-specific nouns that only make sense in one business.
 
-For OTLP over HTTP:
+## More Detail
 
-```yaml
-env:
-  - name: ENABLE_OPEN_TELEMETRY
-    value: "true"
-  - name: OTEL_SERVICE_NAME
-    value: "my-app-rails"
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: "http://open-telemetry-collector.{{APP_NAME}}.cpln.local:4318"
-  - name: OTEL_EXPORTER_OTLP_PROTOCOL
-    value: "http/protobuf"
-```
-
-For StatsD direct metrics:
-
-```yaml
-env:
-  - name: STATSD_HOST
-    value: "open-telemetry-collector.{{APP_NAME}}.cpln.local"
-  - name: STATSD_PORT
-    value: "9126"
-```
-
-Prefer direct metrics when application code can emit them. Direct metrics avoid
-collector-side regex parsing and are usually cheaper and easier to reason about
-than deriving metrics from logs.
-
-## Signals
-
-### Traces
-
-Use OpenTelemetry SDKs or framework auto-instrumentation in your application.
-Send traces to the collector's OTLP HTTP endpoint on port `4318`.
-
-Good default attributes include:
-
-- `service.name`
-- `deployment.environment`
-- `service.version` or commit SHA
-- low-cardinality workload names
-
-Avoid high-cardinality attributes such as request IDs, user IDs, raw URLs, and
-unbounded error messages.
-
-### Metrics
-
-For application-defined metrics, emit StatsD or OTLP metrics directly from the
-application. Common examples include:
-
-- request counters
-- queue depth gauges
-- job duration histograms
-- integration failure counters
-
-The collector can expose Prometheus-formatted metrics on port `9292`. Configure
-your metrics backend to scrape that endpoint according to your Control Plane and
-Grafana setup.
-
-### Logs
-
-Keep application logs useful on their own: structured, redacted, and emitted to
-stdout/stderr. Use log-derived metrics only for temporary prototyping or legacy
-paths where direct instrumentation is not practical, because regex processing in
-the collector can become expensive.
-
-## Review Apps
-
-Telemetry for review apps should be isolated from production telemetry.
-
-Recommended defaults:
-
-1. Use a collector inside each review app GVC or a staging-only collector.
-2. Keep collector inbound access internal with `same-gvc` unless there is a
-   specific reason to expose it.
-3. Do not give review apps production telemetry tokens.
-4. Keep sampling rates and retention lower for noisy review environments.
-5. Avoid sending request bodies, secrets, credentials, or personally identifiable
-   information in spans, labels, or logs.
-
-## Troubleshooting
-
-Check that the collector workload exists:
-
-```sh
-cpflow ps -a $APP_NAME -w open-telemetry-collector
-```
-
-Tail collector logs:
-
-```sh
-cpflow logs -a $APP_NAME -w open-telemetry-collector
-```
-
-Check application logs for exporter errors:
-
-```sh
-cpflow logs -a $APP_NAME -w rails
-```
-
-If telemetry is missing:
-
-1. Confirm the app workload can resolve
-   `open-telemetry-collector.$APP_NAME.cpln.local`.
-2. Confirm the collector listens on the expected ports.
-3. Confirm app env vars are set on the GVC or workload container.
-4. Confirm the application instrumentation library is enabled.
-5. Confirm the collector config exports to the expected backend.
-
-## Future `cpflow` Enhancements
-
-The docs-only setup above works with existing `cpflow` behavior. A small future
-code enhancement could make telemetry safer by adding a deploy-time required ENV
-check. Apps could declare names such as `OTEL_SERVICE_NAME`,
-`OTEL_EXPORTER_OTLP_ENDPOINT`, `STATSD_HOST`, and `STATSD_PORT` in
-`controlplane.yml`, and `cpflow deploy-image` or `cpflow doctor` could fail
-before deployment when those values are missing from the GVC or app workload.
-
-Another optional enhancement would be an opt-in generated collector template.
-That should stay opt-in because teams package collector config and exporters in
-different ways.
+Start with [Collector workload](telemetry/collector.md), then read
+[Application instrumentation](telemetry/application-instrumentation.md). Use
+[Troubleshooting](telemetry/troubleshooting.md) when signals do not appear in
+the backend.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -81,18 +81,23 @@ flowchart TB
   traces["Trace backend"]
   metrics["Metrics backend"]
   logs["OTLP log backend"]
-  platform_logs["Platform log backend"]
+  platform_logs["Platform log capture"]
+  platform_logs_backend["Platform log backend"]
 
   trace_sdk -->|"OTLP traces"| receivers
   metric_sdk -->|"OTLP metrics or StatsD TCP"| receivers
   otlp_logs -->|"OTLP logs"| receivers
-  stdout_logs --> platform_logs
+  stdout_logs -->|"bypasses collector"| platform_logs
+  platform_logs -->|"cpflow logs and historical queries"| platform_logs_backend
   receivers --> processors
   processors --> exporters
   exporters --> traces
   exporters --> metrics
   exporters --> logs
 ```
+
+stdout/stderr logs bypass the collector and are captured directly by the
+platform. Use `cpflow logs` for live tailing.
 
 For new instrumentation, prefer OTLP over HTTP on port `4318`. It is the most
 portable path because it can carry traces, metrics, and logs through one

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -1,0 +1,99 @@
+# Application Instrumentation
+
+Application instrumentation is the code and configuration that creates telemetry
+signals. `cpflow` deploys the infrastructure around that instrumentation, but it
+does not add tracing or metrics libraries to your application.
+
+## Standard Environment Variables
+
+Set these at the GVC level when every app workload should inherit them. Set them
+on one workload container when only that workload should emit telemetry.
+
+```yaml
+env:
+  - name: OTEL_SERVICE_NAME
+    value: "example-web"
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: "http://open-telemetry-collector.{{APP_NAME}}.cpln.local:4318"
+  - name: OTEL_EXPORTER_OTLP_PROTOCOL
+    value: "http/protobuf"
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "deployment.environment=staging,service.namespace=example"
+```
+
+`ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
+Use it only if your application code explicitly reads that flag. Otherwise, use
+standard SDK configuration such as `OTEL_SERVICE_NAME` and
+`OTEL_EXPORTER_OTLP_ENDPOINT`, plus your framework's instrumentation setup.
+
+## Optional StatsD TCP Variables
+
+Use these only when your application client can send StatsD over TCP and your
+collector has a matching `statsd/tcp` receiver.
+
+```yaml
+env:
+  - name: STATSD_HOST
+    value: "open-telemetry-collector.{{APP_NAME}}.cpln.local"
+  - name: STATSD_PORT
+    value: "9127"
+  - name: STATSD_PROTOCOL
+    value: "tcp"
+```
+
+## Generic Ruby Example
+
+This example uses deliberately generic metric names. Keep labels low-cardinality.
+
+```ruby
+statsd.increment(
+  "example.tasks.completed",
+  tags: ["task_type:background", "status:success"]
+)
+
+statsd.timing(
+  "example.jobs.duration_ms",
+  elapsed_ms,
+  tags: ["job_type:scheduled"]
+)
+```
+
+Avoid tags such as `user_id`, `request_id`, raw URLs, or free-form error
+messages. They create high-cardinality metrics and can leak sensitive data.
+
+## Generic Node.js Example
+
+```javascript
+statsd.increment("example.requests.completed", 1, {
+  route: "health_check",
+  status: "success",
+});
+
+statsd.histogram("example.worker.duration_ms", elapsedMs, {
+  worker: "default",
+});
+```
+
+## Service Names
+
+Use names that identify the workload, not a real organization, account, or user.
+
+Good:
+
+- `example-web`
+- `example-worker`
+- `example-scheduler`
+
+Avoid:
+
+- real organization names
+- account names
+- user identifiers
+- business-specific nouns copied from one product into reusable docs
+
+## Logs
+
+Keep logs structured, redacted, and useful without a collector. If your
+application sends OTLP logs, use the same collector endpoint as traces and
+metrics. If it logs to stdout/stderr, use `cpflow logs` for live tailing and the
+platform log backend for historical queries.

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -36,10 +36,12 @@ The `http://` collector endpoint is intended for a collector in the same GVC wit
 `same-gvc` inbound firewall isolation. Use `https://` when the collector is
 outside the same GVC or exposed through a shared telemetry endpoint.
 
-Modern stable OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base
-URL and append `/v1/traces`, `/v1/metrics`, or `/v1/logs` automatically. For
-older or pre-stable SDKs, use signal-specific variables such as
-`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the full signal path.
+Modern stable OpenTelemetry SDKs using OTLP over HTTP treat
+`OTEL_EXPORTER_OTLP_ENDPOINT` as a base URL and append `/v1/traces`,
+`/v1/metrics`, or `/v1/logs` automatically. For OTLP over gRPC, follow your
+SDK's endpoint format, which often uses `host:port` without an `http://` or
+`https://` scheme. For older or pre-stable SDKs, use signal-specific variables
+such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the full signal path.
 
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -17,24 +17,28 @@ values. When setting values directly in the Control Plane console or with
 
 ```yaml
 env:
-  - name: OTEL_SERVICE_NAME
-    value: "example-web"
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: "http://open-telemetry-collector.{{APP_NAME}}.cpln.local:4318"
   - name: OTEL_EXPORTER_OTLP_PROTOCOL
     value: "http/protobuf"
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "deployment.environment=staging,service.namespace=example"
+# When applied at GVC level, each workload container must also set
+# inheritEnv: true. Set OTEL_SERVICE_NAME per workload container, such as
+# example-web or example-worker, so distinct processes stay separate in the
+# telemetry backend.
 ```
 
 Change `deployment.environment=staging` to match the real environment. When this
 value is set at the GVC level, each target workload container must set
 `inheritEnv: true` to receive it. Use workload container env instead when only
-one workload should receive the telemetry settings.
+one workload should receive the telemetry settings. Keep `OTEL_SERVICE_NAME`
+workload-specific at the container level.
 
 The `http://` collector endpoint is intended for a collector in the same GVC with
-`same-gvc` inbound firewall isolation. Use `https://` when the collector is
-outside the same GVC or exposed through a shared telemetry endpoint.
+`same-gvc` inbound firewall isolation. Use `https://` only when a shared
+telemetry endpoint terminates TLS; otherwise use the internal collector hostname
+and protocol configured for that collector.
 
 When using HTTP transport (`http/protobuf` or `http/json`), modern stable
 OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base URL and append
@@ -65,6 +69,9 @@ env:
   - name: STATSD_PROTOCOL
     value: "tcp"
 ```
+
+When applying with `cpln` directly, replace `{{APP_NAME}}` with the actual app
+name.
 
 ## Generic Ruby Example
 
@@ -105,7 +112,13 @@ if (!statsdHost) {
 
 const statsd = createStatsDClient({
   host: statsdHost,
-  port: Number(process.env.STATSD_PORT || "9127"),
+  port: (() => {
+    const port = parseInt(process.env.STATSD_PORT || "9127", 10);
+    if (!Number.isFinite(port)) {
+      throw new Error(`Invalid STATSD_PORT: ${process.env.STATSD_PORT}`);
+    }
+    return port;
+  })(),
   protocol: process.env.STATSD_PROTOCOL || "tcp",
 });
 

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -95,8 +95,13 @@ messages. They create high-cardinality metrics and can leak sensitive data.
 ## Generic Node.js Example
 
 ```javascript
+const statsdHost = process.env.STATSD_HOST;
+if (!statsdHost) {
+  throw new Error("STATSD_HOST is not set");
+}
+
 const statsd = createStatsDClient({
-  host: process.env.STATSD_HOST,
+  host: statsdHost,
   port: Number(process.env.STATSD_PORT || "9127"),
   protocol: process.env.STATSD_PROTOCOL || "tcp",
 });

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -23,10 +23,10 @@ env:
     value: "http/protobuf"
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "deployment.environment=staging,service.namespace=example"
-# When applied at GVC level, each workload container must also set
-# inheritEnv: true. Set OTEL_SERVICE_NAME per workload container, such as
-# example-web or example-worker, so distinct processes stay separate in the
-# telemetry backend.
+# This GVC-level snippet intentionally omits OTEL_SERVICE_NAME.
+# Set OTEL_SERVICE_NAME per workload container, such as example-web or
+# example-worker, and set inheritEnv: true on each container that should
+# receive these shared values.
 ```
 
 Change `deployment.environment=staging` to match the real environment. When this

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -32,6 +32,11 @@ value is set at the GVC level, each target workload container must set
 `inheritEnv: true` to receive it. Use workload container env instead when only
 one workload should receive the telemetry settings.
 
+Modern stable OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base
+URL and append `/v1/traces`, `/v1/metrics`, or `/v1/logs` automatically. For
+older or pre-stable SDKs, use signal-specific variables such as
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the full signal path.
+
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use
 standard SDK configuration such as `OTEL_SERVICE_NAME` and

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -9,6 +9,11 @@ does not add tracing or metrics libraries to your application.
 Set these at the GVC level when every app workload should inherit them. Set them
 on one workload container when only that workload should emit telemetry.
 
+This YAML is intended for a `cpflow` template, such as a file under
+`.controlplane/templates`. When setting values directly in the Control Plane
+console or with `cpln`, replace `{{APP_NAME}}` with the actual app name before
+applying it.
+
 ```yaml
 env:
   - name: OTEL_SERVICE_NAME
@@ -20,11 +25,6 @@ env:
   - name: OTEL_RESOURCE_ATTRIBUTES
     value: "deployment.environment=staging,service.namespace=example"
 ```
-
-`{{APP_NAME}}` is a `cpflow` template variable. It is replaced only when this
-YAML lives in a `cpflow`-processed template such as a file under
-`.controlplane/templates`. When setting values directly in the Control Plane
-console or with `cpln`, replace `{{APP_NAME}}` with the actual app name.
 
 Change `deployment.environment=staging` to match the real environment. When this
 value is set at the GVC level, every workload in that GVC inherits it.

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -36,12 +36,13 @@ The `http://` collector endpoint is intended for a collector in the same GVC wit
 `same-gvc` inbound firewall isolation. Use `https://` when the collector is
 outside the same GVC or exposed through a shared telemetry endpoint.
 
-Modern stable OpenTelemetry SDKs using OTLP over HTTP treat
-`OTEL_EXPORTER_OTLP_ENDPOINT` as a base URL and append `/v1/traces`,
-`/v1/metrics`, or `/v1/logs` automatically. For OTLP over gRPC, follow your
-SDK's endpoint format, which often uses `host:port` without an `http://` or
-`https://` scheme. For older or pre-stable SDKs, use signal-specific variables
-such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the full signal path.
+When using HTTP transport (`http/protobuf` or `http/json`), modern stable
+OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base URL and append
+`/v1/traces`, `/v1/metrics`, or `/v1/logs` automatically. For OTLP over gRPC,
+follow your SDK's endpoint format, which often uses `host:port` without an
+`http://` or `https://` scheme. For older or pre-stable SDKs, use
+signal-specific variables such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the
+full signal path.
 
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -9,10 +9,11 @@ does not add tracing or metrics libraries to your application.
 Set these at the GVC level when every app workload should inherit them. Set them
 on one workload container when only that workload should emit telemetry.
 
-This YAML is intended for a `cpflow` template, such as a file under
-`.controlplane/templates`. When setting values directly in the Control Plane
-console or with `cpln`, replace `{{APP_NAME}}` with the actual app name before
-applying it.
+The snippets below are fragments, not complete templates. In a `cpflow`
+template, put the `env` list under `spec.env` for GVC-level values or under the
+target workload container's `spec.containers[].env` list for workload-only
+values. When setting values directly in the Control Plane console or with
+`cpln`, replace `{{APP_NAME}}` with the actual app name before applying it.
 
 ```yaml
 env:

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -37,7 +37,9 @@ standard SDK configuration such as `OTEL_SERVICE_NAME` and
 ## Optional StatsD TCP Variables
 
 Use these only when your application client can send StatsD over TCP and your
-collector has a matching `statsd/tcp` receiver.
+collector has a matching `statsd/tcp` receiver. These environment variable names
+are examples for application code that reads them; many StatsD clients require
+TCP transport to be configured explicitly in code.
 
 ```yaml
 env:

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -32,6 +32,10 @@ value is set at the GVC level, each target workload container must set
 `inheritEnv: true` to receive it. Use workload container env instead when only
 one workload should receive the telemetry settings.
 
+The `http://` collector endpoint is intended for a collector in the same GVC with
+`same-gvc` inbound firewall isolation. Use `https://` when the collector is
+outside the same GVC or exposed through a shared telemetry endpoint.
+
 Modern stable OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base
 URL and append `/v1/traces`, `/v1/metrics`, or `/v1/logs` automatically. For
 older or pre-stable SDKs, use signal-specific variables such as

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -43,10 +43,11 @@ and protocol configured for that collector.
 When using HTTP transport (`http/protobuf` or `http/json`), modern stable
 OpenTelemetry SDKs treat `OTEL_EXPORTER_OTLP_ENDPOINT` as a base URL and append
 `/v1/traces`, `/v1/metrics`, or `/v1/logs` automatically. For OTLP over gRPC,
-follow your SDK's endpoint format, which often uses `host:port` without an
-`http://` or `https://` scheme. For older or pre-stable SDKs, use
+most stable SDKs expect `http://host:port` for insecure connections and
+`https://host:port` for TLS. Some older or pre-stable SDKs accepted a bare
+`host:port`; check your SDK's documentation. For older or pre-stable SDKs, use
 signal-specific variables such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` with the
-full signal path.
+full signal path when needed.
 
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use
@@ -69,6 +70,9 @@ env:
   - name: STATSD_PROTOCOL
     value: "tcp"
 ```
+
+`9127` is project-specific. The StatsD protocol default is `8125/UDP`; use the
+port your collector's `statsd/tcp` receiver is configured to bind.
 
 When applying with `cpln` directly, replace `{{APP_NAME}}` with the actual app
 name.

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -28,7 +28,9 @@ env:
 ```
 
 Change `deployment.environment=staging` to match the real environment. When this
-value is set at the GVC level, every workload in that GVC inherits it.
+value is set at the GVC level, each target workload container must set
+`inheritEnv: true` to receive it. Use workload container env instead when only
+one workload should receive the telemetry settings.
 
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -21,6 +21,11 @@ env:
     value: "deployment.environment=staging,service.namespace=example"
 ```
 
+`{{APP_NAME}}` is a `cpflow` template variable. It is replaced only when this
+YAML lives in a `cpflow`-processed template such as a file under
+`.controlplane/templates`. When setting values directly in the Control Plane
+console or with `cpln`, replace `{{APP_NAME}}` with the actual app name.
+
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use
 standard SDK configuration such as `OTEL_SERVICE_NAME` and

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -26,6 +26,9 @@ YAML lives in a `cpflow`-processed template such as a file under
 `.controlplane/templates`. When setting values directly in the Control Plane
 console or with `cpln`, replace `{{APP_NAME}}` with the actual app name.
 
+Change `deployment.environment=staging` to match the real environment. When this
+value is set at the GVC level, every workload in that GVC inherits it.
+
 `ENABLE_OPEN_TELEMETRY` is not a standard OpenTelemetry environment variable.
 Use it only if your application code explicitly reads that flag. Otherwise, use
 standard SDK configuration such as `OTEL_SERVICE_NAME` and

--- a/docs/telemetry/application-instrumentation.md
+++ b/docs/telemetry/application-instrumentation.md
@@ -54,8 +54,17 @@ env:
 ## Generic Ruby Example
 
 This example uses deliberately generic metric names. Keep labels low-cardinality.
+Initialize your client with TCP transport before emitting metrics. The exact
+constructor name varies by library, but do not rely on the client's default
+transport when the collector listens on `statsd/tcp`.
 
 ```ruby
+statsd = MyStatsDClient.new(
+  host: ENV.fetch("STATSD_HOST"),
+  port: Integer(ENV.fetch("STATSD_PORT", "9127")),
+  protocol: ENV.fetch("STATSD_PROTOCOL", "tcp")
+)
+
 statsd.increment(
   "example.tasks.completed",
   tags: ["task_type:background", "status:success"]
@@ -74,6 +83,12 @@ messages. They create high-cardinality metrics and can leak sensitive data.
 ## Generic Node.js Example
 
 ```javascript
+const statsd = createStatsDClient({
+  host: process.env.STATSD_HOST,
+  port: Number(process.env.STATSD_PORT || "9127"),
+  protocol: process.env.STATSD_PROTOCOL || "tcp",
+});
+
 statsd.increment("example.requests.completed", 1, {
   route: "health_check",
   status: "success",

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -95,6 +95,10 @@ Replace `<secret-name>` with the dictionary secret that stores
 `TELEMETRY_BACKEND_TOKEN`. Keep this policy scoped to only the backend secret
 the collector needs.
 
+`cpflow apply-template` replaces `{{APP_NAME}}` with the actual app name. When
+applying the YAML directly with `cpln`, replace `{{APP_NAME}}` manually before
+running `cpln apply`.
+
 Keep the collector image pinned to a tested release and update it as part of
 normal dependency maintenance. Do not rely on a floating `latest` tag for
 production workloads.
@@ -112,9 +116,14 @@ FROM otel/opentelemetry-collector-contrib:0.155.0
 COPY config.yaml /etc/otelcol-contrib/config.yaml
 ```
 
-Publish that image to your registry, then use the published image in the
-workload template. Use a different delivery mechanism only if your team already
-has a standard way to provide files to Control Plane workloads.
+Build this image, publish it to your registry, and set the workload template
+`image:` field to that published image. The upstream image is only the base image
+for this Dockerfile because it does not contain your `config.yaml`.
+
+Baking the config into the image keeps collector startup deterministic. If your
+team already manages runtime files through Control Plane, you can instead mount a
+secret-backed file with a `cpln://secret/...` URI and `path:` entry, following
+the same pattern used by other file-delivery templates.
 
 ## Matching Collector Config
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -118,7 +118,7 @@ service:
     metrics:
       receivers: [otlp, statsd/tcp]
       processors: [memory_limiter, batch]
-      exporters: [prometheus]
+      exporters: [prometheus, otlphttp/backend]
 
     logs:
       receivers: [otlp]
@@ -129,7 +129,8 @@ service:
 Before applying the config, replace `telemetry-backend.example.com` with your
 real backend endpoint and headers. Keep `memory_limiter` before `batch`, and
 keep the Prometheus exporter only when your platform or backend scrapes collector
-metrics from port `9292`.
+metrics from port `9292`. For push-only metrics backends, remove `prometheus`
+from the metrics pipeline and keep `otlphttp/backend`.
 
 ## StatsD and UDP
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -27,6 +27,10 @@ spec:
       image: "registry.example.com/example/open-telemetry-collector:0.155.0"
       args:
         - "--config=/etc/otelcol-contrib/config.yaml"
+      # Uncomment when config.yaml references ${env:TELEMETRY_BACKEND_TOKEN}.
+      # env:
+      #   - name: TELEMETRY_BACKEND_TOKEN
+      #     value: cpln://secret/<secret-name>.TELEMETRY_BACKEND_TOKEN
       cpu: 100m
       memory: 256Mi
       ports:
@@ -104,7 +108,7 @@ receivers:
   statsd/tcp:
     endpoint: 0.0.0.0:9127
     transport: tcp
-    collection_interval: 60s
+    aggregation_interval: 60s
 
 processors:
   memory_limiter:
@@ -156,9 +160,11 @@ from the metrics pipeline and keep `otlphttp/backend`.
 Store backend tokens such as `TELEMETRY_BACKEND_TOKEN` in Control Plane secrets
 and bind them only to the collector workload identity shown in the template
 above. Create the collector identity and a policy that grants `reveal` on only
-the telemetry backend secret before applying the collector workload. Use the
-app identity placeholder only when the collector does not need secrets that are
-isolated from app workloads. See
+the telemetry backend secret before applying the collector workload. When the
+collector config references `${env:TELEMETRY_BACKEND_TOKEN}`, also add the
+matching `env` entry to the collector workload so Control Plane injects the
+secret value at startup. Use the app identity placeholder only when the collector
+does not need secrets that are isolated from app workloads. See
 [Secrets and ENV Values](../secrets-and-env-values.md) for the recommended
 pattern.
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -54,8 +54,9 @@ spec:
       # required by your telemetry backend.
       outboundAllowHostname:
         - telemetry-backend.example.com
-  # cpflow apply-template replaces this with the app workload identity link.
-  identityLink: "{{APP_IDENTITY_LINK}}"
+  # Use a collector-specific identity when the collector reads telemetry
+  # backend secrets that app workloads should not reveal.
+  identityLink: "//identity/{{APP_NAME}}-otel-collector-identity"
 ```
 
 Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
@@ -103,7 +104,7 @@ receivers:
   statsd/tcp:
     endpoint: 0.0.0.0:9127
     transport: tcp
-    aggregation_interval: 60s
+    collection_interval: 60s
 
 processors:
   memory_limiter:
@@ -153,7 +154,11 @@ metrics from port `9292`. For push-only metrics backends, remove `prometheus`
 from the metrics pipeline and keep `otlphttp/backend`.
 
 Store backend tokens such as `TELEMETRY_BACKEND_TOKEN` in Control Plane secrets
-and bind them only to the collector workload identity. See
+and bind them only to the collector workload identity shown in the template
+above. Create the collector identity and a policy that grants `reveal` on only
+the telemetry backend secret before applying the collector workload. Use the
+app identity placeholder only when the collector does not need secrets that are
+isolated from app workloads. See
 [Secrets and ENV Values](../secrets-and-env-values.md) for the recommended
 pattern.
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -132,6 +132,16 @@ keep the Prometheus exporter only when your platform or backend scrapes collecto
 metrics from port `9292`. For push-only metrics backends, remove `prometheus`
 from the metrics pipeline and keep `otlphttp/backend`.
 
+Store backend tokens such as `TELEMETRY_BACKEND_TOKEN` in Control Plane secrets
+and bind them only to the collector workload identity. See
+[Secrets and ENV Values](../secrets-and-env-values.md) for the recommended
+pattern.
+
+The Prometheus exporter exposes an unauthenticated scrape endpoint. With
+`same-gvc` firewall isolation, any workload in the same GVC that can reach port
+`9292` can read exported metrics. Widen collector inbound access only when that
+is acceptable.
+
 ## StatsD and UDP
 
 The upstream OpenTelemetry StatsD receiver defaults to UDP on port `8125`.

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -264,9 +264,11 @@ above. List it before `open-telemetry-collector` so `cpflow setup-app` creates
 the collector identity and secret reveal policy before applying the workload
 that references `identityLink`.
 
-Apply the collector template directly:
+For an existing app, apply the identity and policy template before applying the
+collector workload:
 
 ```sh
+cpflow apply-template open-telemetry-collector-secrets -a $APP_NAME
 cpflow apply-template open-telemetry-collector -a $APP_NAME
 ```
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -24,7 +24,7 @@ spec:
   type: standard
   containers:
     - name: open-telemetry-collector
-      image: "otel/opentelemetry-collector-contrib:0.155.0"
+      image: "registry.example.com/example/open-telemetry-collector:0.155.0"
       args:
         - "--config=/etc/otelcol-contrib/config.yaml"
       cpu: 100m
@@ -53,6 +53,8 @@ spec:
       # required by your telemetry backend.
       outboundAllowHostname:
         - telemetry-backend.example.com
+  # cpflow apply-template replaces this with the app workload identity link.
+  identityLink: "{{APP_IDENTITY_LINK}}"
 ```
 
 Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
@@ -62,6 +64,23 @@ production unless your security model explicitly accepts that risk.
 Keep the collector image pinned to a tested release and update it as part of
 normal dependency maintenance. Do not rely on a floating `latest` tag for
 production workloads.
+
+## Delivering Collector Config
+
+The official collector image does not include your application-specific
+`config.yaml`. A simple Control Plane pattern is to build a small collector image
+that starts from the pinned upstream image and copies the config into the path
+used by the workload command.
+
+```dockerfile
+FROM otel/opentelemetry-collector-contrib:0.155.0
+
+COPY config.yaml /etc/otelcol-contrib/config.yaml
+```
+
+Publish that image to your registry, then use the published image in the
+workload template. Use a different delivery mechanism only if your team already
+has a standard way to provide files to Control Plane workloads.
 
 ## Matching Collector Config
 
@@ -142,6 +161,9 @@ The Prometheus exporter exposes an unauthenticated scrape endpoint. With
 `9292` can read exported metrics. Widen collector inbound access only when that
 is acceptable.
 
+Port `9292` is an example scrape port. Configure your scraper to match the port
+you expose in the workload template and bind in the collector config.
+
 ## StatsD and UDP
 
 The upstream OpenTelemetry StatsD receiver defaults to UDP on port `8125`.
@@ -155,6 +177,10 @@ Safer defaults:
 1. Prefer OTLP metrics over HTTP on `4318`.
 2. Use StatsD over TCP only when your app client and collector build support it.
 3. Treat UDP StatsD as an environment-specific advanced option.
+
+If you remove StatsD, remove all three pieces together: the workload port, the
+`statsd/tcp` receiver block, and `statsd/tcp` from the metrics pipeline
+receivers.
 
 ## `controlplane.yml`
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -1,0 +1,169 @@
+# Collector Workload
+
+The OpenTelemetry Collector is a telemetry router. It receives data from
+application workloads, optionally processes or samples it, and exports it to one
+or more backends.
+
+The two files that must agree are:
+
+1. The Control Plane workload template, which exposes ports.
+2. The collector `config.yaml`, which binds receivers and exporters to those
+   same ports.
+
+If these files disagree, telemetry can fail silently.
+
+## Control Plane Workload Template
+
+Add a template such as
+`.controlplane/templates/open-telemetry-collector.yml`.
+
+```yaml
+kind: workload
+name: open-telemetry-collector
+spec:
+  type: standard
+  containers:
+    - name: open-telemetry-collector
+      image: "otel/opentelemetry-collector-contrib:0.103.0"
+      args:
+        - "--config=/etc/otelcol-contrib/config.yaml"
+      cpu: 100m
+      memory: 256Mi
+      ports:
+        # OTLP over HTTP from application SDKs.
+        - number: 4318
+          protocol: http
+        # Optional StatsD over TCP. Use only if your collector config enables it.
+        - number: 9127
+          protocol: tcp
+        # Prometheus-formatted metrics exposed by the collector.
+        - number: 9292
+          protocol: http
+  defaultOptions:
+    autoscaling:
+      metric: disabled
+      minScale: 1
+      maxScale: 1
+    capacityAI: false
+  firewallConfig:
+    internal:
+      inboundAllowType: same-gvc
+    external:
+      # Prefer a narrow allowlist for production. Use the hostnames or CIDRs
+      # required by your telemetry backend.
+      outboundAllowHostname:
+        - telemetry-backend.example.com
+```
+
+Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
+requires IP ranges. Avoid leaving collector egress open to `0.0.0.0/0` in
+production unless your security model explicitly accepts that risk.
+
+## Matching Collector Config
+
+Mount or bake the collector config at the path passed to `--config`. The contrib
+image convention is `/etc/otelcol-contrib/config.yaml`; use a different path only
+when your image or command is built for it.
+
+The collector config must bind every exposed port. This minimal config receives
+OTLP over HTTP, optionally receives StatsD over TCP, and exposes metrics for
+Prometheus scraping.
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+  statsd/tcp:
+    endpoint: 0.0.0.0:9127
+    transport: tcp
+    aggregation_interval: 60s
+
+processors:
+  batch: {}
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:9292
+
+  # Replace debug with your real trace/log exporters before production use.
+  # Debug can print telemetry payloads, so use it only while validating setup.
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+
+    metrics:
+      receivers: [otlp, statsd/tcp]
+      processors: [batch]
+      exporters: [prometheus]
+
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+```
+
+For production, replace `debug` with the exporter for your tracing or logging
+backend. Keep the Prometheus exporter only when your platform or backend scrapes
+collector metrics from port `9292`.
+
+## StatsD and UDP
+
+The upstream OpenTelemetry StatsD receiver defaults to UDP on port `8125`.
+Control Plane workload templates in this repository currently use `http` and
+`tcp` ports, not `udp`. Do not document or deploy UDP StatsD on Control Plane
+unless you have verified that the platform supports the required UDP forwarding
+path for your workload.
+
+Safer defaults:
+
+1. Prefer OTLP metrics over HTTP on `4318`.
+2. Use StatsD over TCP only when your app client and collector build support it.
+3. Treat UDP StatsD as an environment-specific advanced option.
+
+## `controlplane.yml`
+
+Include the collector in setup and informational commands:
+
+```yaml
+aliases:
+  common: &common
+    setup_app_templates:
+      - app
+      - worker
+      - open-telemetry-collector
+
+    app_workloads:
+      - app
+      - worker
+
+    additional_workloads:
+      - open-telemetry-collector
+```
+
+Apply the collector template directly:
+
+```sh
+cpflow apply-template open-telemetry-collector -a $APP_NAME
+```
+
+Or let `cpflow setup-app` apply it with the other templates listed in
+`setup_app_templates`.
+
+## Port Agreement Checklist
+
+| Purpose | Workload port | Collector config |
+| --- | --- | --- |
+| OTLP HTTP | `4318`, `protocol: http` | `receivers.otlp.protocols.http.endpoint: 0.0.0.0:4318` |
+| StatsD TCP | `9127`, `protocol: tcp` | `receivers.statsd/tcp.endpoint: 0.0.0.0:9127` and `transport: tcp` |
+| Prometheus output | `9292`, `protocol: http` | `exporters.prometheus.endpoint: 0.0.0.0:9292` |
+
+Remove any port that is not enabled in the collector config.

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -37,8 +37,8 @@ spec:
         # OTLP over HTTP from application SDKs.
         - number: 4318
           protocol: http
-        # StatsD over TCP. Delete this port unless your collector config
-        # enables statsd/tcp and app clients send TCP StatsD.
+        # StatsD over TCP, not UDP. Delete this port unless your collector
+        # config enables statsd/tcp and app clients set TCP transport.
         # When deleting it, also remove receivers.statsd/tcp and statsd/tcp
         # from service.pipelines.metrics.receivers in config.yaml.
         - number: 9127
@@ -183,7 +183,10 @@ Before applying the config, replace `telemetry-backend.example.com` with your
 real backend endpoint and headers. Keep `memory_limiter` before `batch`, and
 keep the Prometheus exporter only when your platform or backend scrapes collector
 metrics from port `9292`. For push-only metrics backends, remove `prometheus`
-from the metrics pipeline and keep `otlphttp/backend`.
+from the metrics pipeline and keep `otlphttp/backend`. If your application only
+sends OTLP metrics and does not use StatsD, also remove the `statsd/tcp`
+receiver block and `statsd/tcp` from the `metrics.receivers` list. See
+[StatsD and UDP](#statsd-and-udp) for the full three-piece removal.
 
 Store backend tokens such as `TELEMETRY_BACKEND_TOKEN` in Control Plane secrets
 and bind them only to the collector workload identity shown in the template
@@ -232,6 +235,7 @@ aliases:
     setup_app_templates:
       - app
       - worker
+      - open-telemetry-collector-secrets
       - open-telemetry-collector
 
     app_workloads:
@@ -245,6 +249,11 @@ apps:
   example:
     <<: *common
 ```
+
+Use `open-telemetry-collector-secrets` for the identity and policy YAML shown
+above. List it before `open-telemetry-collector` so `cpflow setup-app` creates
+the collector identity and secret reveal policy before applying the workload
+that references `identityLink`.
 
 Apply the collector template directly:
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -34,6 +34,7 @@ spec:
         - number: 4318
           protocol: http
         # Optional StatsD over TCP. Use only if your collector config enables it.
+        # 9127 is not a standard StatsD port; set the same port in app code.
         - number: 9127
           protocol: tcp
         # Prometheus-formatted metrics exposed by the collector.
@@ -200,6 +201,10 @@ aliases:
 
     additional_workloads:
       - open-telemetry-collector
+
+apps:
+  example:
+    <<: *common
 ```
 
 Apply the collector template directly:

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -30,7 +30,7 @@ spec:
       # Uncomment when config.yaml references ${env:TELEMETRY_BACKEND_TOKEN}.
       # env:
       #   - name: TELEMETRY_BACKEND_TOKEN
-      #     value: cpln://secret/<secret-name>.TELEMETRY_BACKEND_TOKEN
+      #     value: cpln://secret/{{APP_NAME}}-telemetry-backend.TELEMETRY_BACKEND_TOKEN
       cpu: 100m
       memory: 256Mi
       ports:
@@ -70,7 +70,8 @@ Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
 requires IP ranges. Avoid leaving collector egress open to `0.0.0.0/0` in
 production unless your security model explicitly accepts that risk.
 
-Create the collector identity and a secret policy before applying the workload
+Create the collector identity and a secret policy in a separate
+`open-telemetry-collector-secrets` template before applying the workload
 template if the collector reads backend tokens from Control Plane secrets:
 
 ```yaml
@@ -89,12 +90,13 @@ bindings:
       - "//gvc/{{APP_NAME}}/identity/{{APP_NAME}}-otel-collector-identity"
 targetKind: secret
 targetLinks:
-  - "//secret/<secret-name>"
+  - "//secret/{{APP_NAME}}-telemetry-backend"
 ```
 
-Replace `<secret-name>` with the dictionary secret that stores
-`TELEMETRY_BACKEND_TOKEN`. Keep this policy scoped to only the backend secret
-the collector needs.
+Create the `{{APP_NAME}}-telemetry-backend` dictionary secret with a
+`TELEMETRY_BACKEND_TOKEN` key, or replace that name consistently before
+applying the templates. Keep this policy scoped to only the backend secret the
+collector needs.
 
 `cpflow apply-template` replaces `{{APP_NAME}}` with the actual app name. When
 applying the YAML directly with `cpln`, replace `{{APP_NAME}}` manually before
@@ -265,6 +267,10 @@ above. List it before `open-telemetry-collector` so `cpflow setup-app` creates
 the collector identity and secret reveal policy before applying the workload
 that references `identityLink`.
 
+Keep `app_workloads` limited to real application workloads such as `app` and
+`worker`. Put the collector under `additional_workloads` so informational
+commands show it without treating it as an app process.
+
 For an existing app, apply the identity and policy template before applying the
 collector workload:
 
@@ -273,8 +279,8 @@ cpflow apply-template open-telemetry-collector-secrets -a $APP_NAME
 cpflow apply-template open-telemetry-collector -a $APP_NAME
 ```
 
-For a brand-new app, `cpflow setup-app` applies it with the other templates
-listed in `setup_app_templates`.
+For a brand-new app, `cpflow setup-app` applies both collector templates with
+the other entries listed in `setup_app_templates`, in the order shown above.
 
 ## Port Agreement Checklist
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -148,7 +148,7 @@ receivers:
   statsd/tcp:
     endpoint: 0.0.0.0:9127
     transport: tcp
-    aggregation_interval: 60s  # metrics appear after this window closes
+    aggregation_interval: 60s  # Use 5s during initial validation.
 
 processors:
   memory_limiter:
@@ -201,6 +201,10 @@ from the metrics pipeline and keep `otlphttp/backend`. If your application only
 sends OTLP metrics and does not use StatsD, also remove the `statsd/tcp`
 receiver block and `statsd/tcp` from the `metrics.receivers` list. See
 [StatsD and UDP](#statsd-and-udp) for the full three-piece removal.
+
+If you have no OTLP push backend at all, remove `otlphttp/backend` from the
+traces, metrics, and logs pipelines and delete the `otlphttp/backend` exporter
+block entirely.
 
 Store backend tokens such as `TELEMETRY_BACKEND_TOKEN` in Control Plane secrets
 and bind them only to the collector workload identity shown in the template

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -37,8 +37,10 @@ spec:
         # OTLP over HTTP from application SDKs.
         - number: 4318
           protocol: http
-        # Optional StatsD over TCP. Use only if your collector config enables it.
-        # 9127 is not a standard StatsD port; set the same port in app code.
+        # StatsD over TCP. Delete this port unless your collector config
+        # enables statsd/tcp and app clients send TCP StatsD.
+        # When deleting it, also remove receivers.statsd/tcp and statsd/tcp
+        # from service.pipelines.metrics.receivers in config.yaml.
         - number: 9127
           protocol: tcp
         # Prometheus-formatted metrics exposed by the collector.
@@ -66,6 +68,32 @@ spec:
 Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
 requires IP ranges. Avoid leaving collector egress open to `0.0.0.0/0` in
 production unless your security model explicitly accepts that risk.
+
+Create the collector identity and a secret policy before applying the workload
+template if the collector reads backend tokens from Control Plane secrets:
+
+```yaml
+kind: identity
+name: "{{APP_NAME}}-otel-collector-identity"
+description: "{{APP_NAME}}-otel-collector-identity"
+
+---
+kind: policy
+name: "{{APP_NAME}}-otel-collector-secrets"
+description: "{{APP_NAME}}-otel-collector-secrets"
+bindings:
+  - permissions:
+      - reveal
+    principalLinks:
+      - "//gvc/{{APP_NAME}}/identity/{{APP_NAME}}-otel-collector-identity"
+targetKind: secret
+targetLinks:
+  - "//secret/<secret-name>"
+```
+
+Replace `<secret-name>` with the dictionary secret that stores
+`TELEMETRY_BACKEND_TOKEN`. Keep this policy scoped to only the backend secret
+the collector needs.
 
 Keep the collector image pinned to a tested release and update it as part of
 normal dependency maintenance. Do not rely on a floating `latest` tag for

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -24,7 +24,7 @@ spec:
   type: standard
   containers:
     - name: open-telemetry-collector
-      image: "otel/opentelemetry-collector-contrib:0.103.0"
+      image: "otel/opentelemetry-collector-contrib:0.155.0"
       args:
         - "--config=/etc/otelcol-contrib/config.yaml"
       cpu: 100m
@@ -59,6 +59,10 @@ Use `outboundAllowCIDR` instead of `outboundAllowHostname` when your backend
 requires IP ranges. Avoid leaving collector egress open to `0.0.0.0/0` in
 production unless your security model explicitly accepts that risk.
 
+Keep the collector image pinned to a tested release and update it as part of
+normal dependency maintenance. Do not rely on a floating `latest` tag for
+production workloads.
+
 ## Matching Collector Config
 
 Mount or bake the collector config at the path passed to `--config`. The contrib
@@ -82,13 +86,25 @@ receivers:
     aggregation_interval: 60s
 
 processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
   batch: {}
 
 exporters:
   prometheus:
     endpoint: 0.0.0.0:9292
 
-  # Replace debug with your real trace/log exporters before production use.
+  # TODO: replace debug with your real trace/log exporters before production.
+  # Example shape:
+  #
+  # otlphttp/traces:
+  #   endpoint: "https://telemetry-backend.example.com"
+  #   headers:
+  #     Authorization: "Bearer ${env:TELEMETRY_BACKEND_TOKEN}"
+  #
   # Debug can print telemetry payloads, so use it only while validating setup.
   debug:
     verbosity: basic
@@ -97,23 +113,23 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [debug]
+      processors: [memory_limiter, batch]
+      exporters: [debug] # TODO: replace with your trace exporter.
 
     metrics:
       receivers: [otlp, statsd/tcp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters: [prometheus]
 
     logs:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [debug]
+      processors: [memory_limiter, batch]
+      exporters: [debug] # TODO: replace with your log exporter.
 ```
 
 For production, replace `debug` with the exporter for your tracing or logging
-backend. Keep the Prometheus exporter only when your platform or backend scrapes
-collector metrics from port `9292`.
+backend. Keep `memory_limiter` before `batch`, and keep the Prometheus exporter
+only when your platform or backend scrapes collector metrics from port `9292`.
 
 ## StatsD and UDP
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -164,6 +164,8 @@ exporters:
 
   # Replace this placeholder with your real trace/log backend.
   otlphttp/backend:
+    # otlphttp treats this as a base endpoint and appends /v1/traces,
+    # /v1/metrics, or /v1/logs for each signal.
     endpoint: "https://telemetry-backend.example.com"
     # headers:
     #   Authorization: "Bearer ${env:TELEMETRY_BACKEND_TOKEN}"

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -148,7 +148,7 @@ receivers:
   statsd/tcp:
     endpoint: 0.0.0.0:9127
     transport: tcp
-    aggregation_interval: 60s
+    aggregation_interval: 60s  # metrics appear after this window closes
 
 processors:
   memory_limiter:
@@ -286,10 +286,8 @@ the other entries listed in `setup_app_templates`, in the order shown above.
 
 ## Port Agreement Checklist
 
-| Purpose | Workload port | Collector config |
-| --- | --- | --- |
-| OTLP HTTP | `4318`, `protocol: http` | `receivers.otlp.protocols.http.endpoint: 0.0.0.0:4318` |
-| StatsD TCP | `9127`, `protocol: tcp` | `receivers.statsd/tcp.endpoint: 0.0.0.0:9127` and `transport: tcp` |
-| Prometheus output | `9292`, `protocol: http` | `exporters.prometheus.endpoint: 0.0.0.0:9292` |
-
-Remove any port that is not enabled in the collector config.
+The Control Plane workload template and collector config must agree on every
+exposed port. See
+[Verify Port Agreement](troubleshooting.md#4-verify-port-agreement) for the
+canonical port checklist. Remove any workload port that is not enabled in the
+collector config.

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -39,6 +39,7 @@ spec:
           protocol: http
         # StatsD over TCP, not UDP. Delete this port unless your collector
         # config enables statsd/tcp and app clients set TCP transport.
+        # 9127 is project-specific; StatsD defaults to 8125/UDP.
         # When deleting it, also remove receivers.statsd/tcp and statsd/tcp
         # from service.pipelines.metrics.receivers in config.yaml.
         - number: 9127

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -97,24 +97,23 @@ exporters:
   prometheus:
     endpoint: 0.0.0.0:9292
 
-  # TODO: replace debug with your real trace/log exporters before production.
-  # Example shape:
-  #
-  # otlphttp/traces:
-  #   endpoint: "https://telemetry-backend.example.com"
-  #   headers:
-  #     Authorization: "Bearer ${env:TELEMETRY_BACKEND_TOKEN}"
-  #
-  # Debug can print telemetry payloads, so use it only while validating setup.
-  debug:
-    verbosity: basic
+  # Replace this placeholder with your real trace/log backend.
+  otlphttp/backend:
+    endpoint: "https://telemetry-backend.example.com"
+    # headers:
+    #   Authorization: "Bearer ${env:TELEMETRY_BACKEND_TOKEN}"
+
+  # Optional validation-only exporter. Do not leave debug in production
+  # pipelines because it writes telemetry payloads to collector logs.
+  # debug:
+  #   verbosity: basic
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug] # TODO: replace with your trace exporter.
+      exporters: [otlphttp/backend]
 
     metrics:
       receivers: [otlp, statsd/tcp]
@@ -124,12 +123,13 @@ service:
     logs:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [debug] # TODO: replace with your log exporter.
+      exporters: [otlphttp/backend]
 ```
 
-For production, replace `debug` with the exporter for your tracing or logging
-backend. Keep `memory_limiter` before `batch`, and keep the Prometheus exporter
-only when your platform or backend scrapes collector metrics from port `9292`.
+Before applying the config, replace `telemetry-backend.example.com` with your
+real backend endpoint and headers. Keep `memory_limiter` before `batch`, and
+keep the Prometheus exporter only when your platform or backend scrapes collector
+metrics from port `9292`.
 
 ## StatsD and UDP
 
@@ -171,8 +171,8 @@ Apply the collector template directly:
 cpflow apply-template open-telemetry-collector -a $APP_NAME
 ```
 
-Or let `cpflow setup-app` apply it with the other templates listed in
-`setup_app_templates`.
+For a brand-new app, `cpflow setup-app` applies it with the other templates
+listed in `setup_app_templates`.
 
 ## Port Agreement Checklist
 

--- a/docs/telemetry/collector.md
+++ b/docs/telemetry/collector.md
@@ -164,9 +164,9 @@ exporters:
 
   # Replace this placeholder with your real trace/log backend.
   otlphttp/backend:
-    # otlphttp treats this as a base endpoint and appends /v1/traces,
-    # /v1/metrics, or /v1/logs for each signal.
     endpoint: "https://telemetry-backend.example.com"
+    # This is a base URL. The exporter appends /v1/traces, /v1/metrics,
+    # and /v1/logs automatically. Do not include the signal path here.
     # headers:
     #   Authorization: "Bearer ${env:TELEMETRY_BACKEND_TOKEN}"
 

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -110,13 +110,15 @@ StatsD client or when a metric library cannot emit OTLP yet.
    `.controlplane/templates/open-telemetry-collector.yml`.
 2. Package a collector `config.yaml` that binds every port exposed by the
    workload template.
-3. Add both collector templates to `setup_app_templates`:
+3. Build the collector image and push it to your registry. Update the workload
+   template's `image:` field to that pushed image reference before applying it.
+4. Add both collector templates to `setup_app_templates`:
    `open-telemetry-collector-secrets` first, then
    `open-telemetry-collector`.
-4. Add the collector to `additional_workloads`.
-5. Set application env vars such as `OTEL_SERVICE_NAME`,
+5. Add the collector to `additional_workloads`.
+6. Set application env vars such as `OTEL_SERVICE_NAME`,
    `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
-6. For an existing app, apply both collector templates in the same order:
+7. For an existing app, apply both collector templates in the same order:
    identity and policy first, then the collector workload.
 
    ```sh
@@ -126,7 +128,7 @@ StatsD client or when a metric library cannot emit OTLP yet.
 
    For a brand-new app, `cpflow setup-app` applies the configured templates in
    `setup_app_templates` order.
-7. Confirm collector logs, application exporter logs, and backend ingestion.
+8. Confirm collector logs, application exporter logs, and backend ingestion.
 
 The collector workload and its `config.yaml` must be kept in sync. If the
 workload exposes `4318`, `9127`, or `9292`, the collector config must bind those

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -12,11 +12,11 @@ send traces, metrics, and logs.
 
 | Page | Use it for |
 | --- | --- |
-| [Collector workload](telemetry/collector.md) | Control Plane workload template, collector ports, and matching `config.yaml` |
-| [Application instrumentation](telemetry/application-instrumentation.md) | Generic app env vars and simple Ruby/Node examples |
-| [Pipelines](telemetry/pipelines.md) | Receivers, processors, exporters, and how signals flow |
-| [Review apps](telemetry/review-apps.md) | Review-app isolation, sampling, secrets, and egress controls |
-| [Troubleshooting](telemetry/troubleshooting.md) | Commands and checks for missing telemetry |
+| [Collector workload](collector.md) | Control Plane workload template, collector ports, and matching `config.yaml` |
+| [Application instrumentation](application-instrumentation.md) | Generic app env vars and simple Ruby/Node examples |
+| [Pipelines](pipelines.md) | Receivers, processors, exporters, and how signals flow |
+| [Review apps](review-apps.md) | Review-app isolation, sampling, secrets, and egress controls |
+| [Troubleshooting](troubleshooting.md) | Commands and checks for missing telemetry |
 
 ## Recommended Shape
 
@@ -142,7 +142,6 @@ or domain-specific nouns that only make sense in one business.
 
 ## More Detail
 
-Start with [Collector workload](telemetry/collector.md), then read
-[Application instrumentation](telemetry/application-instrumentation.md). Use
-[Troubleshooting](telemetry/troubleshooting.md) when signals do not appear in
-the backend.
+Start with [Collector workload](collector.md), then read
+[Application instrumentation](application-instrumentation.md). Use
+[Troubleshooting](troubleshooting.md) when signals do not appear in the backend.

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -23,7 +23,7 @@ send traces, metrics, and logs.
 ```mermaid
 flowchart LR
   app["Application workload(s)"]
-  collector["OpenTelemetry Collector workload"]
+  collector["Collector workload"]
   backend["Telemetry backend(s)"]
   dashboard["Dashboards and alerts"]
 
@@ -126,19 +126,10 @@ collector receiver or exporter.
 
 ## Generic Naming
 
-Use names that describe the application or workload without leaking
-environment-specific details.
-
-Good examples:
-
-- `example-web`
-- `example-worker`
-- `example.tasks.completed`
-- `example.jobs.duration_ms`
-- `deployment.environment=staging`
-
-Avoid examples that include real company names, user IDs, request IDs, raw URLs,
-or domain-specific nouns that only make sense in one business.
+Use generic service names, metric names, and resource attributes in reusable
+telemetry templates. See
+[Service Names](application-instrumentation.md#service-names) for examples and
+avoidance rules.
 
 ## More Detail
 

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -106,17 +106,25 @@ StatsD client or when a metric library cannot emit OTLP yet.
 
 ## Minimal Rollout Checklist
 
-1. Add `.controlplane/templates/open-telemetry-collector.yml`.
+1. Add `.controlplane/templates/open-telemetry-collector-secrets.yml` and
+   `.controlplane/templates/open-telemetry-collector.yml`.
 2. Package a collector `config.yaml` that binds every port exposed by the
    workload template.
-3. Add the collector template to `setup_app_templates`.
+3. Add `open-telemetry-collector-secrets` and `open-telemetry-collector` to
+   `setup_app_templates`, with the secrets template first.
 4. Add the collector to `additional_workloads`.
 5. Set application env vars such as `OTEL_SERVICE_NAME`,
    `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
-6. Apply the collector template with
-   `cpflow apply-template open-telemetry-collector -a $APP_NAME`. For a
-   brand-new app, `cpflow setup-app` applies it with the other configured
-   templates.
+6. For an existing app, apply the identity and policy template first, then the
+   collector workload:
+
+   ```sh
+   cpflow apply-template open-telemetry-collector-secrets -a $APP_NAME
+   cpflow apply-template open-telemetry-collector -a $APP_NAME
+   ```
+
+   For a brand-new app, `cpflow setup-app` applies the configured templates in
+   `setup_app_templates` order.
 7. Confirm collector logs, application exporter logs, and backend ingestion.
 
 The collector workload and its `config.yaml` must be kept in sync. If the

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -110,13 +110,14 @@ StatsD client or when a metric library cannot emit OTLP yet.
    `.controlplane/templates/open-telemetry-collector.yml`.
 2. Package a collector `config.yaml` that binds every port exposed by the
    workload template.
-3. Add `open-telemetry-collector-secrets` and `open-telemetry-collector` to
-   `setup_app_templates`, with the secrets template first.
+3. Add both collector templates to `setup_app_templates`:
+   `open-telemetry-collector-secrets` first, then
+   `open-telemetry-collector`.
 4. Add the collector to `additional_workloads`.
 5. Set application env vars such as `OTEL_SERVICE_NAME`,
    `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
-6. For an existing app, apply the identity and policy template first, then the
-   collector workload:
+6. For an existing app, apply both collector templates in the same order:
+   identity and policy first, then the collector workload.
 
    ```sh
    cpflow apply-template open-telemetry-collector-secrets -a $APP_NAME

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -112,10 +112,13 @@ StatsD client or when a metric library cannot emit OTLP yet.
    workload template.
 3. Build the collector image and push it to your registry. Update the workload
    template's `image:` field to that pushed image reference before applying it.
-4. Add both collector templates to `setup_app_templates`:
+4. Add both collector templates to `setup_app_templates` in
+   `.controlplane/controlplane.yml` (see
+   [Collector `controlplane.yml`](collector.md#controlplaneyml)):
    `open-telemetry-collector-secrets` first, then
    `open-telemetry-collector`.
-5. Add the collector to `additional_workloads`.
+5. Add the collector to `additional_workloads` in
+   `.controlplane/controlplane.yml`.
 6. Set application env vars such as `OTEL_SERVICE_NAME`,
    `OTEL_EXPORTER_OTLP_ENDPOINT`, and `OTEL_EXPORTER_OTLP_PROTOCOL`.
 7. For an existing app, apply both collector templates in the same order:

--- a/docs/telemetry/pipelines.md
+++ b/docs/telemetry/pipelines.md
@@ -26,9 +26,7 @@ flowchart LR
 ```mermaid
 flowchart TB
   app["Application"]
-  otlp_traces["OTLP traces receiver :4318"]
-  otlp_metrics["OTLP metrics receiver :4318"]
-  otlp_logs["OTLP logs receiver :4318"]
+  otlp["OTLP receiver :4318"]
   statsd["Optional StatsD TCP metrics receiver :9127"]
   traces_processors["Trace processors"]
   metrics_processors["Metrics processors"]
@@ -38,14 +36,14 @@ flowchart TB
   prometheus["Prometheus scrape exporter :9292"]
   logs["Log exporter"]
 
-  app -->|"OTLP traces"| otlp_traces
-  app -->|"OTLP metrics"| otlp_metrics
-  app -->|"OTLP logs"| otlp_logs
+  app -->|"OTLP traces, metrics, logs"| otlp
   app -->|"StatsD metrics only"| statsd
-  otlp_traces --> traces_processors --> traces
-  otlp_metrics --> metrics_processors --> metrics_push
-  statsd --> metrics_processors --> prometheus
-  otlp_logs --> logs_processors --> logs
+  otlp -->|"traces"| traces_processors --> traces
+  otlp -->|"metrics"| metrics_processors
+  statsd -->|"metrics"| metrics_processors
+  metrics_processors --> metrics_push
+  metrics_processors --> prometheus
+  otlp -->|"logs"| logs_processors --> logs
 ```
 
 Start with direct application telemetry:

--- a/docs/telemetry/pipelines.md
+++ b/docs/telemetry/pipelines.md
@@ -1,0 +1,94 @@
+# Telemetry Pipelines
+
+Collectors organize telemetry into signal-specific pipelines. Each pipeline has
+receivers, optional processors, and exporters.
+
+```mermaid
+flowchart LR
+  receiver["Receiver"]
+  processor["Processor"]
+  exporter["Exporter"]
+
+  receiver --> processor
+  processor --> exporter
+```
+
+## Pipeline Components
+
+| Component | Role | Examples |
+| --- | --- | --- |
+| Receiver | Accepts telemetry from apps | OTLP HTTP, StatsD TCP |
+| Processor | Modifies, batches, filters, or samples telemetry | `batch`, `memory_limiter`, `attributes` |
+| Exporter | Sends telemetry to a backend or exposes it for scrape | OTLP exporter, Prometheus exporter, debug exporter |
+
+## Recommended Initial Pipelines
+
+```mermaid
+flowchart TB
+  app["Application"]
+  otlp["OTLP receiver :4318"]
+  statsd["Optional StatsD TCP receiver :9127"]
+  batch["Batch processor"]
+  traces["Trace exporter"]
+  prometheus["Prometheus exporter :9292"]
+  logs["Log exporter"]
+
+  app -->|"traces, metrics, logs"| otlp
+  app -->|"optional direct metrics"| statsd
+  otlp --> batch
+  statsd --> batch
+  batch --> traces
+  batch --> prometheus
+  batch --> logs
+```
+
+Start with direct application telemetry:
+
+1. OTLP traces from the app SDK.
+2. OTLP metrics from the app SDK, or StatsD TCP if that is what the app already
+   supports.
+3. Structured logs to stdout/stderr, or OTLP logs if your logging library
+   supports them.
+
+## Direct Metrics First
+
+Prefer direct metrics from application code when you can change the code. Direct
+metrics are explicit, cheap, and easy to test.
+
+Good direct metrics:
+
+- `example.requests.completed`
+- `example.jobs.duration_ms`
+- `example.queue.depth`
+- `example.cache.hit`
+
+Use low-cardinality labels such as:
+
+- `status`
+- `route_name`
+- `worker`
+- `deployment.environment`
+
+## Derived Metrics
+
+Derived metrics can be useful, but they should not be the default for new work.
+
+| Source | Use when | Caution |
+| --- | --- | --- |
+| Spans | You already have spans and need latency/error histograms | Attribute choices can create high cardinality |
+| Logs | You cannot change legacy code yet | Regex processing is expensive and fragile |
+
+When a derived metric proves valuable, prefer moving it into direct application
+instrumentation later.
+
+## Sampling
+
+Sampling belongs in the collector when you need centralized control. A common
+policy shape is:
+
+1. Keep all error traces.
+2. Keep a small percentage of fast successful traces.
+3. Keep a larger percentage of slow successful traces.
+
+Record sampling decisions in the collector config so agents and humans know why
+some traces are absent.

--- a/docs/telemetry/pipelines.md
+++ b/docs/telemetry/pipelines.md
@@ -26,20 +26,26 @@ flowchart LR
 ```mermaid
 flowchart TB
   app["Application"]
-  otlp["OTLP receiver :4318"]
-  statsd["Optional StatsD TCP receiver :9127"]
-  batch["Batch processor"]
+  otlp_traces["OTLP traces receiver :4318"]
+  otlp_metrics["OTLP metrics receiver :4318"]
+  otlp_logs["OTLP logs receiver :4318"]
+  statsd["Optional StatsD TCP metrics receiver :9127"]
+  traces_processors["Trace processors"]
+  metrics_processors["Metrics processors"]
+  logs_processors["Log processors"]
   traces["Trace exporter"]
-  prometheus["Prometheus exporter :9292"]
+  metrics_push["Metrics push exporter"]
+  prometheus["Prometheus scrape exporter :9292"]
   logs["Log exporter"]
 
-  app -->|"traces, metrics, logs"| otlp
-  app -->|"optional direct metrics"| statsd
-  otlp --> batch
-  statsd --> batch
-  batch --> traces
-  batch --> prometheus
-  batch --> logs
+  app -->|"OTLP traces"| otlp_traces
+  app -->|"OTLP metrics"| otlp_metrics
+  app -->|"OTLP logs"| otlp_logs
+  app -->|"StatsD metrics only"| statsd
+  otlp_traces --> traces_processors --> traces
+  otlp_metrics --> metrics_processors --> metrics_push
+  statsd --> metrics_processors --> prometheus
+  otlp_logs --> logs_processors --> logs
 ```
 
 Start with direct application telemetry:

--- a/docs/telemetry/review-apps.md
+++ b/docs/telemetry/review-apps.md
@@ -22,7 +22,9 @@ flowchart TB
 
 1. Use a collector inside each review app GVC, or a staging-only shared collector
    that is intentionally isolated from production.
-2. Keep collector inbound access internal with `same-gvc`.
+2. Keep collector inbound access internal with `same-gvc` when the collector is
+   inside the review app GVC. For a staging-only shared collector in another
+   GVC, configure explicit cross-GVC ingress instead of broad public access.
 3. Do not give review apps production telemetry tokens.
 4. Use lower sampling rates and shorter retention for review apps.
 5. Avoid sending request bodies, credentials, or personally identifiable

--- a/docs/telemetry/review-apps.md
+++ b/docs/telemetry/review-apps.md
@@ -1,0 +1,53 @@
+# Review Apps
+
+Review-app telemetry should help debug a change without giving untrusted or
+short-lived environments access to production telemetry credentials.
+
+```mermaid
+flowchart TB
+  subgraph review["Review app GVC"]
+    app["Review app workloads"]
+    collector["Review collector"]
+  end
+
+  subgraph staging["Staging telemetry"]
+    backend["Non-production backend"]
+  end
+
+  app --> collector
+  collector --> backend
+```
+
+## Recommended Defaults
+
+1. Use a collector inside each review app GVC, or a staging-only shared collector
+   that is intentionally isolated from production.
+2. Keep collector inbound access internal with `same-gvc`.
+3. Do not give review apps production telemetry tokens.
+4. Use lower sampling rates and shorter retention for review apps.
+5. Avoid sending request bodies, credentials, or personally identifiable
+   information in spans, labels, or logs.
+6. Restrict outbound egress to the non-production telemetry backend.
+
+## Environment Separation
+
+Use resource attributes to make review telemetry easy to filter:
+
+```yaml
+env:
+  - name: OTEL_RESOURCE_ATTRIBUTES
+    value: "deployment.environment=review,service.namespace=example"
+```
+
+If every review app has a unique name, keep that name in a bounded attribute only
+when your backend can handle the cardinality. Do not put pull request titles,
+branch names, user names, or request IDs into metric labels.
+
+## Secrets
+
+Store backend tokens in Control Plane secrets and bind only the collector
+identity that needs them. See [Secrets and ENV Values](../secrets-and-env-values.md)
+for the general Control Plane secret pattern.
+
+Review apps should use non-production tokens. If no non-production token exists,
+keep telemetry local to logs until one is available.

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -60,11 +60,11 @@ The Control Plane workload template and collector config must agree.
 From an app workload shell, check that the collector service name resolves:
 
 ```sh
-getent hosts open-telemetry-collector.example-app.cpln.local
+getent hosts open-telemetry-collector.${APP_NAME}.cpln.local
 ```
 
-Replace `example-app` with the actual app name. If your image does not include
-`getent`, use an equivalent DNS tool available in the image.
+Set `APP_NAME` to the actual app name. If your image does not include `getent`,
+use an equivalent DNS tool available in the image.
 
 ## 6. Keep The First Test Simple
 

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -76,8 +76,11 @@ Before adding sampling, filtering, derived metrics, or multiple exporters:
 
 1. Start with one app workload.
 2. Send OTLP traces over HTTP.
-3. Export to a debug exporter or one known backend. Remove the debug exporter
-   before production use; it writes full telemetry payloads to collector logs.
+3. Export to a debug exporter or one known backend. To enable the debug
+   exporter, uncomment the `debug:` block in your collector config, add `debug`
+   to the relevant pipeline exporters list, and rebuild or remount the config.
+   Remove the debug exporter before production use; it writes full telemetry
+   payloads to collector logs.
 4. Confirm data appears.
 5. Add metrics and logs after traces work.
 

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -76,5 +76,9 @@ Before adding sampling, filtering, derived metrics, or multiple exporters:
 4. Confirm data appears.
 5. Add metrics and logs after traces work.
 
+Use the debug exporter only for short validation windows. It writes full
+telemetry payloads to collector logs, so remove or disable it before sending
+production traffic or attributes that may contain sensitive data.
+
 Small steps make it much easier to tell whether the app, collector, network, or
 backend is the source of the problem.

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -2,6 +2,12 @@
 
 Use this checklist when telemetry does not appear in the backend.
 
+Set `APP_NAME` before running the examples:
+
+```sh
+APP_NAME=your-app-name
+```
+
 ## 1. Confirm Workloads
 
 ```sh

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -76,7 +76,8 @@ Before adding sampling, filtering, derived metrics, or multiple exporters:
 
 1. Start with one app workload.
 2. Send OTLP traces over HTTP.
-3. Export to a debug exporter or one known backend.
+3. Export to a debug exporter or one known backend. Remove the debug exporter
+   before production use; it writes full telemetry payloads to collector logs.
 4. Confirm data appears.
 5. Add metrics and logs after traces work.
 

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -17,6 +17,10 @@ cpflow ps -a $APP_NAME -w app
 
 Replace `app` with the workload you are checking.
 
+`cpflow ps` lists running replicas. If the collector is deployed but scaled to
+zero, restart or scale it before debugging collector config or application
+exporter settings.
+
 ## 2. Check Collector Logs
 
 ```sh

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -1,0 +1,74 @@
+# Telemetry Troubleshooting
+
+Use this checklist when telemetry does not appear in the backend.
+
+## 1. Confirm Workloads
+
+```sh
+cpflow ps -a $APP_NAME -w open-telemetry-collector
+cpflow ps -a $APP_NAME -w app
+```
+
+Replace `app` with the workload you are checking.
+
+## 2. Check Collector Logs
+
+```sh
+cpflow logs -a $APP_NAME -w open-telemetry-collector
+```
+
+Look for:
+
+- config parse errors
+- receiver bind failures
+- exporter authentication failures
+- backend DNS or connection failures
+- dropped data due to memory or queue limits
+
+## 3. Check Application Logs
+
+```sh
+cpflow logs -a $APP_NAME -w app
+```
+
+Look for exporter errors from the application SDK. Common causes are:
+
+- wrong `OTEL_EXPORTER_OTLP_ENDPOINT`
+- app instrumentation not enabled
+- collector service name typo
+- unsupported protocol value
+- backend token missing from the collector
+
+## 4. Verify Port Agreement
+
+The Control Plane workload template and collector config must agree.
+
+| Symptom | Check |
+| --- | --- |
+| App cannot export OTLP | Workload exposes `4318`; collector binds `0.0.0.0:4318` |
+| StatsD metrics missing | Workload exposes `9127`; collector has `statsd/tcp` on `0.0.0.0:9127` |
+| Prometheus scrape empty | Workload exposes `9292`; collector has `prometheus` exporter on `0.0.0.0:9292` |
+
+## 5. Verify DNS
+
+From an app workload shell, check that the collector service name resolves:
+
+```sh
+getent hosts open-telemetry-collector.$APP_NAME.cpln.local
+```
+
+If your image does not include `getent`, use an equivalent DNS tool available in
+the image.
+
+## 6. Keep The First Test Simple
+
+Before adding sampling, filtering, derived metrics, or multiple exporters:
+
+1. Start with one app workload.
+2. Send OTLP traces over HTTP.
+3. Export to a debug exporter or one known backend.
+4. Confirm data appears.
+5. Add metrics and logs after traces work.
+
+Small steps make it much easier to tell whether the app, collector, network, or
+backend is the source of the problem.

--- a/docs/telemetry/troubleshooting.md
+++ b/docs/telemetry/troubleshooting.md
@@ -60,11 +60,11 @@ The Control Plane workload template and collector config must agree.
 From an app workload shell, check that the collector service name resolves:
 
 ```sh
-getent hosts open-telemetry-collector.$APP_NAME.cpln.local
+getent hosts open-telemetry-collector.example-app.cpln.local
 ```
 
-If your image does not include `getent`, use an equivalent DNS tool available in
-the image.
+Replace `example-app` with the actual app name. If your image does not include
+`getent`, use an equivalent DNS tool available in the image.
 
 ## 6. Keep The First Test Simple
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -121,7 +121,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 If your app emits OpenTelemetry, StatsD, or structured log signals, run an
 OpenTelemetry Collector as a Control Plane workload in the same GVC and point
 application env vars at the collector's internal service name. See the
-[telemetry guide](/docs/telemetry/) for the template shape, recommended ports,
+[telemetry guide](/docs/telemetry/index.md) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 
 ## CI

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -121,7 +121,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 If your app emits OpenTelemetry, StatsD, Prometheus, or structured log signals,
 run an OpenTelemetry Collector as a Control Plane workload in the same GVC and
 point application env vars at the collector's internal service name. See the
-[telemetry guide](telemetry.md) for the template shape, recommended ports,
+[telemetry guide](telemetry/) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 
 ## CI

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -121,7 +121,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 If your app emits OpenTelemetry, StatsD, or structured log signals, run an
 OpenTelemetry Collector as a Control Plane workload in the same GVC and point
 application env vars at the collector's internal service name. See the
-[telemetry guide](telemetry/) for the template shape, recommended ports,
+[telemetry guide](/docs/telemetry/) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 
 ## CI

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -118,9 +118,9 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 
 ## Telemetry
 
-If your app emits OpenTelemetry, StatsD, Prometheus, or structured log signals,
-run an OpenTelemetry Collector as a Control Plane workload in the same GVC and
-point application env vars at the collector's internal service name. See the
+If your app emits OpenTelemetry, StatsD, or structured log signals, run an
+OpenTelemetry Collector as a Control Plane workload in the same GVC and point
+application env vars at the collector's internal service name. See the
 [telemetry guide](telemetry/) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -121,7 +121,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 If your app emits OpenTelemetry, StatsD, Prometheus, or structured log signals,
 run an OpenTelemetry Collector as a Control Plane workload in the same GVC and
 point application env vars at the collector's internal service name. See the
-[telemetry guide](/docs/telemetry.md) for the template shape, recommended ports,
+[telemetry guide](telemetry.md) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 
 ## CI

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -121,7 +121,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 If your app emits OpenTelemetry, StatsD, or structured log signals, run an
 OpenTelemetry Collector as a Control Plane workload in the same GVC and point
 application env vars at the collector's internal service name. See the
-[telemetry guide](/docs/telemetry/index.md) for the template shape, recommended ports,
+[telemetry guide](https://www.shakacode.com/control-plane-flow/docs/telemetry/) for the template shape, recommended ports,
 review-app guardrails, and troubleshooting commands.
 
 ## CI

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -6,19 +6,20 @@
 4. [CPU](#cpu)
 5. [Remote IP](#remote-ip)
 6. [Secrets and ENV Values](/docs/secrets-and-env-values.md)
-7. [CI](#ci)
-8. [Logs](#logs)
-9. [Memcached](#memcached)
-10. [Sidekiq](#sidekiq)
+7. [Telemetry](#telemetry)
+8. [CI](#ci)
+9. [Logs](#logs)
+10. [Memcached](#memcached)
+11. [Sidekiq](#sidekiq)
     - [Quieting Non-Critical Workers During Deployments](#quieting-non-critical-workers-during-deployments)
     - [Setting Up a Pre Stop Hook](#setting-up-a-pre-stop-hook)
     - [Setting Up a Liveness Probe](#setting-up-a-liveness-probe)
-11. [Minimizing Non-Production App Costs](#minimizing-non-production-app-costs)
+12. [Minimizing Non-Production App Costs](#minimizing-non-production-app-costs)
     - [Share One Control Plane Postgres for Staging and Review Apps](#share-one-control-plane-postgres-for-staging-and-review-apps)
     - [Enable Capacity AI for Demo and Starter Staging Apps](#enable-capacity-ai-for-demo-and-starter-staging-apps)
     - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
     - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
-12. [Useful Links](#useful-links)
+13. [Useful Links](#useful-links)
 
 ## GVCs vs. Orgs
 
@@ -114,6 +115,14 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 
 > **Warning:** Do not use `REMOTE_ADDR` for authentication, rate limiting, auditing, or IP allowlists. Always use
 > framework-specific mechanisms that understand proxy headers (such as Rails' `request.remote_ip`).
+
+## Telemetry
+
+If your app emits OpenTelemetry, StatsD, Prometheus, or structured log signals,
+run an OpenTelemetry Collector as a Control Plane workload in the same GVC and
+point application env vars at the collector's internal service name. See the
+[telemetry guide](/docs/telemetry.md) for the template shape, recommended ports,
+review-app guardrails, and troubleshooting commands.
 
 ## CI
 


### PR DESCRIPTION
## Summary

- Add a telemetry guide for wiring OpenTelemetry Collector workloads with `cpflow` templates.
- Link the guide from the README and `docs/tips.md`.
- Document the docs-only current path plus possible future `cpflow` enhancements for required telemetry env validation.

## Why

Teams can already use `cpflow apply-template` and `setup_app_templates` to deploy collector workloads, but the docs did not spell out the recommended telemetry shape, app env vars, review-app guardrails, or troubleshooting commands.

## Codex Decision Log

- **Non-blocking:** Should this PR add code support for telemetry validation or generated collector templates?
  - **Decision:** Keep this PR docs-only.
  - **Why:** Existing template support already handles the basic telemetry setup, and generated collector config varies by team/backend.
  - **Review later:** Consider a follow-up for deploy-time required ENV validation.

## Validation

- `script/check_cpln_links README.md docs/tips.md docs/telemetry.md`
- `git diff --cached --check`
- `.agents/bin/docs`
- `.agents/bin/lint`

## Validation Notes

- `.agents/bin/validate` could not run locally because RSpec loads `spec/support/command_helpers.rb`, which requires `CPLN_ORG`; local environment had `CPLN_ORG` unset, so the suite failed before examples ran.
- Repo-local `.agents/workflows/pr-processing.md` is absent on current `origin/main`; PR-batch workflow state for that file is `UNKNOWN`.
