### PR TITLE
Fix review app status URL normalization

### DIFF
--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -499,6 +499,10 @@ jobs:
 
                   raw_cpln_gvc_alias = uri.host.delete_prefix(host_prefix).delete_suffix(host_suffix)
                   cpln_gvc_alias = raw_cpln_gvc_alias.split(".").first
+                  if cpln_gvc_alias.to_s.empty?
+                    puts workload_url
+                    exit
+                  end
                   # Avoid a literal command-substitution token here because actionlint flags it inside single-quoted Ruby.
                   cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"
                   app_url = app_domain_template

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -466,7 +466,14 @@ jobs:
           app_url="${workload_url}"
 
           if [[ -n "${workload_url}" ]]; then
-            gvc_json="$(cpln gvc get "${APP_NAME}" --org "${CPLN_ORG}" -o json 2>/dev/null || true)"
+            gvc_stderr="$(mktemp)"
+            if ! gvc_json="$(cpln gvc get "${APP_NAME}" --org "${CPLN_ORG}" -o json 2>"${gvc_stderr}")"; then
+              echo "::warning::Could not read GVC app_domain; falling back to workload endpoint."
+              sed 's/^/cpln gvc get: /' "${gvc_stderr}" >&2
+              gvc_json=""
+            fi
+            rm -f "${gvc_stderr}"
+
             app_domain_template="$(
               jq -r '.spec.env[]? | select(.name == "app_domain") | .value // empty' <<< "${gvc_json}" | head -n 1
             )"
@@ -475,7 +482,13 @@ jobs:
               app_url="$(
                 ruby -ruri -e '
                   workload_name, workload_url, app_domain_template, app_name = ARGV
-                  uri = URI(workload_url)
+                  begin
+                    uri = URI(workload_url)
+                  rescue URI::InvalidURIError
+                    puts workload_url
+                    exit
+                  end
+
                   host_prefix = "#{workload_name}-"
                   host_suffix = ".cpln.app"
 
@@ -484,13 +497,23 @@ jobs:
                     exit
                   end
 
-                  cpln_gvc_alias = uri.host.delete_prefix(host_prefix).delete_suffix(host_suffix)
+                  raw_cpln_gvc_alias = uri.host.delete_prefix(host_prefix).delete_suffix(host_suffix)
+                  cpln_gvc_alias = raw_cpln_gvc_alias.split(".").first
+                  # Avoid a literal command-substitution token here because actionlint flags it inside single-quoted Ruby.
                   cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"
                   app_url = app_domain_template
                     .gsub(cpln_gvc_alias_token, cpln_gvc_alias)
                     .gsub("{{APP_NAME}}", app_name)
 
-                  app_url = "#{app_url}/" unless app_url.end_with?("/")
+                  begin
+                    app_uri = URI(app_url)
+                    if app_uri.path.to_s.empty? && app_uri.query.nil? && app_uri.fragment.nil?
+                      app_url = "#{app_url}/"
+                    end
+                  rescue URI::InvalidURIError
+                    # Keep the substituted template visible instead of hiding a bad app_domain value.
+                  end
+
                   puts app_url
                 ' "${workload_name}" "${workload_url}" "${app_domain_template}" "${APP_NAME}"
               )"

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -463,7 +463,44 @@ jobs:
           set -euo pipefail
           workload_name="${PRIMARY_WORKLOAD:-rails}"
           workload_url="$(cpln workload get "${workload_name}" --gvc "${APP_NAME}" --org "${CPLN_ORG}" -o json | jq -r '.status.endpoint // empty')"
