### PR TITLE
Fix review app refresh readiness discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Fixed template refreshes for existing apps whose workload-list response omits readiness status by consulting each workload's detailed state before selecting a safe fallback image.**
 - **Fixed reusable deployment health checks on BYOK locations by falling back from a disabled standard workload endpoint only after every location is settled, while preserving configured `app_domain` review-app links and using the verified location endpoint as the final URL fallback.** [PR 426](https://github.com/shakacode/control-plane-flow/pull/426) by [Justin Gordon](https://github.com/justin808).
 - **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.** [PR 425](https://github.com/shakacode/control-plane-flow/pull/425) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or modifying existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed template refreshes for existing apps whose workload-list response omits readiness status by consulting each workload's detailed state before selecting a safe fallback image.**
+- **Fixed template refreshes for existing apps whose workload-list response omits readiness status by consulting each workload's detailed state before selecting a safe fallback image.** [PR 429](https://github.com/shakacode/control-plane-flow/pull/429) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable deployment health checks on BYOK locations by falling back from a disabled standard workload endpoint only after every location is settled, while preserving configured `app_domain` review-app links and using the verified location endpoint as the final URL fallback.** [PR 426](https://github.com/shakacode/control-plane-flow/pull/426) by [Justin Gordon](https://github.com/justin808).
 - **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.** [PR 425](https://github.com/shakacode/control-plane-flow/pull/425) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable review-app deployments so existing apps receive changes from configured `setup_app_templates` before the new image is deployed, without deleting the GVC, rerunning post-creation hooks, replacing deployed images before rollout gates pass, or modifying existing secret resources.** [PR 424](https://github.com/shakacode/control-plane-flow/pull/424) by [Justin Gordon](https://github.com/justin808).

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -182,8 +182,7 @@ module Command
     end
 
     def unambiguous_ready_app_image
-      ready_workloads = @existing_workloads.values.compact.select { |workload| workload_ready?(workload) }
-      app_images = ready_workloads.flat_map do |workload|
+      app_images = ready_existing_app_workloads.flat_map do |workload|
         Array(workload.dig("spec", "containers")).filter_map do |container|
           container["image"] if deployable_app_image?(container["image"])
         end
@@ -191,6 +190,17 @@ module Command
       image_prefix = "/org/#{config.org}/image/"
       canonical_images = app_images.map { |image| image.delete_prefix(image_prefix) }
       app_images.first if canonical_images.uniq.one?
+    end
+
+    def ready_existing_app_workloads
+      @existing_workloads.values.compact.filter_map do |workload|
+        next unless Array(workload.dig("spec", "containers")).any? do |container|
+          deployable_app_image?(container["image"])
+        end
+
+        workload = workload_with_readiness(workload)
+        workload if workload_ready?(workload)
+      end
     end
 
     def preserve_workload_images(template, ready_fallback_image) # rubocop:disable Metrics/MethodLength
@@ -220,6 +230,12 @@ module Command
 
     def workload_ready?(workload)
       workload&.dig("status", "readyLatest") == true
+    end
+
+    def workload_with_readiness(workload)
+      return workload unless workload.dig("status", "readyLatest").nil?
+
+      cp.fetch_workload_with_status(workload.fetch("name")) || workload
     end
 
     def app_image?(image)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -181,9 +181,14 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     # The direct API response omits computed fields such as status.readyLatest.
     args = ["cpln", "workload", "get", workload, "--gvc", gvc, "--org", org, "-o", "json"]
     Shell.debug("CMD", Shellwords.join(args))
-    result = Shell.cmd(*args)
+    result = Shell.cmd(*args, capture_stderr: true)
 
-    JSON.parse(result[:output]) if result[:success]
+    return Shell.warn("Failed to fetch status for '#{workload}': #{result[:output].to_s.strip}") unless result[:success]
+
+    JSON.parse(result[:output])
+  rescue JSON::ParserError => e
+    Shell.warn("Failed to parse status for '#{workload}': #{e.message}")
+    nil
   end
 
   def fetch_workload!(workload)

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -181,9 +181,11 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     # The direct API response omits computed fields such as status.readyLatest.
     args = ["cpln", "workload", "get", workload, "--gvc", gvc, "--org", org, "-o", "json"]
     Shell.debug("CMD", Shellwords.join(args))
-    result = Shell.cmd(*args, capture_stderr: true)
+    result = Shell.cmd(*args, separate_stderr: true)
 
-    return Shell.warn("Failed to fetch status for '#{workload}': #{result[:output].to_s.strip}") unless result[:success]
+    unless result[:success]
+      return Shell.warn("Failed to fetch status for '#{workload}': #{result[:error_output].to_s.strip}")
+    end
 
     JSON.parse(result[:output])
   rescue JSON::ParserError => e

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -177,6 +177,15 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.workload_get(workload: workload, gvc: gvc, org: org)
   end
 
+  def fetch_workload_with_status(workload)
+    # The direct API response omits computed fields such as status.readyLatest.
+    args = ["cpln", "workload", "get", workload, "--gvc", gvc, "--org", org, "-o", "json"]
+    Shell.debug("CMD", Shellwords.join(args))
+    result = Shell.cmd(*args)
+
+    JSON.parse(result[:output]) if result[:success]
+  end
+
   def fetch_workload!(workload)
     workload_data = fetch_workload(workload)
     return workload_data if workload_data

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -178,13 +178,11 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def fetch_workload_with_status(workload)
-    # The direct API response omits computed fields such as status.readyLatest.
-    args = ["cpln", "workload", "get", workload, "--gvc", gvc, "--org", org, "-o", "json"]
-    Shell.debug("CMD", Shellwords.join(args))
-    result = Shell.cmd(*args, separate_stderr: true)
+    result = workload_status_result(workload)
 
     unless result[:success]
-      return Shell.warn("Failed to fetch status for '#{workload}': #{result[:error_output].to_s.strip}")
+      Shell.warn("Failed to fetch status for '#{workload}': #{result[:error_output].to_s.strip}")
+      return
     end
 
     JSON.parse(result[:output])
@@ -192,6 +190,14 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     Shell.warn("Failed to parse status for '#{workload}': #{e.message}")
     nil
   end
+
+  def workload_status_result(workload)
+    # The direct API response omits computed fields such as status.readyLatest.
+    args = ["cpln", "workload", "get", workload, "--gvc", gvc, "--org", org, "-o", "json"]
+    Shell.debug("CMD", Shellwords.join(args))
+    Shell.cmd(*args, separate_stderr: true)
+  end
+  private :workload_status_result
 
   def fetch_workload!(workload)
     workload_data = fetch_workload(workload)

--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -65,14 +65,21 @@ class Shell
     tmp_stderr && !verbose
   end
 
-  def self.cmd(*cmd_to_run, capture_stderr: false)
-    output, status = capture_stderr ? Open3.capture2e(*cmd_to_run) : Open3.capture2(*cmd_to_run)
+  def self.cmd(*cmd_to_run, capture_stderr: false, separate_stderr: false)
+    return cmd_with_separate_stderr(*cmd_to_run) if separate_stderr
 
+    output, status = capture_stderr ? Open3.capture2e(*cmd_to_run) : Open3.capture2(*cmd_to_run)
     {
       output: output,
       success: status.success?
     }
   end
+
+  def self.cmd_with_separate_stderr(*cmd_to_run)
+    output, error_output, status = Open3.capture3(*cmd_to_run)
+    { output: output, error_output: error_output, success: status.success? }
+  end
+  private_class_method :cmd_with_separate_stderr
 
   #
   # Hide sensitive data based on the passed pattern

--- a/spec/command/apply_template_unit_spec.rb
+++ b/spec/command/apply_template_unit_spec.rb
@@ -114,6 +114,23 @@ describe Command::ApplyTemplate do
       end
     end
 
+    context "when the workload list omits readiness status" do
+      let(:app_workloads) { %w[node-renderer] }
+      let(:templates) { [workload_template("node-renderer")] }
+      let(:existing_workloads) { [existing_rails.except("status")] }
+
+      before do
+        allow(cp).to receive(:fetch_workload_with_status).with("rails").and_return(existing_rails)
+      end
+
+      it "uses workload details to find the ready fallback image" do
+        command.call
+
+        expect(cp).to have_received(:fetch_workload_with_status).with("rails")
+        expect(applied_templates.dig(0, "spec", "containers", 0, "image")).to eq(deployed_image)
+      end
+    end
+
     context "when existing workloads have different deployed app images" do
       let(:app_workloads) { %w[web] }
       let(:templates) { [workload_template("web")] }

--- a/spec/core/controlplane_spec.rb
+++ b/spec/core/controlplane_spec.rb
@@ -108,14 +108,14 @@ describe Controlplane do
       allow(Shell).to receive(:cmd).with(
         "cpln", "workload", "get", "rails",
         "--gvc", "my-app", "--org", "my-org", "-o", "json",
-        capture_stderr: true
-      ).and_return({ success: true, output: JSON.generate(workload) })
+        separate_stderr: true
+      ).and_return({ success: true, output: JSON.generate(workload), error_output: "update available" })
 
       expect(described_instance.fetch_workload_with_status("rails")).to eq(workload)
     end
 
     it "warns and returns nil when the CLI lookup fails" do
-      allow(Shell).to receive(:cmd).and_return({ success: false, output: "not authorized" })
+      allow(Shell).to receive(:cmd).and_return({ success: false, output: "", error_output: "not authorized" })
       allow(Shell).to receive(:warn)
 
       expect(described_instance.fetch_workload_with_status("rails")).to be_nil
@@ -125,7 +125,7 @@ describe Controlplane do
     end
 
     it "warns and returns nil when the CLI output is not JSON" do
-      allow(Shell).to receive(:cmd).and_return({ success: true, output: "not json" })
+      allow(Shell).to receive(:cmd).and_return({ success: true, output: "not json", error_output: "" })
       allow(Shell).to receive(:warn)
 
       expect(described_instance.fetch_workload_with_status("rails")).to be_nil

--- a/spec/core/controlplane_spec.rb
+++ b/spec/core/controlplane_spec.rb
@@ -95,6 +95,46 @@ describe Controlplane do
     end
   end
 
+  describe "#fetch_workload_with_status" do
+    let(:described_instance) do
+      described_class.allocate.tap do |instance|
+        instance.instance_variable_set(:@gvc, "my-app")
+        instance.instance_variable_set(:@org, "my-org")
+      end
+    end
+
+    it "returns the workload with computed status from the CLI" do
+      workload = { "name" => "rails", "status" => { "readyLatest" => true } }
+      allow(Shell).to receive(:cmd).with(
+        "cpln", "workload", "get", "rails",
+        "--gvc", "my-app", "--org", "my-org", "-o", "json",
+        capture_stderr: true
+      ).and_return({ success: true, output: JSON.generate(workload) })
+
+      expect(described_instance.fetch_workload_with_status("rails")).to eq(workload)
+    end
+
+    it "warns and returns nil when the CLI lookup fails" do
+      allow(Shell).to receive(:cmd).and_return({ success: false, output: "not authorized" })
+      allow(Shell).to receive(:warn)
+
+      expect(described_instance.fetch_workload_with_status("rails")).to be_nil
+      expect(Shell).to have_received(:warn).with(
+        "Failed to fetch status for 'rails': not authorized"
+      )
+    end
+
+    it "warns and returns nil when the CLI output is not JSON" do
+      allow(Shell).to receive(:cmd).and_return({ success: true, output: "not json" })
+      allow(Shell).to receive(:warn)
+
+      expect(described_instance.fetch_workload_with_status("rails")).to be_nil
+      expect(Shell).to have_received(:warn).with(
+        a_string_starting_with("Failed to parse status for 'rails':")
+      )
+    end
+  end
+
   describe "#image_build" do
     let!(:fake_config) { Struct.new(:app, :org).new("my-app", nil) }
     let!(:described_instance) { described_class.new(fake_config) }

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -219,6 +219,12 @@ describe Shell do
       expect(result[:success]).to be(true)
     end
 
+    it "captures stderr separately without corrupting stdout" do
+      result = described_class.cmd("sh", "-c", "echo captured-err >&2; echo captured-out", separate_stderr: true)
+
+      expect(result).to eq(output: "captured-out\n", error_output: "captured-err\n", success: true)
+    end
+
     it "does not capture stderr by default" do
       status = instance_double(Process::Status, success?: true)
       allow(Open3).to receive(:capture2).with("some", "command").and_return(["stdout only\n", status])


### PR DESCRIPTION
## Summary

Fix existing review-app template refreshes when Control Plane's direct workload-list response omits computed readiness fields.

## Root cause

`apply-template --preserve-existing-runtime` selected fallback images only from workloads with `status.readyLatest=true`, but the direct workload list/API responses do not include that computed field. The `cpln workload get` CLI does enrich it, so refreshes incorrectly concluded that no workload was ready and failed before adding newly configured workloads such as `node-renderer`.

## Change

- Query enriched workload status only for existing workloads that reference the app image.
- Capture CLI stdout and stderr separately so successful diagnostic output cannot corrupt the workload JSON.
- Warn and fail closed when the status lookup fails or emits malformed JSON.
- Preserve the existing ambiguity guard when ready workloads disagree on the image.
- Add regression coverage for the missing-readiness refresh and the CLI success/failure/parse contracts.

## Verification

- RED: focused regression failed with `Cannot safely refresh app image for workload 'node-renderer'`.
- GREEN: `bundle exec rspec spec/core/shell_spec.rb spec/core/controlplane_spec.rb spec/command/apply_template_unit_spec.rb` — 53 examples, 0 failures.
- focused RuboCop — 4 files, 0 offenses.
- `./.agents/bin/docs` — passed.
- hosted fast RSpec, RuboCop, command docs, link checks, and Claude review — passed on exact head `365cf502c5f21f1aa4d3a7b9b1bc7013237aa3f2`.
- Live review-app deployment for HiChee #9829 passed template refresh, build, release, deploy, and first-attempt health checks.
- A second exact-head deployment for HiChee #9888 passed the formerly failing template-refresh step and is building.

The broad local integration suite requires the CI-only `CPLN_ORG` shared-org setting; hosted CI exercises the configured environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template refreshes for existing apps when workload readiness information is unavailable.
  * The system now checks detailed workload status to safely select the correct fallback app image.
  * Added clearer warnings when workload status cannot be retrieved or parsed.

* **Tests**
  * Added coverage for missing readiness data, status lookup failures, and separate command output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->