### PR TITLE
Fix deploy-image for internal-only workloads

### DIFF
--- a/.github/actions/cpflow-setup-environment/action.yml
+++ b/.github/actions/cpflow-setup-environment/action.yml
@@ -99,7 +99,7 @@ runs:
 
         # Bump this default when a new Control Plane CLI release should roll out by default.
         # Override per-repo by setting the `CPLN_CLI_VERSION` repo variable.
-        default_cpln_cli_version="3.10.2"
+        default_cpln_cli_version="3.11.0"
 
         CPLN_CLI_VERSION="${CPLN_CLI_VERSION:-${default_cpln_cli_version}}"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 ### Changed
 
 - **Simplified generated review-app help comments to a three-command quick reference, moved setup behind expandable details, and clarified GitHub Actions secret and variable terminology.** [PR 410](https://github.com/shakacode/control-plane-flow/pull/410) by [Justin Gordon](https://github.com/justin808).
-- **Updated reusable GitHub Actions setup to install Control Plane CLI 3.11.0 by default.**
+- **Updated reusable GitHub Actions setup to install Control Plane CLI 3.11.0 by default.** [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 
 ### Fixed
 
-- **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available.
+- **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.2.0] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 ### Changed
 
 - **Simplified generated review-app help comments to a three-command quick reference, moved setup behind expandable details, and clarified GitHub Actions secret and variable terminology.** [PR 410](https://github.com/shakacode/control-plane-flow/pull/410) by [Justin Gordon](https://github.com/justin808).
+- **Updated reusable GitHub Actions setup to install Control Plane CLI 3.11.0 by default.**
+
+### Fixed
+
+- **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available.
 
 ## [5.2.0] - 2026-07-10
 

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -118,6 +118,7 @@ module Command
           step("Deploying image '#{image}' for workload '#{workload}'") do
             cp.workload_set_image_ref(workload, container: container_name, image: image)
             deployed_endpoints[workload] = endpoint_for_workload(workload_data)
+            true
           end
           # Deploy the first matching app-image container per workload; CPLN workloads
           # are expected to have a single container that runs the app image.

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -118,6 +118,7 @@ module Command
           step("Deploying image '#{image}' for workload '#{workload}'") do
             cp.workload_set_image_ref(workload, container: container_name, image: image)
             deployed_endpoints[workload] = endpoint_for_workload(workload_data)
+            # A missing public endpoint is valid; the image update still completed successfully.
             true
           end
           # Deploy the first matching app-image container per workload; CPLN workloads

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -131,7 +131,7 @@ module Command
     def print_deployed_endpoints(deployed_endpoints)
       progress.puts("\nDeployed endpoints:")
       deployed_endpoints.each do |workload, endpoint|
-        progress.puts("  - #{workload}: #{endpoint}")
+        progress.puts("  - #{workload}: #{endpoint || '(no public endpoint)'}")
       end
     end
 
@@ -172,9 +172,15 @@ module Command
 
     def endpoint_for_workload(workload_data)
       endpoint = workload_data.dig("status", "endpoint")
+      return fallback_endpoint_for_workload(workload_data) unless endpoint
+
       Resolv.getaddress(endpoint.split("/").last)
       endpoint
     rescue Resolv::ResolvError
+      fallback_endpoint_for_workload(workload_data)
+    end
+
+    def fallback_endpoint_for_workload(workload_data)
       deployments = cp.fetch_workload_deployments(workload_data["name"])
       deployments.dig("items", 0, "status", "endpoint")
     end

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -364,6 +364,44 @@ describe Command::DeployImage do
       expect { command.call }.to output(%r{- frontend: https://frontend-test\.cpln\.app}).to_stderr
     end
 
+    context "when a workload has no public endpoint" do
+      before do
+        workload_data["status"] = {}
+        allow(cp).to receive(:fetch_workload_deployments)
+          .with("frontend")
+          .and_return({ "items" => [{ "status" => {} }] })
+      end
+
+      it "deploys successfully and reports that no public endpoint is available" do
+        expect { command.call }.to output(/- frontend: \(no public endpoint\)/).to_stderr
+
+        expect(cp).to have_received(:workload_set_image_ref)
+          .with("frontend", container: "rails", image: "test-app:1")
+        expect(cp).to have_received(:fetch_workload_deployments).with("frontend")
+      end
+    end
+
+    context "when the workload endpoint does not resolve" do
+      before do
+        allow(Resolv).to receive(:getaddress).and_raise(Resolv::ResolvError)
+        allow(cp).to receive(:fetch_workload_deployments)
+          .with("frontend")
+          .and_return(
+            {
+              "items" => [
+                { "status" => { "endpoint" => "https://frontend-fallback.cpln.app" } }
+              ]
+            }
+          )
+      end
+
+      it "reports the endpoint from the latest deployment" do
+        expect { command.call }.to output(%r{- frontend: https://frontend-fallback\.cpln\.app}).to_stderr
+
+        expect(cp).to have_received(:fetch_workload_deployments).with("frontend")
+      end
+    end
+
     it "uses the container name for the API call that updates the image ref" do
       command.call
 

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -373,7 +373,9 @@ describe Command::DeployImage do
       end
 
       it "deploys successfully and reports that no public endpoint is available" do
-        expect { command.call }.to output(/- frontend: \(no public endpoint\)/).to_stderr
+        expect do
+          expect { command.call }.not_to raise_error
+        end.to output(/- frontend: \(no public endpoint\)/).to_stderr
 
         expect(cp).to have_received(:workload_set_image_ref)
           .with("frontend", container: "rails", image: "test-app:1")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -170,7 +170,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
     it "exposes overridable cpflow and cpln-cli version inputs" do
       contents = setup_action_path.read
       expect(contents).to include("cpln_cli_version:")
-      expect(contents).to include('default_cpln_cli_version="3.10.2"')
+      expect(contents).to include('default_cpln_cli_version="3.11.0"')
       expect(contents).to include("control_plane_flow_ref:")
       expect(reusable_staging_workflow_path.read).to include("cpln_cli_version: ${{ vars.CPLN_CLI_VERSION }}")
       expect(reusable_staging_workflow_path.read).to include("cpflow_version: ${{ vars.CPFLOW_VERSION }}")


### PR DESCRIPTION
## Summary

- allow `cpflow deploy-image` to deploy internal-only workloads that have no public endpoint
- preserve the existing latest-deployment endpoint fallback and report `(no public endpoint)` when neither source has one
- update the reusable GitHub Actions setup default from Control Plane CLI 3.10.2 to 3.11.0
- document both user-visible changes under `Unreleased`

## Failure evidence

- Downstream Hichee CircleCI job [804740](https://app.circleci.com/pipelines/gh/shakacode/hichee/55132/workflows/13528255-bae7-4914-ba3b-de09892cdcb6/jobs/804740) failed in `Command::DeployImage#endpoint_for_workload` because an internal-only renderer had a nil public endpoint and cpflow called `split` on it.
- The regression example reproduced the same `NoMethodError: undefined method 'split' for nil` before the implementation change, then passed after the fix.

## Validation

- `bundle exec rspec spec/command/deploy_image_unit_spec.rb spec/command/generate_github_actions_spec.rb` - 102 examples, 0 failures
- documented offline remainder through `.agents/bin/test` - 207 examples, 0 failures
- `.agents/bin/validate` with the documented 19-file offline `SPEC` scope - 207 examples, 0 failures; 208 RuboCop files, no offenses
- `.agents/bin/lint` - 208 files, no offenses
- `.agents/bin/docs` - generated command docs current
- composite action YAML parse - passed
- `npm view @controlplane/cli@3.11.0 version` - 3.11.0 exists

- The first hosted fast-suite run on the prior head exposed a process-level regression the focused output matcher had not converted into an RSpec failure: the internal-only example ended the process with exit 64 after 629 passing examples because the deployment step treated the nil endpoint as failure. The corrected implementation returns successful step status independently of endpoint presence; its exact regression run now exits 0.

The credentialed full integration suite was not used as a merge signal. Its interrupted run entered the unrelated live `Command::Run` interactive terminal-size example and remained in a local `cpflow-run` operation for more than 12 minutes. The run was stopped without a final RSpec summary; no Control Plane integration test was rerun after the scope was classified as unrelated to this diff.

## Downstream dependency

- Blocks [Hichee PR #9652](https://github.com/shakacode/hichee/pull/9652), which can pin this exact merged commit with `CPFLOW_VERSION` unset.
- No cpflow gem release is included or required for commit-SHA testing.
- Production was not deployed from this PR or this lane.

