### PR TITLE
Refresh templates for existing review apps

### DIFF
--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -270,6 +270,14 @@ jobs:
           set -euo pipefail
           cpflow setup-app -a "${APP_NAME}" --org "${CPLN_ORG}"
 
+      - name: Refresh existing review app templates
+        if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && steps.check-app.outputs.exists == 'true'
+        working-directory: app
+        shell: bash
+        run: |
+          set -euo pipefail
+          cpflow setup-app -a "${APP_NAME}" --org "${CPLN_ORG}" --refresh-templates
+
       - name: Create initial PR comment
         if: steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && (steps.check-app.outputs.exists == 'true' || steps.setup-review-app.outcome == 'success')
         id: create-comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or overwriting existing secret resources.**
 - **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.2.0] - 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or overwriting existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).
+- **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or modifying existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).
 - **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.2.0] - 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or overwriting existing secret resources.**
+- **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or overwriting existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).
 - **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 
 ## [5.2.0] - 2026-07-10

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -335,7 +335,9 @@ prompts noninteractively, preserves deployed app-image references and existing
 secret resources, and repairs the configured app and shared-secret policy
 bindings. Preserving image references keeps release-phase and ordered-deploy
 gates in control of image rollout; a template failure stops the workflow before
-the image build or deployment.
+the image build or deployment. Existing secret templates are skipped as whole
+resources, so refresh neither changes existing values nor adds newly templated
+keys; provision required new keys separately before deployment.
 You still need the shared review-app runtime secret values described by your
 templates, and the staging token must have access to create and update
 review-app GVCs, workloads, images, identities, policies, and secrets in the

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -327,6 +327,15 @@ the run early instead of deploying an image that cannot boot.
 
 Review apps are different: the generated `+review-app-deploy` workflow creates
 temporary PR apps as needed, including the identity and secret policy binding.
+For an existing review app, each deployment runs
+`cpflow setup-app --refresh-templates` before building and deploying the new
+image. Refresh mode reapplies the configured `setup_app_templates` without
+deleting the GVC or running `hooks.post_creation`, answers template replacement
+prompts noninteractively, preserves deployed app-image references and existing
+secret resources, and repairs the configured app and shared-secret policy
+bindings. Preserving image references keeps release-phase and ordered-deploy
+gates in control of image rollout; a template failure stops the workflow before
+the image build or deployment.
 You still need the shared review-app runtime secret values described by your
 templates, and the staging token must have access to create and update
 review-app GVCs, workloads, images, identities, policies, and secrets in the
@@ -334,12 +343,13 @@ staging org.
 
 If review apps share an existing staging database or another existing secret,
 declare it with `shared_secret_grants` on the review app config entry. The
-deploy workflow runs `setup-app` for new review apps and `deploy-image` for
-image updates; those commands bind or repair the review app identity's `reveal`
-permission on each configured shared policy. The delete and cleanup workflows
-call `cpflow delete`, which removes those bindings as review apps go away. This
-lets one shared database or license secret serve many short-lived review apps
-without granting every review identity access to unrelated app secrets.
+deploy workflow runs `setup-app` for new review apps, refreshes templates for
+existing review apps, and then runs `deploy-image`; those commands bind or
+repair the review app identity's `reveal` permission on each configured shared
+policy. The delete and cleanup workflows call `cpflow delete`, which removes
+those bindings as review apps go away. This lets one shared database or license
+secret serve many short-lived review apps without granting every review
+identity access to unrelated app secrets.
 
 ```yaml
 apps:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,7 @@ cpflow ai-github-flow-prompt
 - Publishes (creates or updates) those at Control Plane infrastructure
 - Picks templates from the `.controlplane/templates` directory
 - Templates are ordinary Control Plane templates but with variable preprocessing
-- Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources while applying other template changes
+- Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources entirely while applying other template changes
 
 **Preprocessed template variables:**
 
@@ -540,7 +540,7 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
-- Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images and existing secret resources, repairing secrets access bindings, and skipping the post-creation hook
+- Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
 
 ```sh
 cpflow setup-app -a $APP_NAME

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,6 +29,7 @@ cpflow ai-github-flow-prompt
 - Publishes (creates or updates) those at Control Plane infrastructure
 - Picks templates from the `.controlplane/templates` directory
 - Templates are ordinary Control Plane templates but with variable preprocessing
+- Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources while applying other template changes
 
 **Preprocessed template variables:**
 
