### PR TITLE
Preserve workload images during template recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.**
+- **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.** [PR 425](https://github.com/shakacode/control-plane-flow/pull/425) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or modifying existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).
 - **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.**
 - **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or modifying existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).
 - **Fixed `cpflow deploy-image` crashing when an internal-only workload has no public endpoint.** Deployments now consult the existing deployment fallback and report when no public endpoint is available. [PR 423](https://github.com/shakacode/control-plane-flow/pull/423) by [Justin Gordon](https://github.com/justin808).
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -331,12 +331,15 @@ For an existing review app, each deployment runs
 `cpflow setup-app --refresh-templates` before building and deploying the new
 image. Refresh mode reapplies the configured `setup_app_templates` without
 deleting the GVC or running `hooks.post_creation`, answers template replacement
-prompts noninteractively, preserves deployed app-image references and existing
-secret resources, and repairs the configured app and shared-secret policy
-bindings. Preserving image references keeps release-phase and ordered-deploy
-gates in control of image rollout; a template failure stops the workflow before
-the image build or deployment. Existing secret templates are skipped as whole
-resources, so refresh neither changes existing values nor adds newly templated
+prompts noninteractively, preserves each matching workload container's exact
+configured app-image reference even when the app is unhealthy or workloads use
+different image versions, and repairs the configured app and shared-secret
+policy bindings. A missing or invalid workload image uses only an unambiguous
+app image from ready workloads; refresh fails closed rather than selecting the
+registry's newest image. Preserving image references keeps release-phase and
+ordered-deploy gates in control of image rollout; a template failure stops the
+workflow before the image build or deployment. Existing secret templates are skipped
+as whole resources, so refresh neither changes existing values nor adds newly templated
 keys; provision required new keys separately before deployment.
 You still need the shared review-app runtime secret values described by your
 templates, and the staging token must have access to create and update

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -29,7 +29,8 @@ cpflow ai-github-flow-prompt
 - Publishes (creates or updates) those at Control Plane infrastructure
 - Picks templates from the `.controlplane/templates` directory
 - Templates are ordinary Control Plane templates but with variable preprocessing
-- Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources entirely while applying other template changes
+- Use `--preserve-existing-runtime` to retain each workload container's configured app image, even when the workload is unready, and skip existing secret resources entirely while applying other template changes
+- Missing or invalid workload images use only an unambiguous app image from ready workloads; refresh fails before applying templates when no safe fallback exists
 
 **Preprocessed template variables:**
 
@@ -540,7 +541,7 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
-- Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
+- Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving each workload's configured app image even when workloads are unready or use mixed image versions, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
 
 ```sh
 cpflow setup-app -a $APP_NAME

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -18,7 +18,8 @@ module Command
       - Publishes (creates or updates) those at Control Plane infrastructure
       - Picks templates from the `.controlplane/templates` directory
       - Templates are ordinary Control Plane templates but with variable preprocessing
-      - Use `--preserve-existing-runtime` to retain deployed app images and skip existing secret resources entirely while applying other template changes
+      - Use `--preserve-existing-runtime` to retain each workload container's configured app image, even when the workload is unready, and skip existing secret resources entirely while applying other template changes
+      - Missing or invalid workload images use only an unambiguous app image from ready workloads; refresh fails before applying templates when no safe fallback exists
 
       **Preprocessed template variables:**
 
@@ -151,7 +152,7 @@ module Command
 
     def preserve_existing_runtime(templates)
       cache_existing_workloads(templates)
-      fallback_image = existing_app_image
+      ready_fallback_image = unambiguous_ready_app_image
 
       templates.filter_map do |template|
         if template["kind"] == "secret" && cp.fetch_secret(template["name"])
@@ -159,7 +160,7 @@ module Command
           next
         end
 
-        preserve_workload_images(template, fallback_image) if template["kind"] == "workload"
+        preserve_workload_images(template, ready_fallback_image) if template["kind"] == "workload"
         template
       end
     end
@@ -180,7 +181,7 @@ module Command
       cp.fetch_workload(name)
     end
 
-    def existing_app_image
+    def unambiguous_ready_app_image
       ready_workloads = @existing_workloads.values.compact.select { |workload| workload_ready?(workload) }
       app_images = ready_workloads.flat_map do |workload|
         Array(workload.dig("spec", "containers")).filter_map do |container|
@@ -192,7 +193,7 @@ module Command
       app_images.first if canonical_images.uniq.one?
     end
 
-    def preserve_workload_images(template, fallback_image) # rubocop:disable Metrics/MethodLength
+    def preserve_workload_images(template, ready_fallback_image) # rubocop:disable Metrics/MethodLength
       existing_workload = fetch_workload(template["name"])
       existing_containers = Array(existing_workload&.dig("spec", "containers"))
                             .to_h { |container| [container["name"], container] }
@@ -201,20 +202,20 @@ module Command
         next unless app_image?(container["image"])
 
         existing_image = existing_containers.dig(container["name"], "image")
-        preserved_image = preserved_image(existing_workload, existing_image, fallback_image)
+        preserved_image = preserved_image(existing_image, ready_fallback_image)
         unless preserved_image
           raise "Cannot safely refresh app image for workload '#{template['name']}' " \
-                "without an unambiguous deployed app image."
+                "without a valid existing workload image or an unambiguous ready fallback image."
         end
 
         container["image"] = preserved_image
       end
     end
 
-    def preserved_image(existing_workload, existing_image, fallback_image)
-      return existing_image if workload_ready?(existing_workload) && deployable_app_image?(existing_image)
+    def preserved_image(existing_image, ready_fallback_image)
+      return existing_image if deployable_app_image?(existing_image)
 
-      fallback_image
+      ready_fallback_image
     end
 
     def workload_ready?(workload)

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -24,7 +24,7 @@ module Command
       - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
       - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
       - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
-      - Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving deployed app images, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
+      - Use `--refresh-templates` to apply configured templates noninteractively to an existing app while preserving each workload's configured app image even when workloads are unready or use mixed image versions, skipping existing secret resources entirely, repairing secrets access bindings, and skipping the post-creation hook
     DESC
     VALIDATIONS = %w[config templates].freeze
 

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -135,6 +135,42 @@ describe Command::ApplyTemplate do
       end
     end
 
+    context "when an unhealthy app has a partial deployment across workloads" do
+      let(:app_workloads) { %w[node-renderer rails sidekiq] }
+      let(:templates) do
+        [
+          workload_template("node-renderer"),
+          workload_template("rails"),
+          workload_template("sidekiq")
+        ]
+      end
+      let(:node_renderer_image) { "/org/test-org/image/test-review-123:0754cf4" }
+      let(:rails_image) { "/org/test-org/image/test-review-123:b6c1" }
+      let(:existing_workloads) do
+        [
+          workload_template("node-renderer").tap do |workload|
+            workload["status"] = { "readyLatest" => false }
+            workload.dig("spec", "containers", 0)["image"] = node_renderer_image
+          end,
+          workload_template("rails").tap do |workload|
+            workload["status"] = { "readyLatest" => false }
+            workload.dig("spec", "containers", 0)["image"] = rails_image
+          end,
+          workload_template("sidekiq").tap do |workload|
+            workload["status"] = { "readyLatest" => false }
+            workload.dig("spec", "containers", 0)["image"] = rails_image
+          end
+        ]
+      end
+
+      it "preserves each workload's configured app image without rolling out the template image" do
+        command.call
+
+        expect(applied_templates.map { |template| template.dig("spec", "containers", 0, "image") })
+          .to eq([node_renderer_image, rails_image, rails_image])
+      end
+    end
+
     context "when equivalent deployed app images use bare and linked references" do
       let(:app_workloads) { %w[web] }
       let(:templates) { [workload_template("web")] }
@@ -162,7 +198,7 @@ describe Command::ApplyTemplate do
         [
           existing_rails,
           workload_template("rails-runner").tap do |workload|
-            workload["status"] = { "readyLatest" => true }
+            workload["status"] = { "readyLatest" => false }
             workload.dig("spec", "containers", 0)["image"] =
               "test-review-123:#{Controlplane::NO_IMAGE_AVAILABLE}"
           end
@@ -179,20 +215,21 @@ describe Command::ApplyTemplate do
     context "when the matching workload's latest revision is not ready" do
       let(:app_workloads) { %w[worker] }
       let(:templates) { [workload_template("worker")] }
+      let(:unready_image) { "/org/test-org/image/test-review-123:7_current" }
       let(:existing_workloads) do
         [
           existing_rails,
           workload_template("worker").tap do |workload|
             workload["status"] = { "readyLatest" => false }
-            workload.dig("spec", "containers", 0)["image"] = latest_image
+            workload.dig("spec", "containers", 0)["image"] = unready_image
           end
         ]
       end
 
-      it "uses a ready workload's deployed app image" do
+      it "preserves the matching workload's configured app image" do
         command.call
 
-        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(unready_image)
       end
     end
 


### PR DESCRIPTION
## Summary
- preserve each existing workload container's configured application image independently during `setup-app --refresh-templates`, even when the workload is unhealthy
- restrict missing or invalid target-image fallback to one unambiguous application image from ready workloads
- keep template refresh fail-closed when neither source is safe; never select the registry's newest image

## Runtime proof
Hichee run https://github.com/shakacode/hichee/actions/runs/30307284014 failed on merged cpflow SHA `12082a5` with:

```
Cannot safely refresh app image for workload 'node-renderer' without an unambiguous deployed app image.
```

The existing review app was unhealthy with a partial deployment: node-renderer was configured at `0754cf4`, while Rails and Sidekiq were at `b6c1`. PR #424 required a ready workload before preserving its own image, so the refresh intended to repair the stale template could not start.

## Safety contract
- Matching workload/container image: preserve the exact configured reference, including bare versus fully qualified form, regardless of readiness.
- Missing, sentinel, or invalid matching image: use only a single canonical application image discovered from ready workloads.
- Ambiguous or absent ready fallback: stop before applying templates.
- Existing secret templates remain skipped as whole resources.
- No Hichee files or live Control Plane resources were changed. No production deployment or gem release is part of this PR.

## Validation
- RED regression: mixed/unready matching image expected `7_current`, old behavior substituted ready fallback `8_good`
- Focused: `88 examples, 0 failures`
- Deterministic offline suite: `330 examples, 0 failures`
- `.agents/bin/lint`: `209 files inspected, no offenses`
- `.agents/bin/docs`: pass
- `git diff --cached --check`: pass
- Adversarial review found one template-parser sentinel leakage risk in an earlier draft; that change was removed. Final adversarial review: clean.
- Full credentialed local `.agents/bin/validate` cannot complete without `CPLN_ORG`; hosted checks remain the full integration gate.

## Downstream
After merge, Hichee must repin the reusable workflow to the exact merge SHA and rerun the review-app action.
