### PR TITLE
Add HTTP retry/backoff to ControlplaneApiDirect and remove @@api_token class state (#383)

### DIFF
--- a/lib/core/controlplane_api_direct.rb
+++ b/lib/core/controlplane_api_direct.rb
@@ -40,6 +40,9 @@ class ControlplaneApiDirect
     end
   end
 
+  # Raised when fetching the API token via `cpln profile token` fails.
+  class TokenRefreshError < StandardError; end
+
   API_METHODS = {
     get: Net::HTTP::Get,
     patch: Net::HTTP::Patch,
@@ -51,40 +54,182 @@ class ControlplaneApiDirect
 
   API_TOKEN_EXPIRY_SECONDS = 300
 
-  class << self
-    attr_accessor :trace
+  # Only GET is retried after the request may have reached the server. The
+  # remaining verbs mutate state, so they only retry connect-phase failures.
+  IDEMPOTENT_METHODS = %i[get].freeze
+
+  # Bounded so a retried connect failure fits within the retry deadline.
+  OPEN_TIMEOUT_SECONDS = 10
+
+  # Thread-safe API token cache. A single instance is shared process-wide by
+  # default (see `default_token_provider`) so each `ControlplaneApiDirect.new`
+  # per API call reuses the cached token; tests inject a fresh instance.
+  class ApiToken
+    def initialize
+      @mutex = Mutex.new
+      @data = nil
+    end
+
+    def fetch
+      @mutex.synchronize do
+        @data = load_token if @data.nil?
+        refresh! if expiring_soon?
+        @data
+      end
+    end
+
+    def reset
+      @mutex.synchronize { @data = nil }
+    end
+
+    private
+
+    def load_token
+      token = ENV.fetch("CPLN_TOKEN", nil)
+      return validate!(token: token, comes_from_profile: false) if token
+
+      validate!(token: fetch_profile_token, comes_from_profile: true)
+    end
+
+    def refresh!
+      @data = validate!(token: fetch_profile_token, comes_from_profile: true)
+    end
+
+    def fetch_profile_token
+      result = Shell.cmd("cpln", "profile", "token")
+      unless result[:success]
+        raise TokenRefreshError,
+              "Failed to fetch the API token via 'cpln profile token'. " \
+              "Please re-run 'cpln profile login' or set the CPLN_TOKEN env variable."
+      end
+
+      result[:output].chomp
+    end
+
+    def validate!(data)
+      token = data[:token]
+      # Allow any token that does not contain line breaks. Scoped service-account
+      # tokens include punctuation such as '/', '+', ':', and '=', so format
+      # validation is deferred to the Control Plane API.
+      return data if token && !token.empty? && !token.match?(/[\r\n]/)
+
+      raise "Unknown API token format. " \
+            "Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable."
+    end
+
+    # Returns `true` when a profile-sourced JWT expires within 5 minutes.
+    def expiring_soon?
+      return false unless @data[:comes_from_profile]
+
+      payload, = JWT.decode(@data[:token], nil, false, algorithms: [])
+      return false unless payload.is_a?(Hash) && payload["exp"]
+
+      payload["exp"].to_i - Time.now.to_i <= API_TOKEN_EXPIRY_SECONDS
+    rescue JWT::DecodeError
+      false
+    end
   end
 
-  def call(url, method:, host: :api, body: nil) # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
-    trace = ControlplaneApiDirect.trace
+  # Retry policy for transient failures: tracks attempts, enforces the attempt
+  # and elapsed-time caps, and sleeps between tries (capped `Retry-After` when
+  # the server provides one, exponential backoff with jitter otherwise).
+  # The deadline is checked only before starting a new attempt: no new attempt
+  # begins after `MAX_TOTAL_RETRY_SECONDS`, but an in-flight attempt may run
+  # past it (bounded by the per-attempt open/read timeouts).
+  class Retrier
+    MAX_ATTEMPTS = 3
+    MAX_TOTAL_RETRY_SECONDS = 120
+    BASE_RETRY_DELAY_SECONDS = 0.5
+    MAX_RETRY_DELAY_SECONDS = 10
+    TRANSIENT_NETWORK_ERRORS = [
+      Net::OpenTimeout, Net::ReadTimeout,
+      Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::EPIPE, Errno::ETIMEDOUT,
+      EOFError, OpenSSL::SSL::SSLError, SocketError
+    ].freeze
+
+    def initialize(sleeper:)
+      @sleeper = sleeper
+      @attempts_made = 1
+      @deadline = Retrier.monotonic_time + MAX_TOTAL_RETRY_SECONDS
+    end
+
+    def self.monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Whether to retry a 429/5xx response received for an idempotent request.
+    def retry_response?(response, idempotent)
+      retriable = response.is_a?(Net::HTTPServerError) || response.is_a?(Net::HTTPTooManyRequests)
+      return false unless idempotent && retriable
+
+      retry?(retry_after: response["Retry-After"])
+    end
+
+    # Whether to retry a transient network error. Non-idempotent requests only
+    # retry when the failure happened before the request may have hit the wire.
+    def retry_exception?(idempotent, request_sent)
+      return false if request_sent && !idempotent
+
+      retry?
+    end
+
+    private
+
+    # When another attempt is allowed, sleeps through the delay and returns `true`.
+    def retry?(retry_after: nil)
+      return false if @attempts_made >= MAX_ATTEMPTS || Retrier.monotonic_time >= @deadline
+
+      @sleeper.call(next_delay(retry_after))
+      @attempts_made += 1
+      true
+    end
+
+    def next_delay(retry_after)
+      seconds = parse_retry_after(retry_after)
+      return seconds if seconds
+
+      backoff = [BASE_RETRY_DELAY_SECONDS * (2**(@attempts_made - 1)), MAX_RETRY_DELAY_SECONDS].min
+      (backoff / 2) + (rand * backoff / 2)
+    end
+
+    # Supports the delta-seconds form of `Retry-After`, capped so a slow or
+    # misconfigured server cannot stall the CLI.
+    def parse_retry_after(value)
+      return nil unless value.to_s.match?(/\A\d+\z/)
+
+      [Integer(value, 10), MAX_RETRY_DELAY_SECONDS].min
+    end
+  end
+
+  class << self
+    attr_accessor :trace
+    attr_reader :default_token_provider
+
+    # Preserved seam: `Controlplane#profile_switch` invalidates the cached
+    # token when the CPLN profile changes.
+    def reset_api_token = default_token_provider.reset
+  end
+
+  @default_token_provider = ApiToken.new
+
+  def initialize(token_provider: ControlplaneApiDirect.default_token_provider, sleeper: nil)
+    @token_provider = token_provider
+    @sleeper = sleeper || ->(seconds) { Kernel.sleep(seconds) }
+  end
+
+  def call(url, method:, host: :api, body: nil)
     uri = URI("#{api_host(host)}#{url}")
-    request = API_METHODS[method].new(uri)
-    request["Content-Type"] = "application/json"
-
-    refresh_api_token if should_refresh_api_token?
-
-    request["Authorization"] = authorization_header
-    request.body = body.to_json if body
+    # Token fetch and request construction happen outside the transient rescue
+    # in attempt_request so their failures (e.g. TokenRefreshError from the
+    # `cpln` shell-out) are never misclassified as retryable network errors.
+    request = build_request(uri, method, body)
+    retrier = Retrier.new(sleeper: @sleeper)
 
     Shell.debug(method.upcase, "#{uri} #{body&.to_json}")
 
-    http = Net::HTTP.new(uri.hostname, uri.port)
-    http.use_ssl = uri.scheme == "https"
-    http.set_debug_output(RedactedDebugOutput.new) if trace
-
-    response = http.start { |ht| ht.request(request) }
-
-    case response
-    when Net::HTTPOK
-      JSON.parse(response.body)
-    when Net::HTTPAccepted
-      true
-    when Net::HTTPNotFound
-      nil
-    when Net::HTTPForbidden
-      raise ForbiddenError.new(url: url, response: response)
-    else
-      raise("#{response} #{response.body}")
+    loop do
+      response = attempt_request(uri, request, method, retrier)
+      return handle_response(response, url) if response
     end
   end
 
@@ -104,54 +249,67 @@ class ControlplaneApiDirect
     "Bearer #{token}"
   end
 
-  # rubocop:disable Style/ClassVars
-  def api_token # rubocop:disable Metrics/MethodLength
-    return @@api_token if defined?(@@api_token)
-
-    @@api_token = {
-      token: ENV.fetch("CPLN_TOKEN", nil),
-      comes_from_profile: false
-    }
-    if @@api_token[:token].nil?
-      @@api_token = {
-        token: Shell.cmd("cpln", "profile", "token")[:output].chomp,
-        comes_from_profile: true
-      }
-    end
-    token = @@api_token[:token]
-    # Allow any token that does not contain line breaks. Scoped service-account
-    # tokens include punctuation such as '/', '+', ':', and '=', so format
-    # validation is deferred to the Control Plane API.
-    return @@api_token if token && !token.empty? && !token.match?(/[\r\n]/)
-
-    raise "Unknown API token format. " \
-          "Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable."
-  end
-
-  # Returns `true` when the token is about to expire in 5 minutes
-  def should_refresh_api_token?
-    return false unless api_token[:comes_from_profile]
-
-    payload, = JWT.decode(api_token[:token], nil, false, algorithms: [])
-    return false unless payload.is_a?(Hash) && payload["exp"]
-
-    difference_in_seconds = payload["exp"].to_i - Time.now.to_i
-
-    difference_in_seconds <= API_TOKEN_EXPIRY_SECONDS
-  rescue JWT::DecodeError
-    false
-  end
-
-  def refresh_api_token
-    @@api_token[:token] = Shell.cmd("cpln", "profile", "token")[:output].chomp
-  end
-
-  def self.reset_api_token
-    remove_class_variable(:@@api_token) if defined?(@@api_token)
-  end
-  # rubocop:enable Style/ClassVars
+  def api_token = @token_provider.fetch
 
   def self.parse_org(url)
     url.match(%r{^/org/([^/]+)})&.[](1)
+  end
+
+  private
+
+  # Returns the response, or `nil` when the attempt failed transiently and the
+  # retrier approved (and already slept before) another attempt. Only the
+  # transport phase (connect + request) is covered by the transient rescue.
+  def attempt_request(uri, request, method, retrier)
+    request_sent = false
+    idempotent = IDEMPOTENT_METHODS.include?(method)
+    response = transport_request(uri, request) { request_sent = true }
+    return response unless retrier.retry_response?(response, idempotent)
+
+    nil
+  rescue *Retrier::TRANSIENT_NETWORK_ERRORS
+    raise unless retrier.retry_exception?(idempotent, request_sent)
+
+    nil
+  end
+
+  def transport_request(uri, request)
+    http = build_http(uri)
+    http.start
+    yield
+    begin
+      http.request(request)
+    ensure
+      http.finish if http.started?
+    end
+  end
+
+  def build_request(uri, method, body)
+    request = API_METHODS[method].new(uri)
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = authorization_header
+    request.body = body.to_json if body
+    request
+  end
+
+  def build_http(uri)
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    # Net::HTTP transparently re-sends requests it deems idempotent once on
+    # mid-flight failures; disable so the Retrier owns the entire retry policy.
+    http.max_retries = 0
+    http.open_timeout = OPEN_TIMEOUT_SECONDS
+    http.set_debug_output(RedactedDebugOutput.new) if ControlplaneApiDirect.trace
+    http
+  end
+
+  def handle_response(response, url)
+    case response
+    when Net::HTTPOK then JSON.parse(response.body)
+    when Net::HTTPAccepted then true
+    when Net::HTTPNotFound then nil
+    when Net::HTTPForbidden then raise(ForbiddenError.new(url: url, response: response))
+    else raise("#{response} #{response.body}")
+    end
   end
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -6,6 +6,7 @@ Some specs exercise only local behavior and can run without Control Plane creden
 CPLN_ORG='' bundle exec rspec \
   spec/patches \
   spec/support_specs \
+  spec/core/controlplane_api_direct_spec.rb \
   spec/core/controlplane_api_spec.rb \
   spec/core/doctor_service_spec.rb \
   spec/core/github_flow_readiness/checks_spec.rb \

--- a/spec/core/controlplane_api_direct_spec.rb
+++ b/spec/core/controlplane_api_direct_spec.rb
@@ -3,7 +3,22 @@
 require "spec_helper"
 
 describe ControlplaneApiDirect do
-  let!(:described_instance) { described_class.new }
+  let(:token_provider) { described_class::ApiToken.new }
+  let(:slept_delays) { [] }
+  let(:described_instance) do
+    described_class.new(token_provider: token_provider, sleeper: ->(seconds) { slept_delays << seconds })
+  end
+
+  it "keeps no class-variable state" do
+    expect(described_class.class_variables).to be_empty
+  end
+
+  it "uses the process-shared default token provider when none is injected" do
+    allow(described_class.default_token_provider).to receive(:fetch)
+      .and_return({ token: "shared-token", comes_from_profile: false })
+
+    expect(described_class.new.api_token[:token]).to eq("shared-token")
+  end
 
   describe "#api_host" do
     it "returns correct host for 'api' when CPLN_ENDPOINT is not set" do
@@ -30,12 +45,8 @@ describe ControlplaneApiDirect do
   end
 
   describe "#api_token" do
-    before do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
-    end
-
-    after do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
+    def jwt_token(expires_in:)
+      JWT.encode({ "exp" => Time.now.to_i + expires_in }, nil, "none")
     end
 
     it "returns token from CPLN_TOKEN" do
@@ -45,6 +56,15 @@ describe ControlplaneApiDirect do
 
       expect(result[:token]).to eq("token_1")
       expect(result[:comes_from_profile]).to be(false)
+    end
+
+    it "prefers CPLN_TOKEN over the profile token" do
+      stub_env("CPLN_TOKEN", "token_1")
+      allow(Shell).to receive(:cmd)
+
+      described_instance.api_token
+
+      expect(Shell).not_to have_received(:cmd)
     end
 
     it "accepts non-empty service account tokens with punctuation" do
@@ -79,7 +99,8 @@ describe ControlplaneApiDirect do
 
     it "returns token from 'cpln profile token'" do
       stub_env("CPLN_TOKEN", nil)
-      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: "token_2" })
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: "token_2\n", success: true })
 
       result = described_instance.api_token
 
