### PR TITLE
Allow offline specs without CPLN_ORG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ twice.
 
 ## Testing
 
-We use real apps for the tests. You'll need to have full access to a Control Plane org, and then set it as the env var `CPLN_ORG` when running the tests (or in the `.env` file):
+See [the spec README](./spec/README.md) for credential-free local examples and the distinction between offline and Control Plane-backed specs.
+
+Specs that use real apps need full access to a Control Plane org. Set it as the `CPLN_ORG` environment variable when running the full suite (or in the `.env` file):
 
 ```sh
 CPLN_ORG=your-org-for-tests bundle exec rspec

--- a/spec/README.md
+++ b/spec/README.md
@@ -3,7 +3,7 @@
 Some specs exercise only local behavior and can run without Control Plane credentials. This verified offline smoke suite does not contact a Control Plane org:
 
 ```sh
-env -u CPLN_ORG bundle exec rspec \
+CPLN_ORG='' bundle exec rspec \
   spec/patches \
   spec/support_specs \
   spec/core/repo_introspection_spec.rb \

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,29 @@
+# Running Specs
+
+Some specs exercise only local behavior and can run without Control Plane credentials. This verified offline smoke suite does not contact a Control Plane org:
+
+```sh
+env -u CPLN_ORG bundle exec rspec \
+  spec/patches \
+  spec/support_specs \
+  spec/core/repo_introspection_spec.rb \
+  spec/rakelib/create_release_spec.rb \
+  spec/command/no_command_spec.rb \
+  spec/command/version_spec.rb \
+  spec/command/deploy_image_unit_spec.rb \
+  spec/command/promote_app_from_upstream_unit_spec.rb
+```
+
+The spec helper still prepares the temporary dummy configuration for these runs. A spec that needs a real Control Plane org raises a clear error when it calls `dummy_test_org`; rerun that spec with `CPLN_ORG` set.
+
+Specs that create, inspect, or delete Control Plane resources need an org with the required access:
+
+```sh
+CPLN_ORG=your-org-for-tests bundle exec rspec
+```
+
+Slow specs are a subset of the credentialed suite. Run them separately with:
+
+```sh
+CPLN_ORG=your-org-for-tests bundle exec rspec --tag slow
+```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -140,11 +140,21 @@ RSpec.configure do |config|
   config.default_retry_count = ENV["RSPEC_RETRY_COUNT"] || 3
 
   config.before(:suite) do
-    DummyAppSetup.setup
+    if CommandHelpers.cpln_org_configured?
+      DummyAppSetup.setup
+    else
+      CommandHelpers.configure_config_file
+    end
   end
 
   config.after(:suite) do
-    DummyAppSetup.cleanup unless ENV.fetch("SKIP_CLEANUP", nil) == "true"
+    next if ENV.fetch("SKIP_CLEANUP", nil) == "true"
+
+    if CommandHelpers.cpln_org_configured?
+      DummyAppSetup.cleanup
+    else
+      CommandHelpers.delete_config_file
+    end
   end
 
   config.before do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,10 +148,8 @@ RSpec.configure do |config|
   end
 
   config.after(:suite) do
-    next if ENV.fetch("SKIP_CLEANUP", nil) == "true"
-
     if CommandHelpers.cpln_org_configured?
-      DummyAppSetup.cleanup
+      DummyAppSetup.cleanup unless ENV.fetch("SKIP_CLEANUP", nil) == "true"
     else
       CommandHelpers.delete_config_file
     end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -8,7 +8,7 @@ require_relative "spawned_command"
 module CommandHelpers # rubocop:disable Metrics/ModuleLength
   module_function
 
-  DUMMY_TEST_ORG = ENV.fetch("CPLN_ORG")
+  DUMMY_TEST_ORG = ENV.fetch("CPLN_ORG", nil)
   DUMMY_TEST_APP_PREFIX = "dummy-test"
 
   CREATE_APP_PARAMS = {
@@ -88,7 +88,13 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
   end
 
   def dummy_test_org
-    DUMMY_TEST_ORG
+    return DUMMY_TEST_ORG if cpln_org_configured?
+
+    raise "CPLN_ORG must be set for specs that interact with a Control Plane org. See spec/README.md."
+  end
+
+  def cpln_org_configured?
+    !DUMMY_TEST_ORG.nil? && !DUMMY_TEST_ORG.empty?
   end
 
   def dummy_test_app_global_identifier


### PR DESCRIPTION
## Summary

Allows the documented offline spec subset to load and run without `CPLN_ORG`, while preserving the existing Control Plane-backed test setup when that variable is configured.

Closes #373.

## Validation

- `bundle exec rubocop` — passed (200 files)
- Credential-free documented smoke suite — passed (81 examples)
- The same smoke suite with `CPLN_ORG=unit-test-org` — passed (81 examples)
- `git diff --check origin/main...HEAD` — passed

The full credentialed suite was not run because no real Control Plane organization is configured in this environment.

## Review

- Manual scope and correctness review completed.
- Automated second-model review was unavailable: the installed local reviewer requires a newer client model, and no authenticated alternate reviewer is available.

## Codex Decision Log

- **Non-blocking:** Whether to retag the broader suite.
  - **Decision:** Kept the existing test selection unchanged and documented the verified credential-free subset instead.
  - **Why:** The requested behavior only requires lazy organization setup; broad retagging would expand the change beyond the issue scope.
  - **Review later:** None.