@@ -539,6 +540,7 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
+- Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images and existing secret resources, repairing secrets access bindings, and skipping the post-creation hook
 
 ```sh
 cpflow setup-app -a $APP_NAME

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -18,7 +18,7 @@ module Command
       - Publishes (creates or updates) those at Control Plane infrastructure
       - Picks templates from the `.controlplane/templates` directory
       - Templates are ordinary Control Plane templates but with variable preprocessing
-      - Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources while applying other template changes
+      - Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources entirely while applying other template changes
 
       **Preprocessed template variables:**
 
@@ -166,16 +166,10 @@ module Command
 
     def cache_existing_workloads(templates)
       template_names = templates.filter_map { |template| template["name"] if template["kind"] == "workload" }
-      configured_names = configured_app_workload_names
-      @existing_workloads = (template_names + configured_names).uniq.to_h do |name|
-        [name, cp.fetch_workload(name)]
+      @existing_workloads = Array(cp.fetch_workloads.fetch("items")).to_h do |workload|
+        [workload.fetch("name"), workload]
       end
-    end
-
-    def configured_app_workload_names
-      Array(config[:app_workloads])
-    rescue RuntimeError
-      []
+      template_names.each { |name| @existing_workloads[name] = nil unless @existing_workloads.key?(name) }
     end
 
     def fetch_workload(name)
@@ -185,7 +179,7 @@ module Command
     end
 
     def existing_app_image
-      # New workloads need any deployed app image until deploy-image moves every app workload to the new image.
+      # The first listed match is only a temporary fallback until deploy-image updates every app workload.
       @existing_workloads.values.compact.filter_map do |workload|
         images = Array(workload.dig("spec", "containers")).filter_map { |container| container["image"] }
         images.find { |image| app_image?(image) }

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -185,6 +185,7 @@ module Command
     end
 
     def existing_app_image
+      # New workloads need any deployed app image until deploy-image moves every app workload to the new image.
       @existing_workloads.values.compact.filter_map do |workload|
         images = Array(workload.dig("spec", "containers")).filter_map { |container| container["image"] }
         images.find { |image| app_image?(image) }

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -166,7 +166,9 @@ module Command
 
     def cache_existing_workloads(templates)
       template_names = templates.filter_map { |template| template["name"] if template["kind"] == "workload" }
-      @existing_workloads = Array(cp.fetch_workloads.fetch("items")).to_h do |workload|
+      workloads = cp.fetch_workloads
+      cp.fetch_gvc! unless workloads
+      @existing_workloads = Array(workloads.fetch("items")).to_h do |workload|
         [workload.fetch("name"), workload]
       end
       template_names.each { |name| @existing_workloads[name] = nil unless @existing_workloads.key?(name) }

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -183,8 +183,10 @@ module Command
         Array(workload.dig("spec", "containers")).filter_map do |container|
           container["image"] if app_image?(container["image"])
         end
-      end.uniq
-      app_images.first if app_images.one?
+      end
+      image_prefix = "/org/#{config.org}/image/"
+      canonical_images = app_images.map { |image| image.delete_prefix(image_prefix) }
+      app_images.first if canonical_images.uniq.one?
     end
 
     def preserve_workload_images(template, fallback_image) # rubocop:disable Metrics/MethodLength

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -197,7 +197,7 @@ module Command
         next unless app_image?(container["image"])
 
         existing_image = existing_containers.dig(container["name"], "image")
-        preserved_image = app_image?(existing_image) ? existing_image : fallback_image
+        preserved_image = deployable_app_image?(existing_image) ? existing_image : fallback_image
         unless preserved_image
           raise "Cannot safely refresh app image for workload '#{template['name']}' " \
                 "without an unambiguous deployed app image."

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -179,7 +179,8 @@ module Command
     end
 
     def existing_app_image
-      app_images = @existing_workloads.values.compact.flat_map do |workload|
+      ready_workloads = @existing_workloads.values.compact.select { |workload| workload_ready?(workload) }
+      app_images = ready_workloads.flat_map do |workload|
         Array(workload.dig("spec", "containers")).filter_map do |container|
           container["image"] if deployable_app_image?(container["image"])
         end
@@ -190,14 +191,15 @@ module Command
     end
 
     def preserve_workload_images(template, fallback_image) # rubocop:disable Metrics/MethodLength
-      existing_containers = Array(fetch_workload(template["name"])&.dig("spec", "containers"))
+      existing_workload = fetch_workload(template["name"])
+      existing_containers = Array(existing_workload&.dig("spec", "containers"))
                             .to_h { |container| [container["name"], container] }
 
       Array(template.dig("spec", "containers")).each do |container|
         next unless app_image?(container["image"])
 
         existing_image = existing_containers.dig(container["name"], "image")
-        preserved_image = deployable_app_image?(existing_image) ? existing_image : fallback_image
+        preserved_image = preserved_image(existing_workload, existing_image, fallback_image)
         unless preserved_image
           raise "Cannot safely refresh app image for workload '#{template['name']}' " \
                 "without an unambiguous deployed app image."
@@ -205,6 +207,16 @@ module Command
 
         container["image"] = preserved_image
       end
+    end
+
+    def preserved_image(existing_workload, existing_image, fallback_image)
+      return existing_image if workload_ready?(existing_workload) && deployable_app_image?(existing_image)
+
+      fallback_image
+    end
+
+    def workload_ready?(workload)
+      workload&.dig("status", "readyLatest") == true
     end
 
     def app_image?(image)

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -209,7 +209,9 @@ module Command
     end
 
     def app_image?(image)
-      image.to_s.match?(%r{\A/org/#{Regexp.escape(config.org)}/image/#{Regexp.escape(config.app)}[:@]})
+      image.to_s.match?(
+        %r{\A(?:/org/#{Regexp.escape(config.org)}/image/)?#{Regexp.escape(config.app)}[:@]}
+      )
     end
 
     def add_app_identity_template(templates)

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -9,7 +9,8 @@ module Command
       app_option(required: true),
       location_option,
       skip_confirm_option,
-      add_app_identity_option
+      add_app_identity_option,
+      preserve_existing_runtime_option
     ].freeze
     DESCRIPTION = "Applies application-specific configs from templates"
     LONG_DESCRIPTION = <<~DESC
@@ -17,6 +18,7 @@ module Command
       - Publishes (creates or updates) those at Control Plane infrastructure
       - Picks templates from the `.controlplane/templates` directory
       - Templates are ordinary Control Plane templates but with variable preprocessing
+      - Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources while applying other template changes
 
       **Preprocessed template variables:**
 
@@ -58,6 +60,7 @@ module Command
       @skipped_templates = []
 
       templates = @template_parser.parse(@names_to_filenames.values)
+      templates = preserve_existing_runtime(templates) if config.options[:preserve_existing_runtime]
       pending_templates = confirm_templates(templates)
       add_app_identity_template(pending_templates) if config.options[:add_app_identity]
       pending_templates.each do |template|
@@ -117,7 +120,7 @@ module Command
     end
 
     def confirm_workload(template) # rubocop:disable Naming/PredicateMethod
-      workload = cp.fetch_workload(template["name"])
+      workload = fetch_workload(template["name"])
       return true unless workload
 
       confirmed = confirm_apply("Workload '#{template['name']}' already exists, do you want to re-create it?")
@@ -144,6 +147,69 @@ module Command
       progress.puts if @asked_for_confirmation
 
       pending_templates
+    end
+
+    def preserve_existing_runtime(templates)
+      cache_existing_workloads(templates)
+      fallback_image = existing_app_image
+
+      templates.filter_map do |template|
+        if template["kind"] == "secret" && cp.fetch_secret(template["name"])
+          report_skipped(template)
+          next
+        end
+
+        preserve_workload_images(template, fallback_image) if template["kind"] == "workload"
+        template
+      end
+    end
+
+    def cache_existing_workloads(templates)
+      template_names = templates.filter_map { |template| template["name"] if template["kind"] == "workload" }
+      configured_names = configured_app_workload_names
+      @existing_workloads = (template_names + configured_names).uniq.to_h do |name|
+        [name, cp.fetch_workload(name)]
+      end
+    end
+
+    def configured_app_workload_names
+      Array(config[:app_workloads])
+    rescue RuntimeError
+      []
+    end
+
+    def fetch_workload(name)
+      return @existing_workloads[name] if @existing_workloads&.key?(name)
+
+      cp.fetch_workload(name)
+    end
+
+    def existing_app_image
+      @existing_workloads.values.compact.filter_map do |workload|
+        images = Array(workload.dig("spec", "containers")).filter_map { |container| container["image"] }
+        images.find { |image| app_image?(image) }
+      end.first
+    end
+
+    def preserve_workload_images(template, fallback_image) # rubocop:disable Metrics/MethodLength
+      existing_containers = Array(fetch_workload(template["name"])&.dig("spec", "containers"))
+                            .to_h { |container| [container["name"], container] }
+
+      Array(template.dig("spec", "containers")).each do |container|
+        next unless app_image?(container["image"])
+
+        existing_image = existing_containers.dig(container["name"], "image")
+        preserved_image = app_image?(existing_image) ? existing_image : fallback_image
+        unless preserved_image
+          raise "Cannot safely refresh app image for workload '#{template['name']}' without a deployed app image."
+        end
+
+        container["image"] = preserved_image
+      end
+    end
+
+    def app_image?(image)
+      image.to_s.match?(%r{\A/org/#{Regexp.escape(config.org)}/image/#{Regexp.escape(config.app)}[:@]})
     end
 
     def add_app_identity_template(templates)

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -179,11 +179,12 @@ module Command
     end
 
     def existing_app_image
-      # The first listed match is only a temporary fallback until deploy-image updates every app workload.
-      @existing_workloads.values.compact.filter_map do |workload|
-        images = Array(workload.dig("spec", "containers")).filter_map { |container| container["image"] }
-        images.find { |image| app_image?(image) }
-      end.first
+      app_images = @existing_workloads.values.compact.flat_map do |workload|
+        Array(workload.dig("spec", "containers")).filter_map do |container|
+          container["image"] if app_image?(container["image"])
+        end
+      end.uniq
+      app_images.first if app_images.one?
     end
 
     def preserve_workload_images(template, fallback_image) # rubocop:disable Metrics/MethodLength
@@ -196,7 +197,8 @@ module Command
         existing_image = existing_containers.dig(container["name"], "image")
         preserved_image = app_image?(existing_image) ? existing_image : fallback_image
         unless preserved_image
-          raise "Cannot safely refresh app image for workload '#{template['name']}' without a deployed app image."
+          raise "Cannot safely refresh app image for workload '#{template['name']}' " \
+                "without an unambiguous deployed app image."
         end
 
         container["image"] = preserved_image

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -181,7 +181,7 @@ module Command
     def existing_app_image
       app_images = @existing_workloads.values.compact.flat_map do |workload|
         Array(workload.dig("spec", "containers")).filter_map do |container|
-          container["image"] if app_image?(container["image"])
+          container["image"] if deployable_app_image?(container["image"])
         end
       end
       image_prefix = "/org/#{config.org}/image/"
@@ -211,6 +211,10 @@ module Command
       image.to_s.match?(
         %r{\A(?:/org/#{Regexp.escape(config.org)}/image/)?#{Regexp.escape(config.app)}[:@]}
       )
+    end
+
+    def deployable_app_image?(image)
+      app_image?(image) && !image.to_s.end_with?(Controlplane::NO_IMAGE_AVAILABLE)
     end
 
     def add_app_identity_template(templates)

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -459,6 +459,28 @@ module Command
       }
     end
 
+    def self.refresh_templates_option(required: false)
+      {
+        name: :refresh_templates,
+        params: {
+          desc: "Refreshes configured templates for an existing app without running post-creation hooks",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
+
+    def self.preserve_existing_runtime_option(required: false)
+      {
+        name: :preserve_existing_runtime,
+        params: {
+          desc: "Preserves deployed app images and existing secret resources while applying templates",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
+
     def self.skip_pre_deletion_hook_option(required: false)
       {
         name: :skip_pre_deletion_hook,

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -474,7 +474,7 @@ module Command
       {
         name: :preserve_existing_runtime,
         params: {
-          desc: "Preserves deployed app images and existing secret resources while applying templates",
+          desc: "Preserves deployed app images and skips existing secret resources entirely while applying templates",
           type: :boolean,
           required: required
         }

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -107,12 +107,18 @@ module Command
       @requested_workload_names ||= Array(config.options[:workload]).map(&:to_s).uniq
     end
 
+    def app_image?(image)
+      image.to_s.match?(
+        %r{\A(?:/org/#{Regexp.escape(config.org)}/image/)?#{Regexp.escape(config.app)}[:@]}
+      )
+    end
+
     def deploy_image_to_workloads(image, workload_data_by_name) # rubocop:disable Metrics/MethodLength
       deployed_endpoints = {}
 
       workload_data_by_name.each do |workload, workload_data|
         workload_data.dig("spec", "containers").each do |container|
-          next unless container["image"].match?(%r{^/org/#{config.org}/image/#{config.app}[:@]})
+          next unless app_image?(container["image"])
 
           container_name = container["name"]
           step("Deploying image '#{image}' for workload '#{workload}'") do

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -24,7 +24,7 @@ module Command
       - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
       - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
       - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
-      - Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images and existing secret resources, repairing secrets access bindings, and skipping the post-creation hook
+      - Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
     DESC
     VALIDATIONS = %w[config templates].freeze
 

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 module Command
-  class SetupApp < Base
+  class SetupApp < Base # rubocop:disable Metrics/ClassLength
     NAME = "setup-app"
     OPTIONS = [
       app_option(required: true),
       skip_secret_access_binding_option,
       skip_secrets_setup_option,
-      skip_post_creation_hook_option
+      skip_post_creation_hook_option,
+      refresh_templates_option
     ].freeze
     DESCRIPTION = "Creates an app and all its workloads"
     LONG_DESCRIPTION = <<~DESC
@@ -23,18 +24,21 @@ module Command
       - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
       - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
       - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
+      - Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images and existing secret resources, repairing secrets access bindings, and skipping the post-creation hook
     DESC
     VALIDATIONS = %w[config templates].freeze
 
-    def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       templates = config[:setup_app_templates]
+      refresh_templates = config.options[:refresh_templates]
 
       app = cp.fetch_gvc
-      if app
+      if app && !refresh_templates
         raise "App '#{config.app}' already exists. If you want to update this app, " \
               "either run 'cpflow delete -a #{config.app}' and then re-run this command, " \
               "or run 'cpflow apply-template #{templates.join(' ')} -a #{config.app}'."
       end
+      raise "App '#{config.app}' does not exist, so its templates cannot be refreshed." if !app && refresh_templates
 
       skip_secrets_setup = skip_secrets_setup?
 
@@ -45,11 +49,12 @@ module Command
 
       args = []
       args.push("--add-app-identity") unless skip_secrets_setup
+      args.push("--yes", "--preserve-existing-runtime") if refresh_templates
       run_cpflow_command("apply-template", *templates, "-a", config.app, *args)
 
       bind_identity_to_policy unless skip_secrets_setup
       bind_shared_secret_policy_grants(shared_secret_policy_grant_pairs) unless skip_secrets_setup
-      run_post_creation_hook unless config.options[:skip_post_creation_hook]
+      run_post_creation_hook unless refresh_templates || config.options[:skip_post_creation_hook]
     end
 
     private

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+describe Command::ApplyTemplate do
+  describe "#call" do
+    let(:options) { { yes: true, preserve_existing_runtime: true } }
+    let(:config) do
+      instance_double(
+        Config,
+        args: %w[postgres rails worker],
+        options: options,
+        app: "test-review-123",
+        org: "test-org",
+        identity: "test-review-123-identity"
+      )
+    end
+    let(:cp) { instance_double(Controlplane) }
+    let(:parser) { instance_double(TemplateParser) }
+    let(:command) { described_class.new(config) }
+    let(:latest_image) { "/org/test-org/image/test-review-123:9_bad" }
+    let(:deployed_image) { "/org/test-org/image/test-review-123:8_good" }
+    let(:templates) do
+      [
+        {
+          "kind" => "secret",
+          "name" => "test-review-123-pg",
+          "type" => "dictionary",
+          "data" => { "password" => "template-placeholder" }
+        },
+        workload_template("rails"),
+        workload_template("worker")
+      ]
+    end
+    let(:existing_rails) do
+      {
+        "kind" => "workload",
+        "name" => "rails",
+        "spec" => {
+          "containers" => [
+            { "name" => "rails", "image" => deployed_image }
+          ]
+        }
+      }
+    end
+    let(:applied_templates) { [] }
+
+    def workload_template(name)
+      {
+        "kind" => "workload",
+        "name" => name,
+        "spec" => {
+          "containers" => [
+            { "name" => name, "image" => latest_image }
+          ]
+        }
+      }
+    end
+
+    before do
+      allow(TemplateParser).to receive(:new).with(command).and_return(parser)
+      allow(parser).to receive(:template_filename) { |name| "#{__dir__}/../spec_helper.rb##{name}" }
+      allow(parser).to receive(:parse).and_return(templates)
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(match(/spec_helper\.rb#/)).and_return(true)
+      allow(command).to receive(:cp).and_return(cp)
+      allow(config).to receive(:[]).with(:app_workloads).and_return(%w[rails worker])
+      allow(cp).to receive(:fetch_secret).with("test-review-123-pg").and_return({ "name" => "test-review-123-pg" })
+      allow(cp).to receive(:fetch_workload).with("rails").and_return(existing_rails)
+      allow(cp).to receive(:fetch_workload).with("worker").and_return(nil)
+      allow(cp).to receive(:apply_hash) do |template|
+        applied_templates << Marshal.load(Marshal.dump(template))
+        [{ kind: template.fetch("kind"), name: template.fetch("name") }]
+      end
+    end
+
+    it "preserves deployed app images and existing secret resources" do
+      command.call
+
+      expect(applied_templates.map { |template| template["name"] })
+        .to eq(%w[rails worker])
+      expect(applied_templates.map { |template| template.dig("spec", "containers", 0, "image") })
+        .to eq([deployed_image, deployed_image])
+    end
+
+    context "without a deployed app image" do
+      let(:existing_rails) { nil }
+
+      it "fails before applying templates" do
+        expect { command.call }
+          .to raise_error(/Cannot safely refresh app image for workload 'rails'/)
+        expect(applied_templates).to be_empty
+      end
+    end
+
+    context "without runtime preservation" do
+      let(:options) { { yes: true, preserve_existing_runtime: false } }
+
+      it "keeps ordinary template application behavior" do
+        command.call
+
+        expect(applied_templates.map { |template| template["name"] })
+          .to eq(%w[test-review-123-pg rails worker])
+        expect(applied_templates.drop(1).map { |template| template.dig("spec", "containers", 0, "image") })
+          .to eq([latest_image, latest_image])
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -39,6 +39,7 @@ describe Command::ApplyTemplate do
       {
         "kind" => "workload",
         "name" => "rails",
+        "status" => { "readyLatest" => true },
         "spec" => {
           "containers" => [
             { "name" => "rails", "image" => deployed_image }
@@ -120,6 +121,7 @@ describe Command::ApplyTemplate do
         [
           existing_rails,
           workload_template("worker").tap do |workload|
+            workload["status"] = { "readyLatest" => true }
             workload.dig("spec", "containers", 0)["image"] =
               "/org/test-org/image/test-review-123:7_other"
           end
@@ -140,6 +142,7 @@ describe Command::ApplyTemplate do
         [
           existing_rails,
           workload_template("worker").tap do |workload|
+            workload["status"] = { "readyLatest" => true }
             workload.dig("spec", "containers", 0)["image"] = "test-review-123:8_good"
           end
         ]
@@ -159,6 +162,7 @@ describe Command::ApplyTemplate do
         [
           existing_rails,
           workload_template("rails-runner").tap do |workload|
+            workload["status"] = { "readyLatest" => true }
             workload.dig("spec", "containers", 0)["image"] =
               "test-review-123:#{Controlplane::NO_IMAGE_AVAILABLE}"
           end
@@ -166,6 +170,26 @@ describe Command::ApplyTemplate do
       end
 
       it "ignores the sentinel when choosing the safe fallback" do
+        command.call
+
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+      end
+    end
+
+    context "when the matching workload's latest revision is not ready" do
+      let(:app_workloads) { %w[worker] }
+      let(:templates) { [workload_template("worker")] }
+      let(:existing_workloads) do
+        [
+          existing_rails,
+          workload_template("worker").tap do |workload|
+            workload["status"] = { "readyLatest" => false }
+            workload.dig("spec", "containers", 0)["image"] = latest_image
+          end
+        ]
+      end
+
+      it "uses a ready workload's deployed app image" do
         command.call
 
         expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -206,6 +206,23 @@ describe Command::ApplyTemplate do
       end
     end
 
+    context "when runtime preservation is requested for a missing app" do
+      before do
+        allow(cp).to receive(:fetch_workloads).and_return(nil)
+        allow(cp).to receive(:fetch_gvc!).and_raise(
+          "Can't find app 'test-review-123', please create it with 'cpflow setup-app -a test-review-123'."
+        )
+      end
+
+      it "uses the established missing-app error" do
+        expect { command.call }
+          .to raise_error("Can't find app 'test-review-123', " \
+                          "please create it with 'cpflow setup-app -a test-review-123'.")
+        expect(cp).to have_received(:fetch_gvc!)
+        expect(applied_templates).to be_empty
+      end
+    end
+
     context "without runtime preservation" do
       let(:options) { { yes: true, preserve_existing_runtime: false } }
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -153,8 +153,8 @@ describe Command::ApplyTemplate do
     end
 
     context "when an existing runner workload uses the missing-image sentinel" do
-      let(:app_workloads) { %w[web] }
-      let(:templates) { [workload_template("web")] }
+      let(:app_workloads) { %w[rails-runner] }
+      let(:templates) { [workload_template("rails-runner")] }
       let(:existing_workloads) do
         [
           existing_rails,

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -84,6 +84,18 @@ describe Command::ApplyTemplate do
         .to eq([deployed_image, deployed_image])
     end
 
+    context "with bare app image references" do
+      let(:latest_image) { "test-review-123:9_bad" }
+      let(:deployed_image) { "test-review-123:8_good" }
+
+      it "preserves the deployed image" do
+        command.call
+
+        expect(applied_templates.map { |template| template.dig("spec", "containers", 0, "image") })
+          .to eq([deployed_image, deployed_image])
+      end
+    end
+
     context "without a deployed app image" do
       let(:existing_rails) { nil }
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -152,6 +152,26 @@ describe Command::ApplyTemplate do
       end
     end
 
+    context "when an existing runner workload uses the missing-image sentinel" do
+      let(:app_workloads) { %w[web] }
+      let(:templates) { [workload_template("web")] }
+      let(:existing_workloads) do
+        [
+          existing_rails,
+          workload_template("rails-runner").tap do |workload|
+            workload.dig("spec", "containers", 0)["image"] =
+              "test-review-123:#{Controlplane::NO_IMAGE_AVAILABLE}"
+          end
+        ]
+      end
+
+      it "ignores the sentinel when choosing the safe fallback" do
+        command.call
+
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+      end
+    end
+
     context "without a deployed app image" do
       let(:existing_rails) { nil }
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -133,6 +133,25 @@ describe Command::ApplyTemplate do
       end
     end
 
+    context "when equivalent deployed app images use bare and linked references" do
+      let(:app_workloads) { %w[web] }
+      let(:templates) { [workload_template("web")] }
+      let(:existing_workloads) do
+        [
+          existing_rails,
+          workload_template("worker").tap do |workload|
+            workload.dig("spec", "containers", 0)["image"] = "test-review-123:8_good"
+          end
+        ]
+      end
+
+      it "uses the equivalent deployed image as the safe fallback" do
+        command.call
+
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+      end
+    end
+
     context "without a deployed app image" do
       let(:existing_rails) { nil }
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -46,6 +46,7 @@ describe Command::ApplyTemplate do
         }
       }
     end
+    let(:existing_workloads) { [existing_rails].compact }
     let(:applied_templates) { [] }
 
     def workload_template(name)
@@ -70,7 +71,7 @@ describe Command::ApplyTemplate do
       allow(config).to receive(:[]).with(:app_workloads).and_return(app_workloads)
       allow(cp).to receive(:fetch_secret).with("test-review-123-pg").and_return({ "name" => "test-review-123-pg" })
       allow(cp).to receive_messages(
-        fetch_workloads: { "items" => [existing_rails].compact },
+        fetch_workloads: { "items" => existing_workloads },
         fetch_workload: nil
       )
       allow(cp).to receive(:fetch_workload).with("rails").and_return(existing_rails)
@@ -109,6 +110,26 @@ describe Command::ApplyTemplate do
         command.call
 
         expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+      end
+    end
+
+    context "when existing workloads have different deployed app images" do
+      let(:app_workloads) { %w[web] }
+      let(:templates) { [workload_template("web")] }
+      let(:existing_workloads) do
+        [
+          existing_rails,
+          workload_template("worker").tap do |workload|
+            workload.dig("spec", "containers", 0)["image"] =
+              "/org/test-org/image/test-review-123:7_other"
+          end
+        ]
+      end
+
+      it "fails before applying an ambiguous fallback image" do
+        expect { command.call }
+          .to raise_error(/Cannot safely refresh app image for workload 'web'/)
+        expect(applied_templates).to be_empty
       end
     end
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -13,9 +13,11 @@ describe Command::ApplyTemplate do
         options: options,
         app: "test-review-123",
         org: "test-org",
-        identity: "test-review-123-identity"
+        identity: "test-review-123-identity",
+        current: { app_workloads: app_workloads }
       )
     end
+    let(:app_workloads) { %w[rails worker] }
     let(:cp) { instance_double(Controlplane) }
     let(:parser) { instance_double(TemplateParser) }
     let(:command) { described_class.new(config) }
@@ -65,10 +67,13 @@ describe Command::ApplyTemplate do
       allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).with(match(/spec_helper\.rb#/)).and_return(true)
       allow(command).to receive(:cp).and_return(cp)
-      allow(config).to receive(:[]).with(:app_workloads).and_return(%w[rails worker])
+      allow(config).to receive(:[]).with(:app_workloads).and_return(app_workloads)
       allow(cp).to receive(:fetch_secret).with("test-review-123-pg").and_return({ "name" => "test-review-123-pg" })
+      allow(cp).to receive_messages(
+        fetch_workloads: { "items" => [existing_rails].compact },
+        fetch_workload: nil
+      )
       allow(cp).to receive(:fetch_workload).with("rails").and_return(existing_rails)
-      allow(cp).to receive(:fetch_workload).with("worker").and_return(nil)
       allow(cp).to receive(:apply_hash) do |template|
         applied_templates << Marshal.load(Marshal.dump(template))
         [{ kind: template.fetch("kind"), name: template.fetch("name") }]
@@ -93,6 +98,17 @@ describe Command::ApplyTemplate do
 
         expect(applied_templates.map { |template| template.dig("spec", "containers", 0, "image") })
           .to eq([deployed_image, deployed_image])
+      end
+    end
+
+    context "when a configured workload was renamed" do
+      let(:app_workloads) { %w[web] }
+      let(:templates) { [workload_template("web")] }
+
+      it "uses the removed workload's deployed app image as the safe fallback" do
+        command.call
+
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
       end
     end
 

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -411,6 +411,19 @@ describe Command::DeployImage do
         .with("frontend", container: "rails", image: "test-app:1")
     end
 
+    context "when a workload uses a bare app image reference" do
+      before do
+        workload_data.dig("spec", "containers", 0)["image"] = "test-app:1"
+      end
+
+      it "updates the app image" do
+        command.call
+
+        expect(cp).to have_received(:workload_set_image_ref)
+          .with("frontend", container: "rails", image: "test-app:1")
+      end
+    end
+
     context "when specific workloads are requested" do
       let(:options) { { run_release_phase: false, workload: ["worker"] } }
       let(:worker_data) do

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -449,6 +449,23 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       )
     end
 
+    it "refreshes existing review app templates before building and deploying the image" do
+      workflow = YAML.load_file(reusable_review_app_workflow_path, aliases: true)
+      steps = workflow.dig("jobs", "deploy", "steps")
+      refresh_step = steps.find { |step| step["name"] == "Refresh existing review app templates" }
+      refresh_command = 'cpflow setup-app -a "${APP_NAME}" --org "${CPLN_ORG}" --refresh-templates'
+
+      expect(refresh_step).to include(
+        "if" => "steps.config.outputs.ready == 'true' && steps.source.outputs.allowed == 'true' && " \
+                "steps.check-app.outputs.exists == 'true'",
+        "working-directory" => "app",
+        "run" => include("set -euo pipefail", refresh_command)
+      )
+      expect(refresh_step).not_to have_key("continue-on-error")
+      expect(steps.index(refresh_step)).to be < steps.index { |step| step["name"] == "Build Docker image" }
+      expect(steps.index(refresh_step)).to be < steps.index { |step| step["name"] == "Deploy to Control Plane" }
+    end
+
     it "gates review-app deploys by author_association and skips fork PRs" do
       contents = reusable_review_app_workflow_path.read
       expect(contents).to include("github.event.comment.author_association")

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -56,6 +56,70 @@ describe Command::SetupApp do
         .with(config.identity_link, "shared-database-secrets-policy")
     end
 
+    it "keeps new app setup interactive and runs the post-creation hook path" do
+      allow(command).to receive(:run_post_creation_hook)
+
+      command.call
+
+      expect(command).to have_received(:run_cpflow_command)
+        .with("apply-template", "app", "rails", "-a", config.app, "--add-app-identity")
+      expect(command).to have_received(:run_post_creation_hook)
+    end
+
+    context "when refreshing templates for an existing app" do
+      before do
+        allow(config).to receive(:options).and_return({ refresh_templates: true })
+        allow(cp).to receive(:fetch_gvc).and_return({ "name" => config.app })
+        allow(command).to receive(:run_post_creation_hook)
+      end
+
+      it "applies configured templates noninteractively and repairs secret bindings without running creation hooks" do
+        command.call
+
+        expect(command).to have_received(:run_cpflow_command)
+          .with(
+            "apply-template", "app", "rails", "-a", config.app,
+            "--add-app-identity", "--yes", "--preserve-existing-runtime"
+          )
+        expect(cp).to have_received(:bind_identity_to_policy)
+          .with(config.identity_link, "test-review-secrets-policy")
+        expect(cp).to have_received(:bind_identity_to_policy)
+          .with(config.identity_link, "shared-database-secrets-policy")
+        expect(command).not_to have_received(:run_post_creation_hook)
+      end
+
+      it "stops when template application fails" do
+        allow(command).to receive(:run_cpflow_command).and_raise(SystemExit.new(64))
+
+        expect { command.call }.to raise_error(SystemExit) { |error| expect(error.status).to eq(64) }
+        expect(cp).not_to have_received(:bind_identity_to_policy)
+      end
+    end
+
+    context "when refreshing templates for a missing app" do
+      before do
+        allow(config).to receive(:options).and_return({ refresh_templates: true })
+      end
+
+      it "raises without creating the app" do
+        expect { command.call }
+          .to raise_error("App 'test-review-123' does not exist, so its templates cannot be refreshed.")
+        expect(command).not_to have_received(:create_secret_and_policy_if_not_exist)
+        expect(command).not_to have_received(:run_cpflow_command)
+      end
+    end
+
+    context "when the app already exists without template refresh" do
+      before do
+        allow(cp).to receive(:fetch_gvc).and_return({ "name" => config.app })
+      end
+
+      it "preserves the existing setup error" do
+        expect { command.call }.to raise_error(/App 'test-review-123' already exists/)
+        expect(command).not_to have_received(:run_cpflow_command)
+      end
+    end
+
     context "when a configured shared policy is missing" do
       before do
         allow(cp).to receive(:fetch_policy).with("shared-database-secrets-policy").and_return(nil)


### PR DESCRIPTION
## Summary

- refresh configured `setup_app_templates` for an existing GitHub Actions review app before image build and deployment
- add `setup-app --refresh-templates` as the explicit, noninteractive command contract
- preserve deployed app-image references and existing secret resources while repairing configured secret-policy bindings

## Runtime proof

Hichee PR #9652 exposed the missing update path on the existing `hichee-review-9652` GVC while the reusable workflow was pinned to control-plane-flow source commit `1674f85b810155df0d68ea4b5b23cb87a0f7bb01`. The node-renderer image changed, but newly checked-in container environment values were absent from the workload spec. Its logs showed `localhost`, `enableHealthEndpoints false`, and a listener on `[::1]:3800`; the workload stayed unready while `deploy-image` waited.

The reusable workflow previously ran `setup-app` only when the GVC did not exist. Existing review apps went directly to image build/deploy, so template changes were never applied.

## Safety contract

- first-time review-app setup is unchanged
- refresh does not delete or recreate the GVC and does not run post-creation hooks
- template replacement is noninteractive and failures stop the workflow before image build/deploy
- existing secrets are not overwritten
- currently deployed app-image references remain in place until the normal deploy-image rollout path runs
- no live Hichee review app was modified by this PR
- no production deployment or gem release is included; source-pinned workflows can consume the merged commit with `CPFLOW_VERSION` unset

## Validation

- TDD red proof: existing-app setup rejected refresh and the reusable workflow lacked a refresh step
- `CPLN_ORG='' bundle exec rspec spec/command/setup_app_spec.rb:76 spec/command/apply_template_unit_spec.rb` — 4 examples, 0 failures
- broader setup/apply-template/workflow focused specs — 10 examples, 0 failures
- deterministic non-live `.agents/bin/validate` seam — 319 examples, 0 failures; 209 RuboCop files, no offenses
- `.agents/bin/docs` — passed
- `git diff --cached --check` — passed
- `actionlint` reports only the three base-equivalent `job.workflow_repository`, `job.workflow_sha`, and `job.workflow_ref` diagnostics

The first local AI review identified a real rollout-order risk from rendering the latest image before deploy gates; the patch now preserves deployed app images and has direct regression coverage. The final local review rerun was incomplete because its nested reviewer lost the WebSocket stream and did not return a verdict. Hosted `claude-review`, CodeRabbit, current-head checks, and the complete review-thread inventory are the closeout review gates.

## Downstream

Hichee PR #9652 remains blocked on this upstream merge and must pin the exact merged commit before rerunning combined review-app validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Existing review apps now refresh configured templates automatically before new images are deployed.
  * Added CLI options to refresh templates while preserving deployed images and existing secrets.
  * Refreshes repair shared-secret access bindings without rerunning post-creation hooks.

* **Bug Fixes**
  * Reusable review-app deployments no longer remove existing resources or replace images before rollout checks.

* **Documentation**
  * Updated command reference, CI automation guidance, and changelog with the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->