@@ -87,9 +108,19 @@ describe ControlplaneApiDirect do
       expect(result[:comes_from_profile]).to be(true)
     end
 
+    it "caches the profile token across fetches" do
+      stub_env("CPLN_TOKEN", nil)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: "token_2", success: true })
+
+      2.times { described_instance.api_token }
+
+      expect(Shell).to have_received(:cmd).once
+    end
+
     it "raises error if token is not found" do
       stub_env("CPLN_TOKEN", nil)
-      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: "" })
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: "", success: true })
 
       message = "Unknown API token format. " \
                 "Please re-run 'cpln profile login' or set the correct CPLN_TOKEN env variable."
@@ -97,17 +128,86 @@ describe ControlplaneApiDirect do
         described_instance.api_token
       end.to raise_error(RuntimeError, message)
     end
+
+    it "raises TokenRefreshError when 'cpln profile token' fails" do
+      stub_env("CPLN_TOKEN", nil)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: "garbage", success: false })
+
+      expect do
+        described_instance.api_token
+      end.to raise_error(described_class::TokenRefreshError, /cpln profile login/)
+    end
+
+    it "refreshes a profile JWT that is about to expire" do
+      stub_env("CPLN_TOKEN", nil)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: jwt_token(expires_in: 60), success: true },
+                                               { output: "refreshed-token", success: true })
+
+      result = described_instance.api_token
+
+      expect(result[:token]).to eq("refreshed-token")
+      expect(result[:comes_from_profile]).to be(true)
+      expect(Shell).to have_received(:cmd).twice
+    end
+
+    it "raises TokenRefreshError when refreshing an expiring token fails" do
+      stub_env("CPLN_TOKEN", nil)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: jwt_token(expires_in: 60), success: true },
+                                               { output: "", success: false })
+
+      expect do
+        described_instance.api_token
+      end.to raise_error(described_class::TokenRefreshError, /cpln profile token/)
+    end
+
+    it "does not refresh JWTs that are not close to expiring" do
+      stub_env("CPLN_TOKEN", nil)
+      token = jwt_token(expires_in: 3600)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: token, success: true })
+
+      2.times { described_instance.api_token }
+
+      expect(described_instance.api_token[:token]).to eq(token)
+      expect(Shell).to have_received(:cmd).once
+    end
+
+    it "does not try to refresh non-JWT profile tokens" do
+      stub_env("CPLN_TOKEN", nil)
+      token = "service-account/key:abc.def/ghi+jkl=mnop"
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: "#{token}\n", success: true })
+
+      2.times { described_instance.api_token }
+
+      expect(described_instance.api_token[:token]).to eq(token)
+      expect(Shell).to have_received(:cmd).once
+    end
+  end
+
+  describe ".reset_api_token" do
+    it "resets the shared default token provider" do
+      allow(described_class.default_token_provider).to receive(:reset)
+
+      described_class.reset_api_token
+
+      expect(described_class.default_token_provider).to have_received(:reset)
+    end
+
+    it "clears the cached token so the next fetch reloads it" do
+      stub_env("CPLN_TOKEN", nil)
+      allow(Shell).to receive(:cmd).with("cpln", "profile", "token")
+                                   .and_return({ output: "token_1", success: true },
+                                               { output: "token_2", success: true })
+
+      expect(described_instance.api_token[:token]).to eq("token_1")
+      token_provider.reset
+      expect(described_instance.api_token[:token]).to eq("token_2")
+    end
   end
 
   describe "#authorization_header" do
