### PR TITLE
Fix cpflow loading without a UTF-8 locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 - **Added generic telemetry documentation for deploying an OpenTelemetry Collector with Control Plane Flow**, including collector workload templates, application instrumentation, telemetry pipelines, review-app isolation, and troubleshooting guidance. [PR 369](https://github.com/shakacode/control-plane-flow/pull/369) by [Justin Gordon](https://github.com/justin808).
 - **Added a Rails-focused Grafana and OpenTelemetry guide for building Control Plane dashboards from generated span and log metrics**, including collector workload guidance, spanmetrics setup, rollout order, alerting, and validation checklists. [PR 352](https://github.com/shakacode/control-plane-flow/pull/352) by [Justin Gordon](https://github.com/justin808).
 
+### Fixed
+
+- **Fixed `cpflow` crashing at load time with `invalid byte sequence in US-ASCII (ArgumentError)` on systems without a UTF-8 locale.** `Command::Base.all_commands` now reads command files with an explicit UTF-8 encoding instead of relying on `Encoding.default_external`. Fixes [issue 372](https://github.com/shakacode/control-plane-flow/issues/372).
+
 ## [5.1.1] - 2026-06-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed `cpflow` crashing at load time with `invalid byte sequence in US-ASCII (ArgumentError)` on systems without a UTF-8 locale.** `Command::Base.all_commands` now reads command files with an explicit UTF-8 encoding instead of relying on `Encoding.default_external`. Fixes [issue 372](https://github.com/shakacode/control-plane-flow/issues/372).
+- **Fixed `cpflow` crashing at load time with `invalid byte sequence in US-ASCII (ArgumentError)` on systems without a UTF-8 locale.** [PR 404](https://github.com/shakacode/control-plane-flow/pull/404) by [Justin Gordon](https://github.com/justin808). `Command::Base.all_commands` now reads command files with an explicit UTF-8 encoding instead of relying on `Encoding.default_external`. Fixes [issue 372](https://github.com/shakacode/control-plane-flow/issues/372).
 
 ## [5.1.1] - 2026-06-03
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -49,7 +49,7 @@ module Command
 
     def self.all_commands # rubocop:disable Metrics/MethodLength
       Dir["#{__dir__}/**/*.rb"].each_with_object({}) do |file, result|
-        content = File.read(file)
+        content = File.read(file, encoding: "UTF-8")
 
         classname = content.match(/^\s+class (?!Base\b)(\w+) < (?:.*(?!Command::)Base)(?:$| .*$)/)&.captures&.first
         next unless classname

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -49,6 +49,26 @@ describe Cpflow do
     expect(Integer(stdout_lines.fetch(1))).to be_positive
   end
 
+  it "loads with a US-ASCII external encoding" do
+    child_env = ENV.each_key.grep(/\ABUNDLE/).to_h { |key| [key, nil] }
+    child_env["LC_ALL"] = "C"
+    child_env["LANG"] = "C"
+    child_env["RUBYLIB"] = nil
+    child_env["RUBYOPT"] = nil
+
+    stdout, stderr, status = Open3.capture3(
+      child_env,
+      RbConfig.ruby,
+      "-I",
+      File.expand_path("../lib", __dir__),
+      "-e",
+      "require \"cpflow\"; puts Cpflow::VERSION"
+    )
+
+    expect(status).to be_success, stderr
+    expect(stdout).to include(Cpflow::VERSION)
+  end
+
   non_boolean_options_by_key_name.each do |option_key_name, option|
     it "raises error if no value is provided for '#{option_key_name}' option" do
       result = run_cpflow_command("test", option_key_name)


### PR DESCRIPTION
## Summary

- Read command files as UTF-8 so command discovery does not depend on the process locale.
- Add a regression that requires cpflow under the C locale, where Ruby uses US-ASCII as its external encoding.
- Document the user-visible startup fix.

Fixes #372.

## Attribution

Independently recreated from the narrow proposal in #398 by @SAY-5. The fork branch was not checked out or executed; the maintainer branch contains a reviewed implementation and a stronger public-interface regression test.

## Validation

- PASS: bundle exec rspec spec/cpflow_spec.rb
- PASS: LC_ALL=C LANG=C bundle exec ruby -I lib -e require cpflow
- PASS: .agents/bin/lint
- BLOCKED by environment: .agents/bin/validate requires a real CPLN_ORG for live Control Plane specs. Its failures are the documented missing-org errors and are unrelated to this locale-only change.

## Review

- Manual diff review: no actionable findings.
- Local Codex review was unavailable because the installed CLI does not support its configured model. Claude Code review was unavailable because this environment is not logged in.

## Codex Decision Log

- Non-blocking: adopt the external proposal on a maintainer-owned branch.
  - Decision: recreate and validate the minimal fix here rather than merge or modify the fork.
  - Why: preserves the trust boundary while retaining contributor attribution.
  - Review later: None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a startup crash when running on systems using a non-UTF-8 locale.
  * Command files are now loaded consistently using UTF-8 encoding.

* **Tests**
  * Added coverage to verify successful startup under US-ASCII locale settings.

* **Documentation**
  * Documented the locale-related startup fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->