### PR TITLE
Deactivate GitHub deployments when review apps are deleted

### DIFF
--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
   issues: write
   pull-requests: write
 
@@ -141,6 +142,39 @@ jobs:
           cpln_org: ${{ steps.review-config.outputs.cpln_org }}
           review_app_prefix: ${{ steps.review-config.outputs.review_app_prefix }}
           working_directory: app
+
+      - name: Deactivate GitHub review deployments
+        if: success() && steps.config.outputs.ready == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          APP_NAME: ${{ steps.review-config.outputs.app_name }}
+        with:
+          script: |
+            const environment = `review/${process.env.APP_NAME}`;
+            const deployments = await github.paginate(github.rest.repos.listDeployments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment,
+              per_page: 100
+            });
+
+            if (deployments.length === 0) {
+              core.info(`No GitHub deployments found for ${environment}.`);
+              return;
+            }
+
+            for (const deployment of deployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: "inactive",
+                environment,
+                description: "Review app deleted"
+              });
+            }
+
+            core.info(`Deactivated ${deployments.length} GitHub deployment(s) for ${environment}.`);
 
       # Finalizer still runs after delete failures, but only after config validation
       # created the initial PR comment and workflow link env vars it updates.

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -14,9 +14,9 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: cpflow-delete-review-app-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
-  # Deletions must not cancel each other mid-flight — a cancelled `cpln` delete can leave
-  # partial state behind. Let the in-progress deletion finish before the next run starts.
+  group: cpflow-review-app-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  # Share the deploy workflow's per-PR queue. An in-flight deploy must finish before
+  # deletion starts so it cannot publish a later success status for the deleted app.
   cancel-in-progress: false
 
 env:
@@ -135,6 +135,7 @@ jobs:
             core.setOutput("comment-id", comment.data.id);
 
       - name: Delete review app
+        id: delete-app
         if: steps.config.outputs.ready == 'true'
         uses: ./.cpflow/.github/actions/cpflow-delete-control-plane-app
         with:
@@ -144,7 +145,9 @@ jobs:
           working_directory: app
 
       - name: Deactivate GitHub review deployments
+        id: deactivate-deployments
         if: success() && steps.config.outputs.ready == 'true'
+        continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
           APP_NAME: ${{ steps.review-config.outputs.app_name }}
@@ -176,35 +179,52 @@ jobs:
 
             core.info(`Deactivated ${deployments.length} GitHub deployment(s) for ${environment}.`);
 
-      # Finalizer still runs after delete failures, but only after config validation
-      # created the initial PR comment and workflow link env vars it updates.
+      # Finalizer still runs after delete or deployment-cleanup failures, but only after
+      # config validation created the initial PR comment and workflow link env vars it updates.
       - name: Finalize delete status
         if: always() && steps.config.outputs.ready == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:
+          APP_NAME: ${{ steps.review-config.outputs.app_name }}
           COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}
-          JOB_STATUS: ${{ job.status }}
+          DELETE_OUTCOME: ${{ steps.delete-app.outcome }}
+          DEACTIVATION_OUTCOME: ${{ steps.deactivate-deployments.outcome }}
         with:
           script: |
             const commentId = Number(process.env.COMMENT_ID);