-    before do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
-    end
-
-    after do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
-    end
-
     it "uses bearer authentication for raw tokens" do
       stub_env("CPLN_TOKEN", "token_1")
 
@@ -121,21 +221,221 @@ describe ControlplaneApiDirect do
     end
   end
 
-  describe "#should_refresh_api_token?" do
+  describe "#call" do
+    let(:http_connection) do
+      instance_double(Net::HTTP, "use_ssl=": nil, "max_retries=": nil, "open_timeout=": nil,
+                                 set_debug_output: nil, start: nil, finish: nil, started?: true)
+    end
+
     before do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
+      stub_env("CPLN_TOKEN", "call-token")
+      stub_env("CPLN_ENDPOINT", nil)
+      allow(Net::HTTP).to receive(:new).and_return(http_connection)
     end
 
-    after do
-      described_class.remove_class_variable(:@@api_token) if described_class.class_variable_defined?(:@@api_token)
+    def http_response(klass, code, body: nil, headers: {})
+      response = klass.new("1.1", code.to_s, klass.name)
+      response.instance_variable_set(:@read, true)
+      response.instance_variable_set(:@body, body)
+      headers.each { |key, value| response[key] = value }
+      response
     end
 
-    it "does not try to refresh non-JWT profile tokens" do
-      stub_env("CPLN_TOKEN", nil)
-      token = "service-account/key:abc.def/ghi+jkl=mnop"
-      allow(Shell).to receive(:cmd).with("cpln", "profile", "token").and_return({ output: "#{token}\n" })
+    def ok_response(body: '{"result":"ok"}')
+      http_response(Net::HTTPOK, 200, body: body)
+    end
 