-          echo "workload_url=${workload_url}" >> "$GITHUB_OUTPUT"
+          app_url="${workload_url}"
+
+          if [[ -n "${workload_url}" ]]; then
+            gvc_json="$(cpln gvc get "${APP_NAME}" --org "${CPLN_ORG}" -o json 2>/dev/null || true)"
+            app_domain_template="$(
+              jq -r '.spec.env[]? | select(.name == "app_domain") | .value // empty' <<< "${gvc_json}" | head -n 1
+            )"
+
+            if [[ -n "${app_domain_template}" ]]; then
+              app_url="$(
+                ruby -ruri -e '
+                  workload_name, workload_url, app_domain_template, app_name = ARGV
+                  uri = URI(workload_url)
+                  host_prefix = "#{workload_name}-"
+                  host_suffix = ".cpln.app"
+
+                  unless uri.host&.start_with?(host_prefix) && uri.host&.end_with?(host_suffix)
+                    puts workload_url
+                    exit
+                  end
+
+                  cpln_gvc_alias = uri.host.delete_prefix(host_prefix).delete_suffix(host_suffix)
+                  cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"
+                  app_url = app_domain_template
+                    .gsub(cpln_gvc_alias_token, cpln_gvc_alias)
+                    .gsub("{{APP_NAME}}", app_name)
+
+                  app_url = "#{app_url}/" unless app_url.end_with?("/")
+                  puts app_url
+                ' "${workload_name}" "${workload_url}" "${app_domain_template}" "${APP_NAME}"
+              )"
+            fi
+          fi
+
+          {
+            echo "workload_url=${workload_url}"
+            echo "app_url=${app_url}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Finalize deployment status
         if: always() && steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
@@ -471,7 +508,7 @@ jobs:
         env:
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
           DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}
