### PR TITLE
test: add unit specs for String monkey-patches (#unindent, #underscore, #indent)

### DIFF
--- a/spec/patches/string_spec.rb
+++ b/spec/patches/string_spec.rb
@@ -24,4 +24,36 @@ RSpec.describe String do
       end
     end
   end
+
+  describe "#unindent" do
+    it "strips leading indentation common to all lines" do
+      indented = "  first line\n    second line\n"
+
+      expect(indented.unindent).to eq("first line\n  second line\n")
+    end
+  end
+
+  describe "#underscore" do
+    it "converts camel case to underscore format" do
+      expect("ControlPlaneFlow".underscore).to eq("control_plane_flow")
+    end
+
+    it "converts double colons to forward slashes" do
+      expect("Cpflow::Cli".underscore).to eq("cpflow/cli")
+    end
+
+    it "handles hyphenated words" do
+      expect("control-plane".underscore).to eq("control_plane")
+    end
+  end
+
+  describe "#indent" do
+    it "indents lines by the specified amount" do
+      expect("hello\nworld".indent(2)).to eq("  hello\n  world")
+    end
+
+    it "uses custom indent character when provided" do
+      expect("hello".indent(1, "\t")).to eq("\thello")
+    end
+  end
 end


### PR DESCRIPTION
# Summary
Added RSpec tests to increase coverage for the `String` patch methods (`#unindent`, `#underscore`, and `#indent`) in `spec/patches/string_spec.rb`.

### Changes
- Added unit test cases for `String#unindent` to verify leading whitespace stripping across multiline strings.
- Added unit test cases for `String#underscore` covering CamelCase, double colon namespaces (`::`), and hyphenated names.
- Added unit test cases for `String#indent` testing standard indentation and custom indent characters.

### Verification
- `bundle exec rspec spec/patches/string_spec.rb` passed cleanly (9 examples, 0 failures).
- `bundle exec rubocop spec/patches/string_spec.rb` passed with no offenses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for removing common indentation from multiline text.
  - Added coverage for converting camelCase and namespaced strings to snake_case formats.
  - Added coverage for adding configurable indentation using spaces or custom characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->