-      expect(described_instance.should_refresh_api_token?).to be(false)
+    it "parses the body of a 200 response" do
+      allow(http_connection).to receive(:request).and_return(ok_response)
+
+      result = described_instance.call("/org/my-org/gvc", method: :get)
+
+      expect(result).to eq({ "result" => "ok" })
+      expect(slept_delays).to be_empty
+    end
+
+    it "disables Net::HTTP's built-in retries and bounds the open timeout" do
+      allow(http_connection).to receive(:request).and_return(ok_response)
+
+      described_instance.call("/org/my-org/gvc", method: :get)
+
+      expect(http_connection).to have_received(:max_retries=).with(0)
+      expect(http_connection).to have_received(:open_timeout=).with(described_class::OPEN_TIMEOUT_SECONDS)
+    end
+
+    it "returns true for a 202 response" do
+      allow(http_connection).to receive(:request).and_return(http_response(Net::HTTPAccepted, 202))
+
+      expect(described_instance.call("/org/my-org/gvc", method: :delete)).to be(true)
+    end
+
+    it "returns nil for a 404 response without retrying" do
+      allow(http_connection).to receive(:request).and_return(http_response(Net::HTTPNotFound, 404))
+
+      expect(described_instance.call("/org/my-org/gvc/missing", method: :get)).to be_nil
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "raises ForbiddenError for a 403 response without retrying" do
+      allow(http_connection).to receive(:request).and_return(http_response(Net::HTTPForbidden, 403))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :get)
+      end.to raise_error(described_class::ForbiddenError, /my-org/)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "fails immediately on a 400 response with no retries" do
+      allow(http_connection).to receive(:request).and_return(http_response(Net::HTTPBadRequest, 400, body: "bad"))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :get)
+      end.to raise_error(RuntimeError, /Net::HTTPBadRequest.*bad/m)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "fails immediately on a 401 response with no retries" do
+      allow(http_connection).to receive(:request).and_return(http_response(Net::HTTPUnauthorized, 401))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :get)
+      end.to raise_error(RuntimeError, /Net::HTTPUnauthorized/)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "retries a GET after a transient 500 and backs off with jitter" do
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPInternalServerError, 500, body: "boom"), ok_response)
+
+      result = described_instance.call("/org/my-org/gvc", method: :get)
+
+      expect(result).to eq({ "result" => "ok" })
+      expect(http_connection).to have_received(:request).twice
+      expect(slept_delays.size).to eq(1)
+      expect(slept_delays.first).to be_between(0.25, 0.5)
+    end
+
+    it "retries a GET after a read timeout" do
+      allow(http_connection).to receive(:request).and_invoke(
+        ->(_request) { raise Net::ReadTimeout },
+        ->(_request) { ok_response }
+      )
+
+      expect(described_instance.call("/org/my-org/gvc", method: :get)).to eq({ "result" => "ok" })
+      expect(http_connection).to have_received(:request).twice
+      expect(slept_delays.size).to eq(1)
+    end
+
+    it "retries a GET after a connect timeout" do
+      allow(http_connection).to receive(:start).and_invoke(
+        ->(*) { raise Net::OpenTimeout },
+        ->(*) {}
+      )
+      allow(http_connection).to receive(:request).and_return(ok_response)
+
+      expect(described_instance.call("/org/my-org/gvc", method: :get)).to eq({ "result" => "ok" })
+      expect(slept_delays.size).to eq(1)
+    end
+
+    it "honors Retry-After on a 429 response" do
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPTooManyRequests, 429, headers: { "Retry-After" => "7" }), ok_response)
+
+      expect(described_instance.call("/org/my-org/gvc", method: :get)).to eq({ "result" => "ok" })
+      expect(slept_delays).to eq([7])
+    end
+
+    it "caps an excessive Retry-After value" do
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPTooManyRequests, 429, headers: { "Retry-After" => "9999" }), ok_response)
+
+      expect(described_instance.call("/org/my-org/gvc", method: :get)).to eq({ "result" => "ok" })
+      expect(slept_delays).to eq([described_class::Retrier::MAX_RETRY_DELAY_SECONDS])
+    end
+
+    it "falls back to backoff when Retry-After is not delta-seconds" do
+      headers = { "Retry-After" => "Wed, 21 Oct 2026 07:28:00 GMT" }
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPTooManyRequests, 429, headers: headers), ok_response)
+
+      expect(described_instance.call("/org/my-org/gvc", method: :get)).to eq({ "result" => "ok" })
+      expect(slept_delays.size).to eq(1)
+      expect(slept_delays.first).to be_between(0.25, 0.5)
+    end
+
+    it "gives up after the attempt cap and raises the original error" do
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPInternalServerError, 500, body: "boom"))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :get)
+      end.to raise_error(RuntimeError, /Net::HTTPInternalServerError.*boom/m)
+      expect(http_connection).to have_received(:request).exactly(3).times
+      expect(slept_delays.size).to eq(2)
+      expect(slept_delays.first).to be_between(0.25, 0.5)
+      expect(slept_delays.last).to be_between(0.5, 1.0)
+    end
+
+    it "does not start a new attempt after the elapsed-time deadline" do
+      allow(described_class::Retrier).to receive(:monotonic_time)
+        .and_return(0, described_class::Retrier::MAX_TOTAL_RETRY_SECONDS + 1)
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPInternalServerError, 500, body: "boom"))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :get)
+      end.to raise_error(RuntimeError, /Net::HTTPInternalServerError/)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "does not retry a POST on a 500 response" do
+      allow(http_connection).to receive(:request)
+        .and_return(http_response(Net::HTTPInternalServerError, 500, body: "boom"))
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :post, body: { name: "gvc" })
+      end.to raise_error(RuntimeError, /Net::HTTPInternalServerError/)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "does not retry a POST that fails after the request was sent" do
+      allow(http_connection).to receive(:request).and_raise(Errno::ECONNRESET)
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :post, body: { name: "gvc" })
+      end.to raise_error(Errno::ECONNRESET)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "does not retry a PUT that fails after the request was sent" do
+      allow(http_connection).to receive(:request).and_raise(Errno::ECONNRESET)
+
+      expect do
+        described_instance.call("/org/my-org/gvc", method: :put, body: { name: "gvc" })
+      end.to raise_error(Errno::ECONNRESET)
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays).to be_empty
+    end
+
+    it "retries a POST when the connection fails before the request is sent" do
+      allow(http_connection).to receive(:start).and_invoke(
+        ->(*) { raise Errno::ECONNREFUSED },
+        ->(*) {}
+      )
+      allow(http_connection).to receive(:request).and_return(ok_response)
+
+      result = described_instance.call("/org/my-org/gvc", method: :post, body: { name: "gvc" })
+
+      expect(result).to eq({ "result" => "ok" })
+      expect(http_connection).to have_received(:request).once
+      expect(slept_delays.size).to eq(1)
     end
   end
 


