### PR TITLE
Add outside contributor intake policy

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -15,6 +15,8 @@ release_qa_runbook: ".agents/workflows/ai-rollout-e2e-test.md — use after publ
 hosted_ci_trigger: "n/a — CI runs on every PR"
 ci_change_detector: n/a
 
+# Consumed by the portable untrusted-contributor-intake skill. These values must
+# be read from the trusted base ref, never from contributor-controlled PR content.
 untrusted_contributor_intake:
   trusted_github_host: github.com
   trusted_github_scheme: https

--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -14,3 +14,8 @@ ci_parity_environment: "n/a — reproduce CI-only failures from the matching job
 release_qa_runbook: ".agents/workflows/ai-rollout-e2e-test.md — use after publishing a cpflow gem that changes GitHub Actions, AI rollout prompts, readiness checks, generator output, or React on Rails deployment behavior"
 hosted_ci_trigger: "n/a — CI runs on every PR"
 ci_change_detector: n/a
+
+untrusted_contributor_intake:
+  trusted_github_host: github.com
+  trusted_github_scheme: https
+  trusted_github_repo: shakacode/control-plane-flow

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What changes, and why is it useful? -->
+
+## Related issue
+
+<!-- Use "Closes #123" for an accepted issue, or link the maintainer discussion. -->
+
+## Validation
+
+<!-- List the exact commands or manual checks you ran. -->
+
+## Checklist
+
+- [ ] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
+- [ ] The change is focused and contains no unrelated cleanup or generated churn.
+- [ ] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
+- [ ] I reviewed and understand all submitted content, including AI-assisted changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Before Opening a Pull Request
+
+Please start with an open issue labeled `good first issue` or `help wanted`, or discuss the proposed change in an issue before investing significant work. Pull requests should link the accepted issue and explain the user problem or regression they address.
+
+Small typo fixes are welcome without prior discussion. Unsolicited coverage-only changes, refactors, formatting or generated-file churn, dependency or workflow changes, and broad documentation rewrites may be closed when they do not address an accepted issue, a demonstrated regression, or a maintainer request.
+
+Keep each pull request focused, include the relevant validation, and update tests, documentation, and `CHANGELOG.md` when the change affects them. Contributors remain responsible for reviewing and understanding everything they submit, including AI-assisted content and automated review suggestions.
+
 ## Installation
 
 Rather than installing `cpflow` as a Ruby gem, install this repo locally and alias the `cpflow` command globally for easier


### PR DESCRIPTION
## Summary

- document that substantial contributions should start from an accepted issue or maintainer discussion
- add a pull request template that asks for scope, issue context, validation, and contributor ownership of AI-assisted content
- pin the trusted GitHub host and repository used by the outside-contributor intake workflow

## Why

This gives contributors clear expectations and lets maintainers close low-signal drive-by changes consistently without spending review and CI time rediscovering the policy. The trusted-origin configuration also allows read-only fork intake to fail closed against the intended repository.

## Validation

- `git diff --check`
- parsed `.agents/agent-workflow.yml` with Ruby `YAML.safe_load_file`
- attempted `.agents/bin/validate`; the existing full suite fails broadly because `CPLN_ORG` is not configured in this credential-free worktree, before any failure related to these documentation/configuration-only changes