-            const success = process.env.JOB_STATUS === "success";
-            const body = success
-              ? [
-                  "## ✅ Review App Deleted",
-                  "",
-                  `_Review app for PR #${process.env.PR_NUMBER} is deleted_`,
-                  "",
-                  `🎮 [Control Plane Console](${process.env.CONSOLE_URL})`,
-                  `📋 [View Workflow Logs](${process.env.WORKFLOW_URL})`
-                ].join("\n")
-              : [
-                  "## ❌ Failed to Delete Review App",
-                  "",
-                  `_Failed to delete review app for PR #${process.env.PR_NUMBER}_`,
-                  "",
-                  `🎮 [Control Plane Console](${process.env.CONSOLE_URL})`,
-                  `📋 [View Workflow Logs](${process.env.WORKFLOW_URL})`
-                ].join("\n");
+            const deleteSucceeded = process.env.DELETE_OUTCOME === "success";
+            const deactivationSucceeded = process.env.DEACTIVATION_OUTCOME === "success";
+            let body;
+
+            if (!deleteSucceeded) {
+              body = [
+                "## ❌ Failed to Delete Review App",
+                "",
+                `_Failed to delete review app for PR #${process.env.PR_NUMBER}_`,
+                "",
+                `🎮 [Control Plane Console](${process.env.CONSOLE_URL})`,
+                `📋 [View Workflow Logs](${process.env.WORKFLOW_URL})`
+              ].join("\n");
+            } else if (!deactivationSucceeded) {
+              body = [
+                "## ⚠️ Review App Deleted, GitHub Deployment Cleanup Failed",
+                "",
+                `_Review app for PR #${process.env.PR_NUMBER} was deleted from Control Plane, but GitHub deployments for \`review/${process.env.APP_NAME}\` could not be marked inactive_`,
+                "",
+                "Re-run this deletion workflow to retry the GitHub deployment cleanup.",
+                `🎮 [Control Plane Console](${process.env.CONSOLE_URL})`,
+                `📋 [View Workflow Logs](${process.env.WORKFLOW_URL})`
+              ].join("\n");
+            } else {
+              body = [
+                "## ✅ Review App Deleted",
+                "",
+                `_Review app for PR #${process.env.PR_NUMBER} is deleted_`,
+                "",
+                `🎮 [Control Plane Console](${process.env.CONSOLE_URL})`,
+                `📋 [View Workflow Logs](${process.env.WORKFLOW_URL})`
+              ].join("\n");
+            }
 
             if (!Number.isFinite(commentId) || commentId <= 0) {
               core.warning("Skipping delete status comment update because no comment id was created.");
@@ -217,3 +237,10 @@ jobs:
               comment_id: commentId,
               body
             });
+
+      - name: Fail when GitHub deployment cleanup failed
+        if: steps.config.outputs.ready == 'true' && steps.delete-app.outcome == 'success' && steps.deactivate-deployments.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "Review app was deleted, but GitHub deployments could not be marked inactive." >&2
+          exit 1

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Deactivate GitHub review deployments
         id: deactivate-deployments
-        if: success() && steps.config.outputs.ready == 'true'
+        if: steps.config.outputs.ready == 'true' && steps.delete-app.outcome == 'success'
         continue-on-error: true
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         env:

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -166,7 +166,23 @@ jobs:
               return;
             }
 
+            let deactivatedCount = 0;
+            let alreadyInactiveCount = 0;
+
             for (const deployment of deployments) {
+              const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                per_page: 1
+              });
+              const [latestStatus] = statuses;
+
+              if (latestStatus?.state === "inactive") {
+                alreadyInactiveCount += 1;
+                continue;
+              }
+
               await github.rest.repos.createDeploymentStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -175,9 +191,13 @@ jobs:
                 environment,
                 description: "Review app deleted"
               });
+              deactivatedCount += 1;
             }
 
-            core.info(`Deactivated ${deployments.length} GitHub deployment(s) for ${environment}.`);
+            core.info(
+              `Deactivated ${deactivatedCount} GitHub deployment(s) for ${environment}; ` +
+              `skipped ${alreadyInactiveCount} already inactive deployment(s).`
+            );
 
       # Finalizer still runs after delete or deployment-cleanup failures, but only after
       # config validation created the initial PR comment and workflow link env vars it updates.

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -321,6 +321,8 @@ jobs:
               repo: context.repo.repo,
               ref: process.env.PR_SHA,
               environment: `review/${process.env.APP_NAME}`,