### PR DESCRIPTION
Closes #383.

Hardens `ControlplaneApiDirect` — the HTTP client behind every Control Plane API call:

1. **Bounded retry with backoff** (`Retrier`): GET retries transient network errors (`Net::OpenTimeout`/`ReadTimeout`, `ECONNRESET`/`ECONNREFUSED`/`EPIPE`/`ETIMEDOUT`, `EOFError`, `OpenSSL::SSL::SSLError`, `SocketError`), 429, and 5xx. Equal-jitter exponential backoff (0.5·2^n capped at 10s); `Retry-After` delta-seconds honored, capped at 10s; 3 attempts max; 120s deadline (no new attempt begins after it; an in-flight attempt may run past it). POST/PATCH/PUT/DELETE retry **only** connect-phase failures — `http.max_retries = 0` disables Net::HTTP's hidden internal resend of PUT/DELETE (verified on a real socket: a PUT RST mid-response was silently re-sent before this change, exactly once after it fails cleanly). 4xx ≠ 429 fails immediately. `open_timeout` 10s so connect-timeout retries are actually reachable within the deadline.
2. **`@@api_token` class variable removed**: replaced with `ApiToken` — a mutex-guarded, process-shared-by-default, per-instance-injectable token provider. Preserves `CPLN_TOKEN` priority, profile fallback, JWT 5-min-expiry refresh, the token-format guard, the `{token:, comes_from_profile:}` hash shape used by `lib/command/run.rb`, and the `reset_api_token` seam used by `lib/core/controlplane.rb` on profile switch (issue's claim that it was test-only was incorrect — it's a production call site).
3. **Token fetch/refresh now checks `Shell.cmd[:success]`** and raises `TokenRefreshError` with an actionable message instead of silently proceeding with garbage output.
4. Specs: 44 offline examples (0.09s, zero real sleeps via injected sleeper) — retry/backoff windows (non-overlapping jitter ranges pin exponential growth), Retry-After honored/capped/HTTP-date-fallback, deadline gate (stubbed monotonic clock), per-method retry policy incl. PUT/POST after-send no-retry, token provider lifecycle, `class_variables.empty?`, no manual state reset anywhere. `spec/core/controlplane_api_direct_spec.rb` added to the documented offline suite.

