### PR TITLE
Read command files as UTF-8 in all_commands to support non-UTF-8 locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 - **Added generic telemetry documentation for deploying an OpenTelemetry Collector with Control Plane Flow**, including collector workload templates, application instrumentation, telemetry pipelines, review-app isolation, and troubleshooting guidance. [PR 369](https://github.com/shakacode/control-plane-flow/pull/369) by [Justin Gordon](https://github.com/justin808).
 - **Added a Rails-focused Grafana and OpenTelemetry guide for building Control Plane dashboards from generated span and log metrics**, including collector workload guidance, spanmetrics setup, rollout order, alerting, and validation checklists. [PR 352](https://github.com/shakacode/control-plane-flow/pull/352) by [Justin Gordon](https://github.com/justin808).
 
+### Fixed
+
+- **Fixed `cpflow` crashing at load time with `invalid byte sequence in US-ASCII (ArgumentError)` on systems without a UTF-8 locale.** `Command::Base.all_commands` now reads command files with an explicit UTF-8 encoding instead of relying on `Encoding.default_external`. Fixes [issue 372](https://github.com/shakacode/control-plane-flow/issues/372).
+
 ## [5.1.1] - 2026-06-03
 
 ### Changed

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -49,7 +49,7 @@ module Command
 
     def self.all_commands # rubocop:disable Metrics/MethodLength
       Dir["#{__dir__}/**/*.rb"].each_with_object({}) do |file, result|
-        content = File.read(file)
+        content = File.read(file, encoding: "UTF-8")
 
         classname = content.match(/^\s+class (?!Base\b)(\w+) < (?:.*(?!Command::)Base)(?:$| .*$)/)&.captures&.first
         next unless classname

--- a/spec/command/base_spec.rb
+++ b/spec/command/base_spec.rb
@@ -70,4 +70,18 @@ describe Command::Base do
       end
     end
   end
+
+  describe ".all_commands" do
+    it "loads every command when the default external encoding is not UTF-8" do
+      original_encoding = Encoding.default_external
+
+      begin
+        Encoding.default_external = Encoding::US_ASCII
+        expect { described_class.all_commands }.not_to raise_error
+        expect(described_class.all_commands).not_to be_empty
+      ensure
+        Encoding.default_external = original_encoding
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #372.

`Command::Base.all_commands` reads every command file with `File.read(file)` and runs a regex over the content. Without a UTF-8 locale, `Encoding.default_external` becomes `US-ASCII`, so reading the two command files that contain non-ASCII characters (`cleanup_stale_apps.rb`, `delete.rb`) raises `invalid byte sequence in US-ASCII` at load time, which makes every `cpflow` command unusable. This reads those files as UTF-8 explicitly.

Added a spec that runs `all_commands` with `Encoding.default_external` set to `US-ASCII` and asserts it no longer raises. `bundle exec rspec spec/command/base_spec.rb` and `bundle exec rubocop` both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash on systems using non-UTF-8 locale settings.
  * Command files are now consistently read using UTF-8 encoding.

* **Tests**
  * Added coverage to verify command discovery succeeds under restrictive locale settings.

* **Documentation**
  * Updated the unreleased changelog with details of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->