+              transient_environment: true,
+              production_environment: false,
               auto_merge: false,
               required_contexts: [], // intentional: review apps deploy regardless of required status checks
               description: `Control Plane review app for PR #${process.env.PR_NUMBER}`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Fixed review-app deletion leaving successful GitHub deployments active after the Control Plane app was removed.**
 - **Fixed template refreshes for existing apps whose workload-list response omits readiness status by consulting each workload's detailed state before selecting a safe fallback image.** [PR 429](https://github.com/shakacode/control-plane-flow/pull/429) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable deployment health checks on BYOK locations by falling back from a disabled standard workload endpoint only after every location is settled, while preserving configured `app_domain` review-app links and using the verified location endpoint as the final URL fallback.** [PR 426](https://github.com/shakacode/control-plane-flow/pull/426) by [Justin Gordon](https://github.com/justin808).
 - **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.** [PR 425](https://github.com/shakacode/control-plane-flow/pull/425) by [Justin Gordon](https://github.com/justin808).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed review-app deletion leaving successful GitHub deployments active after the Control Plane app was removed.**
+- **Fixed review-app deletion leaving successful GitHub deployments active after the Control Plane app was removed.** [PR 430](https://github.com/shakacode/control-plane-flow/pull/430) by [Justin Gordon](https://github.com/justin808).
 - **Fixed template refreshes for existing apps whose workload-list response omits readiness status by consulting each workload's detailed state before selecting a safe fallback image.** [PR 429](https://github.com/shakacode/control-plane-flow/pull/429) by [Justin Gordon](https://github.com/justin808).
 - **Fixed reusable deployment health checks on BYOK locations by falling back from a disabled standard workload endpoint only after every location is settled, while preserving configured `app_domain` review-app links and using the verified location endpoint as the final URL fallback.** [PR 426](https://github.com/shakacode/control-plane-flow/pull/426) by [Justin Gordon](https://github.com/justin808).
 - **Fixed template refresh recovery for unhealthy or partially deployed review apps by preserving each workload's configured app image independently, while limiting missing-image fallbacks to one unambiguous image from ready workloads.** [PR 425](https://github.com/shakacode/control-plane-flow/pull/425) by [Justin Gordon](https://github.com/justin808).

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -482,7 +482,7 @@ The generated flow uses these defaults:
   so it runs in the base-repository context and has repository-secret access for teardown. That is also why you must
   never check out PR or fork code in this job; see the customization guidance below. The PR-close path does not require a
   trusted commenter. The generated `cpflow-delete-review-app.yml` pins `GITHUB_TOKEN` permissions to the minimum it needs
-  (`contents: read`, `issues: write`, `pull-requests: write`); if you customize this workflow, preserve that
+  (`contents: read`, `deployments: write`, `issues: write`, `pull-requests: write`); if you customize this workflow, preserve that
   `permissions:` block because omitting it can fall back to broader repository defaults;
 - manual workflow dispatch by a repository collaborator can also delete a review app without a `+review-app-delete`
   comment, and does not require a trusted commenter;
@@ -604,7 +604,10 @@ deploy key scoped to the minimum private dependency access, and never use a pers
   are available for teardown; `hooks.pre_deletion` still executes through the latest PR-built image on this path, so
   review-app credentials must remain disposable.
 - After Control Plane deletion succeeds, marks every GitHub deployment for the exact `review/<app-name>` environment
-  inactive so the repository does not retain a stale active review deployment.
+  inactive so the repository does not retain a stale active review deployment. Deploy and delete workflows share one
+  per-PR concurrency queue, ensuring an in-flight deploy finishes before deletion and cannot publish a later success
+  status after the app is removed. If GitHub deployment cleanup fails after Control Plane deletion, the workflow reports
+  that partial outcome accurately and still fails so the cleanup can be retried.
 - Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`); manual dispatch and
   automatic PR-close teardown do not require a trusted commenter.
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -603,6 +603,8 @@ deploy key scoped to the minimum private dependency access, and never use a pers
 - Also deletes it automatically when the pull request closes through a `pull_request_target` event, so repository secrets
   are available for teardown; `hooks.pre_deletion` still executes through the latest PR-built image on this path, so
   review-app credentials must remain disposable.
+- After Control Plane deletion succeeds, marks every GitHub deployment for the exact `review/<app-name>` environment
+  inactive so the repository does not retain a stale active review deployment.
 - Accepts `+review-app-delete` only from trusted commenters (`OWNER`, `MEMBER`, or `COLLABORATOR`); manual dispatch and
   automatic PR-close teardown do not require a trusted commenter.
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -585,7 +585,7 @@ deploy key scoped to the minimum private dependency access, and never use a pers
 - For manual dispatch, provide the PR number; the workflow rejects fork PRs at runtime because it builds Docker images
   with repository secrets.
 - Redeploys an existing review app automatically on later PR pushes.
-- Creates a GitHub deployment and comments with the review URL and logs.
+- Creates a transient, non-production GitHub deployment and comments with the review URL and logs.
 - Leaves PR pushes alone until the first review app is explicitly requested, which keeps demo-app costs down.
 - Supports cost-conscious review apps when paired with one warm replica, Capacity AI, and a disabled autoscaling
   metric for public demos, starter staging apps, and long-lived review apps; see

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -604,7 +604,8 @@ deploy key scoped to the minimum private dependency access, and never use a pers
   are available for teardown; `hooks.pre_deletion` still executes through the latest PR-built image on this path, so
   review-app credentials must remain disposable.
 - After Control Plane deletion succeeds, marks every GitHub deployment for the exact `review/<app-name>` environment
-  inactive so the repository does not retain a stale active review deployment. Deploy and delete workflows share one
+  inactive so the repository does not retain a stale active review deployment, while skipping deployments whose latest
+  status is already inactive so repeated teardown is idempotent. Deploy and delete workflows share one
   per-PR concurrency queue, ensuring an in-flight deploy finishes before deletion and cannot publish a later success
   status after the app is removed. If GitHub deployment cleanup fails after Control Plane deletion, the workflow reports
   that partial outcome accurately and still fails so the cleanup can be retried.

--- a/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
+++ b/lib/github_flow_templates/.github/workflows/cpflow-delete-review-app.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
   issues: write
   pull-requests: write
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -660,6 +660,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("group: cpflow-review-app-")
       expect(contents).to include("id: delete-app")
       expect(contents).to include("id: deactivate-deployments")
+      expect(contents).to include("steps.delete-app.outcome == 'success'")
       expect(contents).to include("continue-on-error: true")
       expect(contents).to include("listDeploymentStatuses")
       expect(contents).to include('latestStatus?.state === "inactive"')

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -657,6 +657,12 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       contents = reusable_delete_review_workflow_path.read
       wrapper = YAML.safe_load_file(delete_review_workflow_path, aliases: true)
       expect(contents).to include("concurrency:")
+      expect(contents).to include("group: cpflow-review-app-")
+      expect(contents).to include("id: delete-app")
+      expect(contents).to include("id: deactivate-deployments")
+      expect(contents).to include("continue-on-error: true")
+      expect(contents).to include("Review App Deleted, GitHub Deployment Cleanup Failed")
+      expect(contents).to include("Fail when GitHub deployment cleanup failed")
       expect(contents).to include('pull_request_friendly: "true"')
       expect(contents).to include("Checkout repository")
       expect(contents).to include("path: app")
@@ -677,7 +683,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
       expect(contents).to include("id: config")
       expect(contents).to match(/steps\.config\.outputs\.ready == 'true'/)
-      expect(contents).to include("Finalizer still runs after delete failures")
+      expect(contents).to include("Finalizer still runs after delete or deployment-cleanup failures")
       expect(contents).to include("if: always() && steps.config.outputs.ready == 'true'")
     end
 
@@ -698,7 +704,10 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(delete_contents).not_to include('Number("${{ steps.create-comment.outputs.comment-id }}")')
       expect(delete_contents).not_to include('"${{ job.status }}"')
       expect(delete_contents).to include("COMMENT_ID: ${{ steps.create-comment.outputs.comment-id }}")
-      expect(delete_contents).to include("JOB_STATUS: ${{ job.status }}")
+      expect(delete_contents).to include("DELETE_OUTCOME: ${{ steps.delete-app.outcome }}")
+      expect(delete_contents).to include(
+        "DEACTIVATION_OUTCOME: ${{ steps.deactivate-deployments.outcome }}"
+      )
     end
 
     it "uses shell env vars for stale review cleanup inputs" do

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -661,6 +661,8 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("id: delete-app")
       expect(contents).to include("id: deactivate-deployments")
       expect(contents).to include("continue-on-error: true")
+      expect(contents).to include("listDeploymentStatuses")
+      expect(contents).to include('latestStatus?.state === "inactive"')
       expect(contents).to include("Review App Deleted, GitHub Deployment Cleanup Failed")
       expect(contents).to include("Fail when GitHub deployment cleanup failed")
       expect(contents).to include('pull_request_friendly: "true"')

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -655,6 +655,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
     it "configures delete-review-app concurrency and handles missing comment ids" do
       contents = reusable_delete_review_workflow_path.read
+      wrapper = YAML.safe_load_file(delete_review_workflow_path, aliases: true)
       expect(contents).to include("concurrency:")
       expect(contents).to include('pull_request_friendly: "true"')
       expect(contents).to include("Checkout repository")
@@ -665,6 +666,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(delete_review_workflow_path.read).to include("mirrors the upstream job guard")
       expect(delete_review_workflow_path.read).to include("CPLN_TOKEN_STAGING: ${{ secrets.CPLN_TOKEN_STAGING }}")
       expect(delete_review_workflow_path.read).not_to include("secrets: inherit")
+      expect(wrapper.fetch("permissions")).to include("deployments" => "write")
       expect(contents).to include(
         "Skipping delete status comment update because no comment id was created."
       )

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
       expect(workflow.dig("concurrency", "group")).to start_with("cpflow-review-app-")
       expect(workflow.dig("concurrency", "cancel-in-progress")).to be(false)
     end
+
+    it "creates future review deployments as transient environments" do
+      deploy_steps = deploy_workflow.fetch("jobs").fetch("deploy").fetch("steps")
+      init_step = deploy_steps.find { |step| step["name"] == "Initialize GitHub deployment" }
+      script = init_step.fetch("with").fetch("script")
+
+      expect(script).to include("transient_environment: true")
+      expect(script).to include("production_environment: false")
+    end
   end
 
   describe "Delete Control Plane App action" do

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
       script = step.fetch("with").fetch("script")
       expect(script).to include("const environment = `review/${process.env.APP_NAME}`;")
       expect(script).to include("github.paginate(github.rest.repos.listDeployments")
+      expect(script).to include("github.rest.repos.listDeploymentStatuses")
+      expect(script).to include('latestStatus?.state === "inactive"')
       expect(script).to include("for (const deployment of deployments)")
       expect(script).to include("github.rest.repos.createDeploymentStatus")
       expect(script).to include('state: "inactive"')

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
       expect(step).to include(
         "id" => "deactivate-deployments",
         "continue-on-error" => true,
-        "if" => "success() && steps.config.outputs.ready == 'true'",
+        "if" => "steps.config.outputs.ready == 'true' && steps.delete-app.outcome == 'success'",
         "env" => {
           "APP_NAME" => "${{ steps.review-config.outputs.app_name }}"
         }

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -74,6 +74,25 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
         "working_directory" => "app"
       )
     end
+
+    it "deactivates every GitHub deployment for the deleted review environment" do
+      expect(workflow.fetch("permissions")).to include("deployments" => "write")
+
+      step = step_named("Deactivate GitHub review deployments")
+      expect(step).to include(
+        "if" => "success() && steps.config.outputs.ready == 'true'",
+        "env" => {
+          "APP_NAME" => "${{ steps.review-config.outputs.app_name }}"
+        }
+      )
+
+      script = step.fetch("with").fetch("script")
+      expect(script).to include("const environment = `review/${process.env.APP_NAME}`;")
+      expect(script).to include("github.paginate(github.rest.repos.listDeployments")
+      expect(script).to include("for (const deployment of deployments)")
+      expect(script).to include("github.rest.repos.createDeploymentStatus")
+      expect(script).to include('state: "inactive"')
+    end
   end
 
   describe "Delete Control Plane App action" do

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
 
     let(:steps) { workflow.fetch("jobs").fetch("delete-review-app").fetch("steps") }
 
+    let(:deploy_workflow) do
+      YAML.safe_load_file(
+        File.expand_path("../.github/workflows/cpflow-deploy-review-app.yml", __dir__),
+        aliases: true
+      )
+    end
+
     def step_named(name)
       steps.find { |step| step["name"] == name }
     end
@@ -80,6 +87,8 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
 
       step = step_named("Deactivate GitHub review deployments")
       expect(step).to include(
+        "id" => "deactivate-deployments",
+        "continue-on-error" => true,
         "if" => "success() && steps.config.outputs.ready == 'true'",
         "env" => {
           "APP_NAME" => "${{ steps.review-config.outputs.app_name }}"
@@ -92,6 +101,30 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
       expect(script).to include("for (const deployment of deployments)")
       expect(script).to include("github.rest.repos.createDeploymentStatus")
       expect(script).to include('state: "inactive"')
+    end
+
+    it "reports deployment cleanup failures accurately before failing the workflow" do
+      expect(step_named("Delete review app")).to include("id" => "delete-app")
+
+      finalizer = step_named("Finalize delete status")
+      expect(finalizer.fetch("env")).to include(
+        "DELETE_OUTCOME" => "${{ steps.delete-app.outcome }}",
+        "DEACTIVATION_OUTCOME" => "${{ steps.deactivate-deployments.outcome }}"
+      )
+      expect(finalizer.dig("with", "script")).to include(
+        "Review App Deleted, GitHub Deployment Cleanup Failed"
+      )
+
+      failure_step = step_named("Fail when GitHub deployment cleanup failed")
+      expect(failure_step.fetch("if")).to include("steps.deactivate-deployments.outcome == 'failure'")
+      expect(failure_step.fetch("run")).to include("exit 1")
+      expect(steps.index(finalizer)).to be < steps.index(failure_step)
+    end
+
+    it "serializes deploy and delete workflows in the same per-PR concurrency group" do
+      expect(workflow.fetch("concurrency")).to eq(deploy_workflow.fetch("concurrency"))
+      expect(workflow.dig("concurrency", "group")).to start_with("cpflow-review-app-")
+      expect(workflow.dig("concurrency", "cancel-in-progress")).to be(false)
     end
   end
 


### PR DESCRIPTION
## Summary

- grant delete-review-app workflows deployment write access
- create future review deployments as transient, non-production environments
- mark every deployment in the exact `review/<app-name>` environment inactive after Control Plane deletion succeeds
- skip deployments whose latest status is already inactive so repeated teardown is idempotent
- serialize deploy/delete workflows in one per-PR concurrency queue so deletion follows any in-flight deploy
- distinguish Control Plane deletion failures from GitHub deployment-cleanup failures while keeping either failure visible
- document the lifecycle and cover the reusable workflow and generated caller with contract tests

## Why

A successful `cpflow delete` removes the Control Plane GVC, but the last successful GitHub deployment otherwise remains active. This leaves the repository environment UI pointing at a review app that no longer exists.

The deactivation step runs only after the delete step reports success, paginates every deployment for the exact review environment, and is a no-op when no deployments exist. It checks each deployment latest status before writing, so retries skip already-inactive history instead of posting duplicate statuses. Deploy and delete share one non-cancelling per-PR queue, so an in-flight deploy cannot post success after deletion. A GitHub deactivation failure produces an accurate partial-success PR comment and then deliberately fails the workflow so cleanup remains visible and retryable.

## Verification

- `bundle exec rspec spec/github_workflows_spec.rb spec/command/generate_github_actions_spec.rb` (84 examples, 0 failures)
- `.agents/bin/lint` (209 files, no offenses)
- `.agents/bin/docs`
- `git diff --check`

Full `.agents/bin/validate` could not complete locally because the integration portion of the repository suite requires `CPLN_ORG` and live Control Plane credentials; the failures were broad missing-org errors unrelated to this change. Hosted CI is expected to run with the repository environment.

## Rollout

Downstream repositories must repin/regenerate their generated Control Plane Flow workflows after this change ships in a release; the reusable workflow and caller both need `deployments: write`.