## Codex Decision Log

- **Non-blocking:** #380 (typed error hierarchy) hasn't landed; the issue marks it as a dependency.
  - **Decision:** Proceed with file-local `TokenRefreshError < StandardError`; retry classification keys off exception classes/HTTP status directly.
  - **Why:** Maintainer explicitly targeted #383 in this batch; the classification is clean without the hierarchy.
  - **Review later:** Fold `TokenRefreshError` into the #380 hierarchy when it lands.
- **Non-blocking:** `trace` class attr left as-is (written by `config.rb`, read by `controlplane.rb`) — folding into instance config is not a non-breaking single-file change.
- **Non-blocking:** Authorization header computed once per `call`, not per attempt. Worst-case call ≈190s vs the 300s JWT refresh margin — no expiry window.
- **Non-blocking (accepted nits):** deadline check precedes the sleep, so an attempt can begin ≤10s past the 120s deadline; read-timeout retries cap at 2 attempts (60s default read timeout × deadline arithmetic); `validate!` takes a positional hash; mutex held across the `cpln profile token` subprocess (fine for a CLI).

## Confidence

- Unit specs: **44 examples, 0 failures, ~0.09s**; combined with the verified-double consumer spec (`controlplane_api_spec.rb`): **71 examples, 0 failures**.
- Full documented offline suite + batch lanes: **239 examples, 0 failures** at seeds 24680, 13579 (worker) and 77613 (reviewer).
- Independent skeptical review including a **real-socket integration harness** (8/8 scenarios, 0 leaked sockets): initial major (Net::HTTP hidden resend) found, fixed, and re-verified on the wire; all five fix areas delta-verified.
- Grep proofs: no `@@api_token` anywhere; `reset_api_token` only at its definition and the preserved `controlplane.rb:23` call site; rubocop clean with three old disables removed and zero added.
- Risk: medium (runtime HTTP path) — mitigated by wire-level verification and unchanged response-handling semantics (200/202/404/403/5xx-raise message shapes byte-compatible, verified against the `spec_helper` retry matcher from #415).

Batch: CPFLOW B 07-16 15:43 (`cpf-b-20260716-1543`), lane issue383, epic #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