-          APP_URL: ${{ steps.workload.outputs.workload_url }}
+          APP_URL: ${{ steps.workload.outputs.app_url }}
           JOB_STATUS: ${{ job.status }}
         with:
           script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,6 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 - **Fixed `doctor` and `setup-app` template validation to inspect only configured `setup_app_templates`, avoiding duplicate-resource errors from unused alternative templates while preserving the all-template fallback.** [PR 363](https://github.com/shakacode/control-plane-flow/pull/363) by [Justin Gordon](https://github.com/justin808).
 - **Fixed generated review-app deploy workflows so they wait for workload readiness and an accepted HTTP response before marking a GitHub deployment successful.** [PR 363](https://github.com/shakacode/control-plane-flow/pull/363) by [Justin Gordon](https://github.com/justin808).
 - **Fixed `cpflow` crashing at load time with `invalid byte sequence in US-ASCII (ArgumentError)` on systems without a UTF-8 locale.** [PR 404](https://github.com/shakacode/control-plane-flow/pull/404) by [Justin Gordon](https://github.com/justin808). `Command::Base.all_commands` now reads command files with an explicit UTF-8 encoding instead of relying on `Encoding.default_external`. Fixes [issue 372](https://github.com/shakacode/control-plane-flow/issues/372).
-
-### Fixed
-
 - **Fixed generated review-app status links so reusable deployments prefer the deployed app domain instead of the raw Control Plane workload endpoint.** [PR 395](https://github.com/shakacode/control-plane-flow/pull/395) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.1.1] - 2026-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 - **Added generic telemetry documentation for deploying an OpenTelemetry Collector with Control Plane Flow**, including collector workload templates, application instrumentation, telemetry pipelines, review-app isolation, and troubleshooting guidance. [PR 369](https://github.com/shakacode/control-plane-flow/pull/369) by [Justin Gordon](https://github.com/justin808).
 - **Added a Rails-focused Grafana and OpenTelemetry guide for building Control Plane dashboards from generated span and log metrics**, including collector workload guidance, spanmetrics setup, rollout order, alerting, and validation checklists. [PR 352](https://github.com/shakacode/control-plane-flow/pull/352) by [Justin Gordon](https://github.com/justin808).
 
+### Fixed
+
+- **Fixed generated review-app status links so reusable deployments prefer the deployed app domain instead of the raw Control Plane workload endpoint.** [PR 395](https://github.com/shakacode/control-plane-flow/pull/395) by [Justin Gordon](https://github.com/justin808).
+
 ## [5.1.1] - 2026-06-03
 
 ### Changed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -565,7 +565,7 @@ cpflow terraform import
 Regenerates the generated cpflow GitHub Actions wrappers and helper files
 from the currently installed cpflow gem. Use this after updating the
 cpflow gem so checked-in workflow wrappers move to the matching upstream
-release tag, for example `v5.1.1`.
+release tag, for example `v5.2.0`.
 
 If the existing generated staging workflow uses a custom single staging
 branch, the command preserves it. Pass `--staging-branch BRANCH` to set or

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -664,7 +664,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include('select(.name == "app_domain")')
       expect(contents).to include('host_suffix = ".cpln.app"')
       expect(contents).to include('cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"')
-      expect(contents).to include('.gsub(cpln_gvc_alias_token, cpln_gvc_alias)')
+      expect(contents).to include(".gsub(cpln_gvc_alias_token, cpln_gvc_alias)")
       expect(contents).to include('.gsub("{{APP_NAME}}", app_name)')
       expect(contents).to include('echo "app_url=${app_url}"')
       expect(contents).to include("APP_URL: ${{ steps.workload.outputs.app_url }}")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "open3"
 require "pathname"
 require "tmpdir"
 require "yaml"
@@ -56,6 +57,23 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
   def reusable_pr_open_help_workflow_path
     shared_workflow_path("cpflow-review-app-help")
+  end
+
+  def review_app_url_ruby_script
+    match = reusable_review_app_workflow_path.read.match(
+      /ruby -ruri -e '\n(?<script>.*?)\n\s*' "\$\{workload_name\}"/m
+    )
+
+    match[:script].lines.map { |line| line.delete_prefix("                  ") }.join
+  end
+
+  def run_review_app_url_script(**args)
+    script_args = args.fetch_values(:workload_name, :workload_url, :app_domain_template, :app_name)
+    stdout, stderr, status = Open3.capture3("ruby", "-ruri", "-e", review_app_url_ruby_script, *script_args)
+
+    expect(stderr).to eq("")
+    expect(status).to be_success
+    stdout.strip
   end
 
   def command_body_match_expression(command)
@@ -661,6 +679,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
       expect(contents).to include('workload_url="$(cpln workload get "${workload_name}"')
       expect(contents).to include('gvc_json="$(cpln gvc get "${APP_NAME}" --org "${CPLN_ORG}" -o json')
+      expect(contents).to include("Could not read GVC app_domain; falling back to workload endpoint.")
       expect(contents).to include('select(.name == "app_domain")')
       expect(contents).to include('host_suffix = ".cpln.app"')
       expect(contents).to include('cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"')
@@ -669,6 +688,44 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include('echo "app_url=${app_url}"')
       expect(contents).to include("APP_URL: ${{ steps.workload.outputs.app_url }}")
       expect(contents).not_to include("APP_URL: ${{ steps.workload.outputs.workload_url }}")
+    end
+
+    it "builds review-app app_domain URLs from workload endpoints" do
+      expect(
+        run_review_app_url_script(
+          workload_name: "rails",
+          workload_url: "https://rails-abc123.cpln.app",
+          app_domain_template: "https://rails-$(CPLN_GVC_ALIAS).example.test",
+          app_name: "hichee-review-1"
+        )
+      ).to eq("https://rails-abc123.example.test/")
+
+      expect(
+        run_review_app_url_script(
+          workload_name: "rails",
+          workload_url: "https://rails-abc123.org-prefix.cpln.app",
+          app_domain_template: "https://preview.example.test/{{APP_NAME}}?alias=$(CPLN_GVC_ALIAS)",
+          app_name: "hichee-review-1"
+        )
+      ).to eq("https://preview.example.test/hichee-review-1?alias=abc123")
+
+      expect(
+        run_review_app_url_script(
+          workload_name: "rails",
+          workload_url: "not a uri",
+          app_domain_template: "https://rails-$(CPLN_GVC_ALIAS).example.test",
+          app_name: "hichee-review-1"
+        )
+      ).to eq("not a uri")
+
+      expect(
+        run_review_app_url_script(
+          workload_name: "rails",
+          workload_url: "https://custom.example.test",
+          app_domain_template: "https://rails-$(CPLN_GVC_ALIAS).example.test",
+          app_name: "hichee-review-1"
+        )
+      ).to eq("https://custom.example.test")
     end
 
     it "supports an animated deploy status icon with a repository override" do

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -721,6 +721,15 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(
         run_review_app_url_script(
           workload_name: "rails",
+          workload_url: "https://rails-.cpln.app",
+          app_domain_template: "https://rails-$(CPLN_GVC_ALIAS).example.test",
+          app_name: "hichee-review-1"
+        )
+      ).to eq("https://rails-.cpln.app")
+
+      expect(
+        run_review_app_url_script(
+          workload_name: "rails",
           workload_url: "https://custom.example.test",
           app_domain_template: "https://rails-$(CPLN_GVC_ALIAS).example.test",
           app_name: "hichee-review-1"

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -535,7 +535,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(review_contents).not_to include('"${{ job.status }}"')
       expect(review_contents).to include("COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}")
       expect(review_contents).to include("DEPLOYMENT_ID: ${{ steps.init-deployment.outputs.result }}")
-      expect(review_contents).to include("APP_URL: ${{ steps.workload.outputs.workload_url }}")
+      expect(review_contents).to include("APP_URL: ${{ steps.workload.outputs.app_url }}")
       expect(review_contents).to include("JOB_STATUS: ${{ job.status }}")
 
       delete_contents = reusable_delete_review_workflow_path.read
@@ -654,6 +654,21 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
         "accepted_statuses: ${{ vars.REVIEW_APP_HEALTH_CHECK_ACCEPTED_STATUSES || '200 301 302' }}"
       )
       expect(contents).to include("curl_max_time: ${{ vars.REVIEW_APP_HEALTH_CHECK_CURL_MAX_TIME || '10' }}")
+    end
+
+    it "prefers the deployed app_domain for review-app links when available" do
+      contents = reusable_review_app_workflow_path.read
+
+      expect(contents).to include('workload_url="$(cpln workload get "${workload_name}"')
+      expect(contents).to include('gvc_json="$(cpln gvc get "${APP_NAME}" --org "${CPLN_ORG}" -o json')
+      expect(contents).to include('select(.name == "app_domain")')
+      expect(contents).to include('host_suffix = ".cpln.app"')
+      expect(contents).to include('cpln_gvc_alias_token = "$" + "(CPLN_GVC_ALIAS)"')
+      expect(contents).to include('.gsub(cpln_gvc_alias_token, cpln_gvc_alias)')
+      expect(contents).to include('.gsub("{{APP_NAME}}", app_name)')
+      expect(contents).to include('echo "app_url=${app_url}"')
+      expect(contents).to include("APP_URL: ${{ steps.workload.outputs.app_url }}")
+      expect(contents).not_to include("APP_URL: ${{ steps.workload.outputs.workload_url }}")
     end
 
     it "supports an animated deploy status icon with a repository override" do


### PR DESCRIPTION
## Summary

- Derive review-app status links from the deployed GVC `app_domain` when available.
- Keep the raw Control Plane workload endpoint as the fallback when the endpoint cannot be parsed or matched to the expected `.cpln.app` host format.
- Support Control Plane org-prefixed endpoint hosts by stripping the org endpoint suffix from the derived GVC alias.
- Preserve path/query app-domain templates instead of blindly appending a trailing slash.
- Add generator coverage and a behavioral spec that executes the embedded URL-derivation Ruby against representative endpoints.

## Why

Downstream apps should not need local post-processing jobs to rewrite the review-app URL in deployment statuses and comments. Centralizing this in the reusable workflow also avoids fragile downstream `gh api -f` body updates and deployment-selection fallbacks.

## Verification

- `CPLN_ORG=dummy bundle exec rspec spec/command/generate_github_actions_spec.rb`
- `bundle exec rubocop spec/command/generate_github_actions_spec.rb`
- `ruby -e "require 'yaml'; Dir['.github/workflows/*.yml', '.github/actions/**/action.yml'].sort.each { |path| YAML.safe_load_file(path, aliases: true) }; puts 'yaml ok'"`
- `actionlint -ignore 'property "workflow_(ref|sha|repository|file_path)" is not defined in object type' .github/workflows/cpflow-deploy-review-app.yml`
- `.agents/bin/docs`

`CPLN_ORG=dummy .agents/bin/validate` was attempted, but the full suite exercises live Control Plane integration paths and failed because org `dummy` does not exist. The focused generator spec above covers this workflow change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected review-app status links to use the deployed application domain when available.
  * Added fallback handling so links continue to work when domain configuration is unavailable or invalid.
* **Tests**
  * Added coverage for domain-based URL generation and edge cases.
* **Documentation**
  * Updated the unreleased changelog with the corrected review-app link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->