### PR TITLE
Add ordered per-workload deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Added
 
+- **Added ordered per-workload deploys with repeatable `cpflow deploy-image -w/--workload` filtering and optional `deploy_order` groups in `controlplane.yml`.** [PR 397](https://github.com/shakacode/control-plane-flow/pull/397) by [Justin Gordon](https://github.com/justin808). Fixes [issue 396](https://github.com/shakacode/control-plane-flow/issues/396). `cpflow deploy-image` can now deploy selected app workloads, and production promotion inherits `deploy_order` so workloads such as a Node renderer can roll out and become ready before Rails.
 - **Added generic telemetry documentation for deploying an OpenTelemetry Collector with Control Plane Flow**, including collector workload templates, application instrumentation, telemetry pipelines, review-app isolation, and troubleshooting guidance. [PR 369](https://github.com/shakacode/control-plane-flow/pull/369) by [Justin Gordon](https://github.com/justin808).
 - **Added a Rails-focused Grafana and OpenTelemetry guide for building Control Plane dashboards from generated span and log metrics**, including collector workload guidance, spanmetrics setup, rollout order, alerting, and validation checklists. [PR 352](https://github.com/shakacode/control-plane-flow/pull/352) by [Justin Gordon](https://github.com/justin808).
 

--- a/README.md
+++ b/README.md
@@ -268,8 +268,18 @@ aliases:
     # On the other hand, if you have a workload for Redis, that would NOT use the application Docker image
     # and not be listed here.
     app_workloads:
+      - node-renderer
       - rails
       - sidekiq
+
+    # Optional ordered deploy groups for `cpflow deploy-image` and
+    # `cpflow promote-app-from-upstream`. Each group is deployed and waited on
+    # before the next group starts. Any app workloads omitted here deploy last
+    # as an implicit final group. Explicit `deploy-image -w/--workload` options
+    # override this ordering for one-off deploys.
+    deploy_order:
+      - [node-renderer]
+      - [rails, sidekiq]
 
     # Additional "service type" workloads, using non-application Docker images.
     # These are only used by the `info` and `ps:` commands in order to get all of the defined workloads.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -149,6 +149,9 @@ cpflow delete -a $APP_NAME -w $WORKLOAD_NAME
 ### `deploy-image`
 
 - Deploys the latest image to app workloads
+- Use `--workload`/`-w` one or more times to deploy only selected app workloads
+- If `deploy_order` is configured and no `--workload` is provided, deploys ordered workload groups one at a time and waits for each group to be ready before continuing
+- Workloads listed in `app_workloads` but omitted from `deploy_order` deploy last as an implicit final group
 - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
 - The release script is run in the context of `cpflow run` with the latest image
 - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
@@ -156,7 +159,14 @@ cpflow delete -a $APP_NAME -w $WORKLOAD_NAME
 - Repairs missing `shared_secret_grants` policy bindings before running a release phase or updating workloads
 
 ```sh
+# Deploys the latest image to all app workloads.
 cpflow deploy-image -a $APP_NAME
+
+# Deploys only one app workload.
+cpflow deploy-image -a $APP_NAME -w node-renderer
+
+# Deploys only selected app workloads.
+cpflow deploy-image -a $APP_NAME -w node-renderer -w sidekiq
 ```
 
 ### `doctor`
@@ -374,6 +384,7 @@ cpflow open-console -a $APP_NAME
 - It performs the following steps:
   - Runs `cpflow copy-image-from-upstream` to copy the latest image from upstream
   - Runs `cpflow deploy-image` to deploy the image
+  - Honors `deploy_order` from `.controlplane/controlplane.yml` through `cpflow deploy-image`
   - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
   - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
   - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -96,7 +96,7 @@ module Command
       }
     end
 
-    def self.workload_option(required: false)
+    def self.workload_option(required: false, repeatable: false)
       {
         name: :workload,
         params: {
@@ -104,6 +104,7 @@ module Command
           banner: "WORKLOAD_NAME",
           desc: "Workload name",
           type: :string,
+          repeatable: repeatable,
           required: required
         }
       }
@@ -581,6 +582,20 @@ module Command
       end
 
       success
+    end
+
+    def wait_for_workloads_ready(workloads, reverse: false)
+      workloads_to_wait_for = reverse ? workloads.reverse : workloads
+
+      workloads_to_wait_for.each do |workload|
+        if cp.workload_suspended?(workload)
+          progress.puts("Workload '#{workload}' is suspended. Skipping...")
+        else
+          step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
+            cp.workload_deployments_ready?(workload, location: config.location, expected_status: true)
+          end
+        end
+      end
     end
 
     def cp

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -3,40 +3,108 @@
 require "resolv"
 
 module Command
-  class DeployImage < Base
+  class DeployImage < Base # rubocop:disable Metrics/ClassLength
     NAME = "deploy-image"
     OPTIONS = [
       app_option(required: true),
+      workload_option(repeatable: true),
       run_release_phase_option,
       use_digest_image_ref_option
     ].freeze
     DESCRIPTION = "Deploys the latest image to app workloads, and runs a release script (optional)"
     LONG_DESCRIPTION = <<~DESC
       - Deploys the latest image to app workloads
+      - Use `--workload`/`-w` one or more times to deploy only selected app workloads
+      - If `deploy_order` is configured and no `--workload` is provided, deploys ordered workload groups one at a time and waits for each group to be ready before continuing
+      - Workloads listed in `app_workloads` but omitted from `deploy_order` deploy last as an implicit final group
       - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
       - The release script is run in the context of `cpflow run` with the latest image
       - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
       - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest
       - Repairs missing `shared_secret_grants` policy bindings before running a release phase or updating workloads
     DESC
+    EXAMPLES = <<~EX
+      ```sh
+      # Deploys the latest image to all app workloads.
+      cpflow deploy-image -a $APP_NAME
+
+      # Deploys only one app workload.
+      cpflow deploy-image -a $APP_NAME -w node-renderer
+
+      # Deploys only selected app workloads.
+      cpflow deploy-image -a $APP_NAME -w node-renderer -w sidekiq
+      ```
+    EX
 
     def call
       release_script = release_script_to_run
       image = resolve_image_to_deploy
       shared_secret_policy_grant_pairs = resolve_shared_secret_policy_grants
-      workload_data_by_name = app_workload_data
+      workload_data_by_name = app_workload_data(workload_names_to_deploy)
 
       bind_shared_secret_policy_grants(shared_secret_policy_grant_pairs)
       run_release_script(release_script) if release_script
-      deploy_image_to_workloads(image, workload_data_by_name)
+      deploy_image(image, workload_data_by_name)
     end
 
     private
 
-    def app_workload_data
-      config[:app_workloads].to_h do |workload|
+    def workload_names_to_deploy
+      app_workloads = config[:app_workloads]
+      requested_workloads = requested_workload_names
+      return app_workloads if requested_workloads.empty?
+
+      ensure_workloads_configured!(requested_workloads, app_workloads)
+      requested_workloads
+    end
+
+    def ensure_workloads_configured!(requested_workloads, app_workloads)
+      requested_workloads.each do |workload|
+        next if app_workloads.include?(workload)
+
+        raise "Workload '#{workload}' must be listed in app_workloads for app '#{config.app}'."
+      end
+    end
+
+    def app_workload_data(workloads)
+      workloads.to_h do |workload|
         [workload, cp.fetch_workload!(workload)]
       end
+    end
+
+    def deploy_image(image, workload_data_by_name)
+      deployed_endpoints = {}
+
+      if deploy_in_order?
+        deploy_image_to_ordered_workloads(image, workload_data_by_name, deployed_endpoints)
+      else
+        deployed_endpoints.merge!(deploy_image_to_workloads(image, workload_data_by_name))
+      end
+    ensure
+      print_deployed_endpoints(deployed_endpoints)
+    end
+
+    def deploy_in_order?
+      requested_workload_names.empty? && config.deploy_order
+    end
+
+    def deployment_groups(workload_data_by_name)
+      ordered_groups = config.deploy_order
+      ordered_workloads = ordered_groups.flatten
+      unordered_workloads = workload_data_by_name.keys - ordered_workloads
+
+      [*ordered_groups, unordered_workloads].reject(&:empty?)
+    end
+
+    def deploy_image_to_ordered_workloads(image, workload_data_by_name, deployed_endpoints)
+      deployment_groups(workload_data_by_name).each do |group|
+        deployed_endpoints.merge!(deploy_image_to_workloads(image, workload_data_by_name.slice(*group)))
+        wait_for_workloads_ready(group)
+      end
+    end
+
+    def requested_workload_names
+      @requested_workload_names ||= Array(config.options[:workload]).map(&:to_s).uniq
     end
 
     def deploy_image_to_workloads(image, workload_data_by_name) # rubocop:disable Metrics/MethodLength
@@ -57,6 +125,10 @@ module Command
         end
       end
 
+      deployed_endpoints
+    end
+
+    def print_deployed_endpoints(deployed_endpoints)
       progress.puts("\nDeployed endpoints:")
       deployed_endpoints.each do |workload, endpoint|
         progress.puts("  - #{workload}: #{endpoint}")

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -14,6 +14,7 @@ module Command
       - It performs the following steps:
         - Runs `cpflow copy-image-from-upstream` to copy the latest image from upstream
         - Runs `cpflow deploy-image` to deploy the image
+        - Honors `deploy_order` from `.controlplane/controlplane.yml` through `cpflow deploy-image`
         - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
         - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
         - If `use_digest_image_ref` is `true` in the `.controlplane/controlplane.yml` file or `--use-digest-image-ref` option is provided, deployed image's reference will include its digest

--- a/lib/command/ps_wait.rb
+++ b/lib/command/ps_wait.rb
@@ -26,19 +26,11 @@ module Command
       ```
     EX
 
-    def call # rubocop:disable Metrics/MethodLength
+    def call
       @workloads = [config.options[:workload]] if config.options[:workload]
       @workloads ||= config[:app_workloads] + config[:additional_workloads]
 
-      @workloads.reverse_each do |workload|
-        if cp.workload_suspended?(workload)
-          progress.puts("Workload '#{workload}' is suspended. Skipping...")
-        else
-          step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
-            cp.workload_deployments_ready?(workload, location: config.location, expected_status: true)
-          end
-        end
-      end
+      wait_for_workloads_ready(@workloads, reverse: true)
     end
   end
 end

--- a/lib/core/config.rb
+++ b/lib/core/config.rb
@@ -166,6 +166,28 @@ class Config # rubocop:disable Metrics/ClassLength
     current&.dig(:use_digest_image_ref) == true
   end
 
+  def deploy_order
+    return nil unless current&.key?(:deploy_order)
+
+    @deploy_order ||= normalize_deploy_order(
+      current.fetch(:deploy_order),
+      app_workloads_for_deploy_order!(current, app),
+      app
+    )
+  end
+
+  def validate_deploy_orders!
+    apps.each do |app_name, app_options|
+      next unless app_options.key?(:deploy_order)
+
+      normalize_deploy_order(
+        app_options.fetch(:deploy_order),
+        app_workloads_for_deploy_order!(app_options, app_name),
+        app_name
+      )
+    end
+  end
+
   private
 
   def ensure_current_config!
@@ -250,6 +272,78 @@ class Config # rubocop:disable Metrics/ClassLength
 
       seen_names[name] = true
     end
+  end
+
+  def app_workloads_for_deploy_order!(app_options, app_name)
+    app_workloads = app_options[:app_workloads]
+    return app_workloads if app_workloads.is_a?(Array)
+
+    raise "deploy_order for app '#{app_name}' requires app_workloads to be an array."
+  end
+
+  def normalize_deploy_order(raw_deploy_order, app_workloads, app_name)
+    ensure_deploy_order_array!(raw_deploy_order, app_name)
+    context = {
+      app_workload_names: app_workloads.map(&:to_s),
+      seen_workloads: {},
+      app_name: app_name
+    }
+
+    raw_deploy_order.map.with_index do |group, index|
+      normalize_deploy_order_group(group, index, context)
+    end
+  end
+
+  def ensure_deploy_order_array!(raw_deploy_order, app_name)
+    raise "deploy_order for app '#{app_name}' must be an array of workload groups." unless raw_deploy_order.is_a?(Array)
+    return unless raw_deploy_order.empty?
+
+    raise "deploy_order for app '#{app_name}' must include at least one workload group."
+  end
+
+  def normalize_deploy_order_group(group, index, context)
+    group_number = index + 1
+    ensure_deploy_order_group_array!(group, group_number, context.fetch(:app_name))
+
+    group.map.with_index do |workload, workload_index|
+      normalize_deploy_order_workload(workload, group_number, workload_index, context)
+    end
+  end
+
+  def ensure_deploy_order_group_array!(group, group_number, app_name)
+    unless group.is_a?(Array)
+      raise "deploy_order group ##{group_number} for app '#{app_name}' must be an array of workload names."
+    end
+    return unless group.empty?
+
+    raise "deploy_order group ##{group_number} for app '#{app_name}' must include at least one workload."
+  end
+
+  def normalize_deploy_order_workload(workload, group_number, workload_index, context)
+    app_name = context.fetch(:app_name)
+    unless workload.is_a?(String) && !workload.strip.empty?
+      raise "deploy_order group ##{group_number} entry ##{workload_index + 1} " \
+            "for app '#{app_name}' must be a workload name."
+    end
+
+    workload_name = workload.strip
+    ensure_deploy_order_workload_configured!(workload_name, context.fetch(:app_workload_names), app_name)
+    ensure_deploy_order_workload_unique!(workload_name, context.fetch(:seen_workloads), app_name)
+    workload_name
+  end
+
+  def ensure_deploy_order_workload_configured!(workload_name, app_workload_names, app_name)
+    return if app_workload_names.include?(workload_name)
+
+    raise "deploy_order workload '#{workload_name}' must be listed in app_workloads for app '#{app_name}'."
+  end
+
+  def ensure_deploy_order_workload_unique!(workload_name, seen_workloads, app_name)
+    if seen_workloads[workload_name]
+      raise "deploy_order workload '#{workload_name}' must appear only once for app '#{app_name}'."
+    end
+
+    seen_workloads[workload_name] = true
   end
 
   def ensure_app!

--- a/lib/core/doctor_service.rb
+++ b/lib/core/doctor_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DoctorService
+class DoctorService # rubocop:disable Metrics/ClassLength
   class ValidationError < StandardError; end
 
   extend Forwardable
@@ -34,7 +34,10 @@ class DoctorService
     exit(ExitCode::ERROR_DEFAULT) if @any_failed_validation
   end
 
-  def validate_config = check_for_app_names_contained_in_others
+  def validate_config
+    check_for_app_names_contained_in_others
+    check_deploy_orders
+  end
 
   def validate_templates
     @template_parser = TemplateParser.new(@command)
@@ -55,6 +58,12 @@ class DoctorService
            .map { |app_prefix, app_name| "  - '#{app_prefix}' is a prefix of '#{app_name}'" }
            .join("\n")
     raise ValidationError, "#{Shell.color("ERROR: #{message}", :red)}\n#{list}"
+  end
+
+  def check_deploy_orders
+    config.validate_deploy_orders!
+  rescue RuntimeError => e
+    raise ValidationError, Shell.color("ERROR: #{e.message}", :red)
   end
 
   def find_app_names_contained_in_others # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -3,6 +3,32 @@
 require "spec_helper"
 
 describe Command::DeployImage do
+  describe "OPTIONS" do
+    it "declares --workload as repeatable" do
+      workload_option = described_class::OPTIONS.find { |option| option[:name] == :workload }
+
+      expect(workload_option[:params]).to include(type: :string, repeatable: true, aliases: ["-w"])
+    end
+
+    it "passes repeated --workload flags through Thor as an array" do
+      config = instance_double(Config)
+      command = instance_double(described_class, call: true)
+      captured_options = nil
+      allow(Config).to receive(:new) do |_args, options, _required_options|
+        captured_options = options
+        config
+      end
+      allow(described_class).to receive(:new).with(config).and_return(command)
+      allow(Cpflow::Cli).to receive(:show_info_header)
+
+      result = run_cpflow_command("deploy-image", "-a", "test-app", "-w", "frontend", "-w", "worker")
+
+      expect(result[:status]).to eq(0), result[:stderr]
+      expect(captured_options[:workload]).to eq(%w[frontend worker])
+      expect(command).to have_received(:call)
+    end
+  end
+
   describe "#resolve_image_to_deploy" do
     def build_command(image_details:, use_digest_image_ref: true)
       image = "test-app:1"
@@ -71,13 +97,16 @@ describe Command::DeployImage do
     end
   end
 
+  # rubocop:disable RSpec/MultipleMemoizedHelpers
   describe "#call" do
     let(:config) do
       instance_double(
         Config,
         app: "test-app",
         org: "test-org",
-        options: { run_release_phase: run_release_phase },
+        location: "aws-us-west-2",
+        options: options,
+        deploy_order: deploy_order,
         use_digest_image_ref?: false,
         identity: "test-app-identity",
         identity_link: "/org/test-org/gvc/test-app/identity/test-app-identity",
@@ -95,6 +124,8 @@ describe Command::DeployImage do
         ]
       )
     end
+    let(:options) { { run_release_phase: run_release_phase } }
+    let(:deploy_order) { nil }
     let(:run_release_phase) { false }
     let(:cp) { instance_double(Controlplane) }
     let(:command) { described_class.new(config) }
@@ -340,6 +371,189 @@ describe Command::DeployImage do
         .with("frontend", container: "rails", image: "test-app:1")
     end
 
+    context "when specific workloads are requested" do
+      let(:options) { { run_release_phase: false, workload: ["worker"] } }
+      let(:worker_data) do
+        {
+          "name" => "worker",
+          "spec" => {
+            "containers" => [
+              { "name" => "sidekiq", "image" => "/org/test-org/image/test-app:1" }
+            ]
+          },
+          "status" => { "endpoint" => "https://worker-test.cpln.app" }
+        }
+      end
+
+      before do
+        allow(config).to receive(:[]).with(:app_workloads).and_return(%w[frontend worker])
+        allow(cp).to receive(:fetch_workload!).with("worker").and_return(worker_data)
+      end
+
+      it "deploys only the requested workloads" do
+        command.call
+
+        expect(cp).not_to have_received(:fetch_workload!).with("frontend")
+        expect(cp).to have_received(:workload_set_image_ref)
+          .with("worker", container: "sidekiq", image: "test-app:1")
+        expect(cp).not_to have_received(:workload_set_image_ref)
+          .with("frontend", container: "rails", image: "test-app:1")
+      end
+    end
+
+    context "when a requested workload is not configured" do
+      let(:options) { { run_release_phase: false, workload: ["missing"] } }
+
+      it "raises before fetching or deploying workloads" do
+        expect { command.call }
+          .to raise_error("Workload 'missing' must be listed in app_workloads for app 'test-app'.")
+        expect(cp).not_to have_received(:fetch_workload!)
+        expect(cp).not_to have_received(:workload_set_image_ref)
+      end
+    end
+
+    context "when deploy_order is configured" do
+      let(:deploy_order) { [["node-renderer"], ["rails"]] }
+      let(:node_renderer_data) do
+        {
+          "name" => "node-renderer",
+          "spec" => {
+            "containers" => [
+              { "name" => "renderer", "image" => "/org/test-org/image/test-app:1" }
+            ]
+          },
+          "status" => { "endpoint" => "https://renderer-test.cpln.app" }
+        }
+      end
+      let(:rails_data) do
+        {
+          "name" => "rails",
+          "spec" => {
+            "containers" => [
+              { "name" => "rails", "image" => "/org/test-org/image/test-app:1" }
+            ]
+          },
+          "status" => { "endpoint" => "https://rails-test.cpln.app" }
+        }
+      end
+      let(:sidekiq_data) do
+        {
+          "name" => "sidekiq",
+          "spec" => {
+            "containers" => [
+              { "name" => "worker", "image" => "/org/test-org/image/test-app:1" }
+            ]
+          },
+          "status" => { "endpoint" => "https://sidekiq-test.cpln.app" }
+        }
+      end
+
+      before do
+        allow(config).to receive(:[]).with(:app_workloads).and_return(%w[node-renderer rails sidekiq])
+        allow(cp).to receive(:fetch_workload!).with("node-renderer").and_return(node_renderer_data)
+        allow(cp).to receive(:fetch_workload!).with("rails").and_return(rails_data)
+        allow(cp).to receive(:fetch_workload!).with("sidekiq").and_return(sidekiq_data)
+        allow(cp).to receive_messages(workload_suspended?: false, workload_deployments_ready?: true)
+      end
+
+      it "deploys ordered groups and waits for each group before deploying the next" do
+        events = []
+        allow(cp).to receive(:workload_set_image_ref) { |workload, **| events << [:deploy, workload] }
+        allow(cp).to receive(:workload_suspended?) do |workload|
+          events << [:suspended?, workload]
+          false
+        end
+        allow(cp).to receive(:workload_deployments_ready?) do |workload, **|
+          events << [:ready, workload]
+          true
+        end
+
+        command.call
+
+        expect(events).to eq(
+          [
+            [:deploy, "node-renderer"],
+            [:suspended?, "node-renderer"],
+            [:ready, "node-renderer"],
+            [:deploy, "rails"],
+            [:suspended?, "rails"],
+            [:ready, "rails"],
+            [:deploy, "sidekiq"],
+            [:suspended?, "sidekiq"],
+            [:ready, "sidekiq"]
+          ]
+        )
+      end
+
+      it "skips readiness waits for suspended workloads" do
+        allow(cp).to receive(:workload_suspended?).with("node-renderer").and_return(true)
+
+        command.call
+
+        expect(cp).not_to have_received(:workload_deployments_ready?)
+          .with("node-renderer", location: "aws-us-west-2", expected_status: true)
+      end
+
+      it "prints one deployed endpoints summary after all ordered groups finish" do
+        expect { command.call }.to output(
+          satisfy do |stderr|
+            stderr.scan("Deployed endpoints:").size == 1 &&
+              stderr.include?("  - node-renderer: https://renderer-test.cpln.app") &&
+              stderr.include?("  - rails: https://rails-test.cpln.app") &&
+              stderr.include?("  - sidekiq: https://sidekiq-test.cpln.app")
+          end
+        ).to_stderr
+      end
+
+      it "prints deployed endpoints before aborting when an ordered readiness wait fails" do
+        allow(command).to receive(:wait_for_workloads_ready) do |group|
+          exit(ExitCode::ERROR_DEFAULT) if group == ["rails"]
+        end
+
+        expect do
+          expect { command.call }
+            .to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::ERROR_DEFAULT) }
+        end.to output(
+          satisfy do |stderr|
+            stderr.scan("Deployed endpoints:").size == 1 &&
+              stderr.include?("  - node-renderer: https://renderer-test.cpln.app") &&
+              stderr.include?("  - rails: https://rails-test.cpln.app") &&
+              !stderr.include?("  - sidekiq: https://sidekiq-test.cpln.app")
+          end
+        ).to_stderr
+      end
+    end
+
+    context "when specific workloads are requested with deploy_order configured" do
+      let(:options) { { run_release_phase: false, workload: ["worker"] } }
+      let(:deploy_order) { [["frontend"]] }
+      let(:worker_data) do
+        {
+          "name" => "worker",
+          "spec" => {
+            "containers" => [
+              { "name" => "sidekiq", "image" => "/org/test-org/image/test-app:1" }
+            ]
+          },
+          "status" => { "endpoint" => "https://worker-test.cpln.app" }
+        }
+      end
+
+      before do
+        allow(config).to receive(:[]).with(:app_workloads).and_return(%w[frontend worker])
+        allow(cp).to receive(:fetch_workload!).with("worker").and_return(worker_data)
+        allow(cp).to receive_messages(workload_suspended?: false, workload_deployments_ready?: true)
+      end
+
+      it "lets the explicit workload selection override deploy_order" do
+        command.call
+
+        expect(cp).to have_received(:workload_set_image_ref)
+          .with("worker", container: "sidekiq", image: "test-app:1")
+        expect(cp).not_to have_received(:workload_deployments_ready?)
+      end
+    end
+
     context "when a workload has multiple containers matching the app image" do
       let(:workload_data) do
         {
@@ -388,4 +602,5 @@ describe Command::DeployImage do
       end
     end
   end
+  # rubocop:enable RSpec/MultipleMemoizedHelpers
 end

--- a/spec/command/doctor_spec.rb
+++ b/spec/command/doctor_spec.rb
@@ -30,6 +30,23 @@ describe Command::Doctor do
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("[PASS] config")
     end
+
+    it "fails cleanly if deploy_order is invalid" do
+      temporarily_switch_config_file("valid-app-names")
+
+      progress = StringIO.new
+      config = instance_double(Config, apps: { "test-app" => { app_workloads: %w[rails] } })
+      command = instance_double(described_class, config: config, progress: progress)
+
+      allow(config).to receive(:validate_deploy_orders!)
+        .and_raise("deploy_order workload 'node-renderer' must be listed in app_workloads for app 'test-app'.")
+
+      expect { DoctorService.new(command).run_validations(["config"]) }.to raise_error(SystemExit)
+      expect(progress.string).to include("[FAIL] config")
+      expect(progress.string)
+        .to include("deploy_order workload 'node-renderer' must be listed in app_workloads for app 'test-app'.")
+      expect(progress.string).not_to include("NoMethodError")
+    end
   end
 
   context "when validating templates" do

--- a/spec/core/config_spec.rb
+++ b/spec/core/config_spec.rb
@@ -227,4 +227,96 @@ describe Config do
       end
     end
   end
+
+  describe "#deploy_order" do
+    def build_config(current, app: "test-app")
+      instance = described_class.allocate
+      instance.instance_variable_set(:@app, app)
+      allow(instance).to receive(:current).and_return(current)
+      instance
+    end
+
+    it "defaults to no deploy order" do
+      config = build_config({ app_workloads: %w[rails sidekiq] })
+
+      expect(config.deploy_order).to be_nil
+    end
+
+    it "normalizes deploy order groups" do
+      config = build_config(
+        {
+          app_workloads: %w[node-renderer rails sidekiq],
+          deploy_order: [["node-renderer"], %w[rails sidekiq]]
+        }
+      )
+
+      expect(config.deploy_order).to eq([["node-renderer"], %w[rails sidekiq]])
+    end
+
+    it "raises when deploy order is not an array" do
+      config = build_config({ app_workloads: %w[rails], deploy_order: "rails" })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order for app 'test-app' must be an array of workload groups.")
+    end
+
+    it "raises when deploy order is empty" do
+      config = build_config({ app_workloads: %w[rails], deploy_order: [] })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order for app 'test-app' must include at least one workload group.")
+    end
+
+    it "raises when a deploy order group is not an array" do
+      config = build_config({ app_workloads: %w[rails], deploy_order: ["rails"] })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order group #1 for app 'test-app' must be an array of workload names.")
+    end
+
+    it "raises when a deploy order group is empty" do
+      config = build_config({ app_workloads: %w[rails], deploy_order: [[]] })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order group #1 for app 'test-app' must include at least one workload.")
+    end
+
+    it "raises when a deploy order workload is not configured" do
+      config = build_config({ app_workloads: %w[rails], deploy_order: [["node-renderer"]] })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order workload 'node-renderer' must be listed in app_workloads for app 'test-app'.")
+    end
+
+    it "raises when a deploy order workload is duplicated" do
+      config = build_config({ app_workloads: %w[rails sidekiq], deploy_order: [%w[rails], %w[sidekiq rails]] })
+
+      expect { config.deploy_order }
+        .to raise_error("deploy_order workload 'rails' must appear only once for app 'test-app'.")
+    end
+  end
+
+  describe "#validate_deploy_orders!" do
+    def build_config(apps)
+      instance = described_class.allocate
+      allow(instance).to receive(:apps).and_return(apps)
+      instance
+    end
+
+    it "validates deploy_order for each app and skips apps without deploy_order" do
+      config = build_config(
+        {
+          test_app: {
+            app_workloads: %w[node-renderer rails sidekiq],
+            deploy_order: [["node-renderer"], %w[rails sidekiq]]
+          },
+          worker_app: { app_workloads: %w[worker] },
+          invalid_app: { app_workloads: %w[frontend], deploy_order: [["missing"]] }
+        }
+      )
+
+      expect { config.validate_deploy_orders! }
+        .to raise_error("deploy_order workload 'missing' must be listed in app_workloads for app 'invalid_app'.")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add repeatable `cpflow deploy-image -w/--workload` support for deploying selected `app_workloads`.
- Add `deploy_order` config support so `deploy-image` deploys ordered groups, waits for each group to be ready, skips suspended workloads, and deploys unlisted app workloads last.
- Wire `deploy_order` validation into `doctor --validations config`, and update generated command docs, README config reference, and changelog.

Fixes #396.

## Validation

- `CPLN_ORG=test-org .agents/bin/test spec/core/config_spec.rb spec/command/deploy_image_unit_spec.rb`
- `CPLN_ORG=test-org .agents/bin/test spec/core/config_spec.rb spec/command/deploy_image_unit_spec.rb spec/command/doctor_spec.rb:34`
- `CPLN_ORG=test-org .agents/bin/test spec/command/doctor_spec.rb`
- `.agents/bin/lint`
- `.agents/bin/docs`
- `bundle exec ruby -Ilib ./cpflow deploy-image --help`

Attempted full local validation with `CPLN_ORG=test-org .agents/bin/validate`; stopped after repeated live-spec failures because `test-org` is not a real Control Plane org in this environment. Hosted PR CI should provide the full gate with the repo's configured environment.

## Codex Decision Log

- **Non-blocking:** Full local validation requires a real Control Plane org, which is not available in this worktree environment.
  - **Decision:** Ran focused unit/docs/lint/help checks locally and left the full suite to PR CI.
  - **Why:** The full suite failed before reaching this change's behavior with `Can't find org 'test-org'` in live specs.
  - **Review later:** Confirm PR CI is green before merge.

### QA Evidence

- QA lane: not required; single-lane gem command/config change covered by focused unit/docs/lint validation.
- Scope checked: `deploy-image` workload filtering/order orchestration, `deploy_order` config validation, `ps:wait` readiness helper reuse, command docs, README, changelog.
- Tested at: `4f4f367` before PR creation.
- Automated checks: listed in Validation.
- Manual checks: `cpflow deploy-image --help` verified the new command help renders.
- Findings: full local validation blocked by missing real Control Plane org; no code findings from focused checks.
- QA required: no
- QA required rationale: no separate app/manual lane needed for a scoped CLI/gem behavior change with unit coverage and generated-doc checks.
- QA lane status: not_applicable
- Release-blocking status: not_applicable
- Process-gap disposition: not applicable

<!-- qa-evidence v1
required: no
status: not_applicable
tested_at: 4f4f367
scope: deploy-image workload filtering/order orchestration; deploy_order config validation; ps:wait readiness helper reuse; command docs; README; changelog
automated_checks: focused rspec commands, lint, docs, CLI help smoke listed in PR Validation
manual_checks: cpflow deploy-image --help
findings: full local validation blocked by missing real Control Plane org; focused checks clear
release_blocking: not_applicable
process_gap_disposition: not applicable
-->