### PR TITLE
[codex] Add source-owned docs sidebar

### DIFF
--- a/docs/grafana-opentelemetry.md
+++ b/docs/grafana-opentelemetry.md
@@ -19,7 +19,7 @@ queries. A collector can receive traces/logs, normalize them, generate focused
 Prometheus metrics, and expose those metrics for Control Plane Grafana to scrape.
 
 For the generic Control Plane telemetry template shape, start with
-[Telemetry](/docs/telemetry/index.md) and
+[Telemetry](/docs/telemetry/) and
 [Collector Workload](/docs/telemetry/collector.md). This guide is the Rails and
 Grafana companion: it focuses on application instrumentation, spanmetrics,
 dashboards, and alerting.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -35,6 +35,7 @@ const sidebars: SidebarsConfig = {
         'telemetry/application-instrumentation',
         'telemetry/pipelines',
         'telemetry/review-apps',
+        'grafana-opentelemetry',
         'telemetry/troubleshooting',
       ],
     },
@@ -43,6 +44,7 @@ const sidebars: SidebarsConfig = {
       label: 'Data Services',
       items: [
         'postgres',
+        'rds-private-networking',
         'redis',
       ],
     },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -1,0 +1,68 @@
+import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
+
+const sidebars: SidebarsConfig = {
+  docsSidebar: [
+    {type: 'doc', id: 'index', label: 'Documentation Guide'},
+    {type: 'doc', id: 'README', label: 'Overview'},
+    {
+      type: 'category',
+      label: 'Start Here',
+      collapsed: false,
+      items: [
+        {type: 'doc', id: 'migrating-heroku-to-control-plane', label: 'Migrate from Heroku'},
+        {type: 'doc', id: 'ci-automation', label: 'Automate GitHub Flow'},
+        {type: 'doc', id: 'ai-github-flow-prompt', label: 'AI Rollout Prompt'},
+        {type: 'doc', id: 'commands', label: 'Command Reference'},
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Core Operations',
+      items: [
+        'secrets-and-env-values',
+        'dns',
+        'thruster',
+        'troubleshooting',
+        'tips',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Telemetry',
+      link: {type: 'doc', id: 'telemetry/index'},
+      items: [
+        'telemetry/collector',
+        'telemetry/application-instrumentation',
+        'telemetry/pipelines',
+        'telemetry/review-apps',
+        'telemetry/troubleshooting',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Data Services',
+      items: [
+        'postgres',
+        'redis',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Terraform',
+      items: [
+        'terraform/overview',
+        'terraform/details',
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Project',
+      items: [
+        {type: 'doc', id: 'releasing', label: 'Releasing the Gem'},
+        {type: 'doc', id: 'changelog', label: 'Changelog'},
+      ],
+    },
+  ],
+};
+
+export default sidebars;


### PR DESCRIPTION
## Summary

- Add `docs/sidebars.ts` as the canonical docs sidebar source for controlplaneflow.com.
- Include the existing Telemetry section and child pages in that source-owned navigation.
- Align Control Plane Flow with the React on Rails pattern where the source repo owns docs sidebar structure and the site repo syncs it.

## Validation

- PASS `.agents/bin/docs`
- PASS `.agents/bin/lint`
- PARTIAL `.agents/bin/validate` with `CPLN_ORG=shakacode-heroku-to-control-plane-ci RSPEC_RETRY_RETRY_COUNT=1`: progressed past org setup but was interrupted after repeated live-suite failure markers in unrelated Control Plane-backed specs.
- PASS `CONTROL_PLANE_FLOW_REPO=/Users/justin/.codex/worktrees/35fc/control-plane-flow npm run build:full` in `controlplaneflow-com`
- PASS `npm run smoke:build` in `controlplaneflow-com`

Related site PR: https://github.com/shakacode/controlplaneflow-com/pull/12